### PR TITLE
web: GitHub Pages demo build (wasm32 + on-screen keyboard)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,69 @@
+name: Deploy keysynth web demo to GitHub Pages
+
+on:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+# Single concurrent deploy; cancel in-flight runs on new pushes.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry & target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: web-build
+
+      - name: Install Trunk
+        uses: jetli/trunk-action@v0.5.0
+        with:
+          version: latest
+
+      - name: Install wasm-bindgen-cli
+        uses: jetli/wasm-bindgen-action@v0.2.0
+        with:
+          version: latest
+
+      - name: Build (release)
+        # Cargo features (`--no-default-features --features web`) and the
+        # target bin (`keysynth-web`) are declared inline in
+        # `web/index.html`. `--public-url` rewrites asset URLs to the
+        # GitHub Pages subpath: https://<user>.github.io/<repo>/  →
+        # /<repo>/.
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          trunk build --release --public-url "/${REPO_NAME}/"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,11 +3,15 @@ name: Deploy keysynth web demo to GitHub Pages
 on:
   push:
     branches: [main, master]
+  pull_request:
+    branches: [main, master]
   workflow_dispatch:
 
-# Single concurrent deploy; cancel in-flight runs on new pushes.
+# Single concurrent deploy; cancel in-flight runs on new pushes. PR runs
+# from the same branch are also coalesced under their own group key so
+# repeated pushes to a PR don't queue stale builds.
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -53,11 +57,18 @@ jobs:
           trunk build --release --public-url "/${REPO_NAME}/"
 
       - name: Upload Pages artifact
+        # Only upload on push to main/master (or workflow_dispatch). PR
+        # runs are validate-only — uploading would require Pages write
+        # permission from a fork PR which GitHub denies anyway.
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
   deploy:
+    # Skip deploy on PR runs — those are build-only validation. Deploy
+    # only fires when the workflow runs from a push to main/master.
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
+/dist
 
 # CARGO_TARGET_DIR may point elsewhere; keep the default rule too.
+# /dist is trunk's default output for the web demo.
 
 # OS / editor noise
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,16 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
-name = "accesskit"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b76d84ee70e30a4a7e39ab9018e2b17a6a09e31084176cc7c0b2dec036ba45"
-dependencies = [
- "enumn",
- "serde",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,7 +33,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -105,15 +94,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,25 +111,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
-
-[[package]]
-name = "ash"
-version = "0.38.0+1.3.281"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
-dependencies = [
- "libloading",
-]
 
 [[package]]
 name = "atomic-waker"
@@ -164,12 +129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,25 +141,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bitflags"
@@ -213,9 +157,6 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "block"
@@ -264,7 +205,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -365,12 +306,6 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -402,47 +337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -652,7 +546,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -693,7 +587,6 @@ checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
 dependencies = [
  "bytemuck",
  "emath",
- "serde",
 ]
 
 [[package]]
@@ -706,13 +599,11 @@ dependencies = [
  "bytemuck",
  "document-features",
  "egui",
- "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow 0.14.2",
+ "glow",
  "glutin",
  "glutin-winit",
- "home",
  "image",
  "js-sys",
  "log",
@@ -721,16 +612,12 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "parking_lot",
  "percent-encoding",
- "pollster",
  "raw-window-handle",
- "ron",
- "serde",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "wgpu",
  "winapi",
  "windows-sys 0.52.0",
  "winit",
@@ -742,33 +629,11 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
 dependencies = [
- "accesskit",
  "ahash",
  "emath",
  "epaint",
  "log",
  "nohash-hasher",
- "ron",
- "serde",
-]
-
-[[package]]
-name = "egui-wgpu"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00fd5d06d8405397e64a928fa0ef3934b3c30273ea7603e3dc4627b1f7a1a82"
-dependencies = [
- "ahash",
- "bytemuck",
- "document-features",
- "egui",
- "epaint",
- "log",
- "thiserror 1.0.69",
- "type-map",
- "web-time",
- "wgpu",
- "winit",
 ]
 
 [[package]]
@@ -782,7 +647,6 @@ dependencies = [
  "egui",
  "log",
  "raw-window-handle",
- "serde",
  "smithay-clipboard",
  "web-time",
  "webbrowser",
@@ -798,7 +662,7 @@ dependencies = [
  "ahash",
  "bytemuck",
  "egui",
- "glow 0.14.2",
+ "glow",
  "log",
  "memoffset",
  "wasm-bindgen",
@@ -818,18 +682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
 dependencies = [
  "bytemuck",
- "serde",
-]
-
-[[package]]
-name = "enumn"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -847,7 +699,6 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
- "serde",
 ]
 
 [[package]]
@@ -904,12 +755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +772,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1010,18 +855,6 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glow"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
@@ -1039,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
  "bitflags 2.11.1",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "cgl",
  "dispatch2",
  "glutin_egl_sys",
@@ -1063,7 +896,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -1099,107 +932,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.1",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "winapi",
- "windows 0.52.0",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.11.1",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "hassle-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
-dependencies = [
- "bitflags 2.11.1",
- "com",
- "libc",
- "libloading",
- "thiserror 1.0.69",
- "widestring",
- "winapi",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "hound"
@@ -1330,7 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1391,7 +1133,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1419,7 +1161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1464,17 +1206,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading",
- "pkg-config",
 ]
 
 [[package]]
@@ -1560,15 +1291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,21 +1312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "metal"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
-dependencies = [
- "bitflags 2.11.1",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
 ]
 
 [[package]]
@@ -1648,27 +1355,6 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
-]
-
-[[package]]
-name = "naga"
-version = "22.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bitflags 2.11.1",
- "cfg_aliases 0.1.1",
- "codespan-reporting",
- "hexf-parse",
- "indexmap",
- "log",
- "rustc-hash 1.1.0",
- "spirv",
- "termcolor",
- "thiserror 1.0.69",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1732,7 +1418,7 @@ checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1769,7 +1455,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1809,16 +1495,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
+ "syn",
 ]
 
 [[package]]
@@ -2164,12 +1841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,7 +1863,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2241,12 +1912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,12 +1919,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "presser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "primal-check"
@@ -2287,12 +1946,6 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "profiling"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "pxfm"
@@ -2385,30 +2038,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "renderdoc-sys"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
-
-[[package]]
-name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
-dependencies = [
- "base64",
- "bitflags 2.11.1",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2531,7 +2160,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2669,15 +2298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,17 +2314,6 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2725,16 +2334,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
+ "syn",
 ]
 
 [[package]]
@@ -2763,7 +2363,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2774,7 +2374,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2851,15 +2451,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
-name = "type-map"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
-dependencies = [
- "rustc-hash 2.1.2",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,18 +2461,6 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -2968,7 +2547,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3153,115 +2732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wgpu"
-version = "22.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
-dependencies = [
- "arrayvec",
- "cfg_aliases 0.1.1",
- "document-features",
- "js-sys",
- "log",
- "naga",
- "parking_lot",
- "profiling",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "22.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
-dependencies = [
- "arrayvec",
- "bit-vec",
- "bitflags 2.11.1",
- "cfg_aliases 0.1.1",
- "document-features",
- "indexmap",
- "log",
- "naga",
- "once_cell",
- "parking_lot",
- "profiling",
- "raw-window-handle",
- "rustc-hash 1.1.0",
- "smallvec",
- "thiserror 1.0.69",
- "wgpu-hal",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bitflags 2.11.1",
- "block",
- "cfg_aliases 0.1.1",
- "core-graphics-types",
- "glow 0.13.1",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-allocator",
- "gpu-descriptor",
- "hassle-rs",
- "js-sys",
- "khronos-egl",
- "libc",
- "libloading",
- "log",
- "metal",
- "naga",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc",
- "once_cell",
- "parking_lot",
- "profiling",
- "raw-window-handle",
- "renderdoc-sys",
- "rustc-hash 1.1.0",
- "smallvec",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types",
- "winapi",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
-dependencies = [
- "bitflags 2.11.1",
- "js-sys",
- "web-sys",
-]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,16 +2764,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
@@ -3319,15 +2779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
  "windows-core 0.56.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -3361,7 +2812,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3372,7 +2823,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3634,7 +3085,7 @@ dependencies = [
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -3775,7 +3226,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -3796,7 +3247,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3816,7 +3267,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -3850,7 +3301,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "accesskit"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b76d84ee70e30a4a7e39ab9018e2b17a6a09e31084176cc7c0b2dec036ba45"
+dependencies = [
+ "enumn",
+ "serde",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +43,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -94,6 +105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,10 +131,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -129,6 +164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,10 +182,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bitflags"
@@ -157,6 +213,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block"
@@ -205,7 +264,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -306,6 +365,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -340,6 +405,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "com"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
+dependencies = [
+ "com_macros",
+]
+
+[[package]]
+name = "com_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
+dependencies = [
+ "com_macros_support",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "com_macros_support"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -536,7 +652,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -577,6 +693,7 @@ checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
 dependencies = [
  "bytemuck",
  "emath",
+ "serde",
 ]
 
 [[package]]
@@ -589,11 +706,13 @@ dependencies = [
  "bytemuck",
  "document-features",
  "egui",
+ "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow",
+ "glow 0.14.2",
  "glutin",
  "glutin-winit",
+ "home",
  "image",
  "js-sys",
  "log",
@@ -602,12 +721,16 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "parking_lot",
  "percent-encoding",
+ "pollster",
  "raw-window-handle",
+ "ron",
+ "serde",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
+ "wgpu",
  "winapi",
  "windows-sys 0.52.0",
  "winit",
@@ -619,11 +742,33 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
 dependencies = [
+ "accesskit",
  "ahash",
  "emath",
  "epaint",
  "log",
  "nohash-hasher",
+ "ron",
+ "serde",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00fd5d06d8405397e64a928fa0ef3934b3c30273ea7603e3dc4627b1f7a1a82"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "epaint",
+ "log",
+ "thiserror 1.0.69",
+ "type-map",
+ "web-time",
+ "wgpu",
+ "winit",
 ]
 
 [[package]]
@@ -637,6 +782,7 @@ dependencies = [
  "egui",
  "log",
  "raw-window-handle",
+ "serde",
  "smithay-clipboard",
  "web-time",
  "webbrowser",
@@ -652,7 +798,7 @@ dependencies = [
  "ahash",
  "bytemuck",
  "egui",
- "glow",
+ "glow 0.14.2",
  "log",
  "memoffset",
  "wasm-bindgen",
@@ -672,6 +818,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
 dependencies = [
  "bytemuck",
+ "serde",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -689,6 +847,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
+ "serde",
 ]
 
 [[package]]
@@ -745,6 +904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,7 +927,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -845,6 +1010,18 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
@@ -862,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
  "bitflags 2.11.1",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "cgl",
  "dispatch2",
  "glutin_egl_sys",
@@ -886,7 +1063,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -922,16 +1099,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.11.1",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "winapi",
+ "windows 0.52.0",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.11.1",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hassle-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
+dependencies = [
+ "bitflags 2.11.1",
+ "com",
+ "libc",
+ "libloading",
+ "thiserror 1.0.69",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "hound"
@@ -1062,7 +1330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1123,7 +1391,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1151,7 +1419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1180,17 +1448,33 @@ dependencies = [
 name = "keysynth"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "cpal",
  "ctrlc",
  "eframe",
  "egui",
  "hound",
  "image",
+ "js-sys",
  "midir",
  "rustfft",
  "rustysynth",
  "serde",
  "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1276,6 +1560,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1590,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.11.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
 ]
 
 [[package]]
@@ -1340,6 +1648,27 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.11.1",
+ "cfg_aliases 0.1.1",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "termcolor",
+ "thiserror 1.0.69",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1403,7 +1732,7 @@ checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -1440,7 +1769,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1480,7 +1809,16 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -1826,6 +2164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,7 +2192,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1897,6 +2241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +2254,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "primal-check"
@@ -1931,6 +2287,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "pxfm"
@@ -2023,6 +2385,30 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.11.1",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2145,7 +2531,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2283,6 +2669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2694,17 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2319,7 +2725,16 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2348,7 +2763,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2359,7 +2774,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2436,6 +2851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +2870,18 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -2532,7 +2968,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2717,6 +3153,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
+dependencies = [
+ "arrayvec",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 1.0.69",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bitflags 2.11.1",
+ "block",
+ "cfg_aliases 0.1.1",
+ "core-graphics-types",
+ "glow 0.13.1",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hassle-rs",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
+dependencies = [
+ "bitflags 2.11.1",
+ "js-sys",
+ "web-sys",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,6 +3294,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
@@ -2764,6 +3319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
  "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -2797,7 +3361,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2808,7 +3372,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3070,7 +3634,7 @@ dependencies = [
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -3211,7 +3775,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3232,7 +3796,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3252,7 +3816,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3286,7 +3850,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,84 +4,142 @@ version = "0.1.0"
 edition = "2021"
 description = "Real-time MIDI keyboard -> speaker synth (square / Karplus-Strong)."
 
+[features]
+# Default = full native build (live MIDI in, native audio out, SF2/SFZ playback,
+# offline analysis bins). Disable default features and pass `--features web` to
+# get the trimmed wasm32 build for the GitHub Pages demo.
+default = ["native"]
+
+native = [
+    "dep:midir",
+    "dep:ctrlc",
+    "dep:rustysynth",
+    "dep:hound",
+    "dep:rustfft",
+    "dep:image",
+]
+
+# Web build: stripped to the modelling engines + on-screen keyboard. Drops
+# midir / rustysynth / hound / rustfft / image / sfz so the wasm bundle stays
+# small and so we don't try to compile native-only crates against
+# wasm32-unknown-unknown.
+web = [
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:web-sys",
+    "dep:console_error_panic_hook",
+    "dep:js-sys",
+    "cpal/wasm-bindgen",
+]
+
 [dependencies]
-midir = "0.10"
+# DSP / GUI core — shared between native and web builds.
 cpal = "0.15"
-ctrlc = "3.4"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 egui = "0.29"
-
-# bench binary deps (SoundFont reference comparison harness)
-rustysynth = "1.3"
-hound = "3.5"
-
-# analyse binary: STFT, harmonic decay, spectrogram PNG, JSON report
-rustfft = "6"
-image = { version = "0.25", default-features = false, features = ["png"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+# Native-only (gated via `native` feature).
+midir = { version = "0.10", optional = true }
+ctrlc = { version = "3.4", optional = true }
+rustysynth = { version = "1.3", optional = true }
+hound = { version = "3.5", optional = true }
+rustfft = { version = "6", optional = true }
+image = { version = "0.25", default-features = false, features = ["png"], optional = true }
+
+# Web-only (gated via `web` feature). Pulled in only when targeting wasm32.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+js-sys = { version = "0.3", optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
+web-sys = { version = "0.3", optional = true, features = [
+    "Window",
+    "Document",
+    "Element",
+    "HtmlCanvasElement",
+    "Navigator",
+    "MidiAccess",
+    "MidiInput",
+    "MidiInputMap",
+    "MidiMessageEvent",
+    "MidiOptions",
+    "MidiPort",
+] }
 
 [profile.release]
 opt-level = 3
 lto = "thin"
 
+# Smaller wasm bundle: tighter inlining + size-aware codegen. opt-level = "s"
+# (size) keeps DSP hot loops vectorised in practice but trims dead code more
+# aggressively than "3". LTO already on from the shared profile.release above.
+[profile.release.package."*"]
+opt-level = 3
+
+# ---------------------------------------------------------------------------
+# Binaries.
+#
+# `keysynth` is the live native synth.
+# `keysynth-web` is the wasm32 entry point built by trunk.
+# Everything else is an offline harness (bench / analyse / extract dump /
+# render / score / build_modal_lut). All offline tools require the `native`
+# feature so `cargo build --no-default-features --features web --target
+# wasm32-unknown-unknown` only sees `keysynth-web`.
+# ---------------------------------------------------------------------------
+
 [[bin]]
 name = "keysynth"
 path = "src/main.rs"
+required-features = ["native"]
+
+[[bin]]
+name = "keysynth-web"
+path = "src/bin/web.rs"
+required-features = ["web"]
 
 [[bin]]
 name = "bench"
 path = "src/bin/bench.rs"
+required-features = ["native"]
 
 [[bin]]
 name = "analyse"
 path = "src/bin/analyse.rs"
+required-features = ["native"]
 
-# cpubench binary: 32-voice sustained polyphony cost per engine.
-# Tracks issue #2 per-voice CPU budget.
 [[bin]]
 name = "cpubench"
 path = "src/bin/cpubench.rs"
+required-features = ["native"]
 
-# extract_dump binary: dump the issue #3 extractors' output for a WAV.
-# Used to pin / re-pin golden values when an extractor's algorithm changes.
 [[bin]]
 name = "extract_dump"
 path = "src/bin/extract_dump.rs"
+required-features = ["native"]
 
-# render_modal binary: modal-synthesis piano voice C4 pilot (issue #3 alt path).
-# Extracts modes from a reference WAV via src/extract/* and renders them back
-# through ModalPianoVoice (parallel bandpass resonator bank).
 [[bin]]
 name = "render_modal"
 path = "src/bin/render_modal.rs"
+required-features = ["native"]
 
-# score binary: weighted multi-metric loss between a reference and a
-# candidate WAV. Combines MR-STFT, T60 vector, onset envelope, centroid
-# trajectory, and inharmonicity-coefficient residual into one scalar.
 [[bin]]
 name = "score"
 path = "src/bin/score.rs"
+required-features = ["native"]
 
-# build_modal_lut binary: extract per-note modal LUT (decompose + t60 +
-# attack) from SFZ Salamander reference WAVs. Output is consumed by
-# voices::piano_modal::ModalPianoVoice (issue #3 A2 supervised path).
 [[bin]]
 name = "build_modal_lut"
 path = "src/bin/build_modal_lut.rs"
+required-features = ["native"]
 
-# render_chord binary: render N-note chord through any engine for
-# chord-level GT comparison. Single-note evaluation hides the polyphony
-# stacking artifact, so chord-level renders are needed for issue #3
-# realism evaluation.
 [[bin]]
 name = "render_chord"
 path = "src/bin/render_chord.rs"
+required-features = ["native"]
 
-# render_song binary: render short multi-note phrases (chord
-# progressions, melody+bass, two-voice imitation) through any engine
-# for musical-context realism evaluation. Multi-event timeline
-# scheduling, per-event velocity/duration.
 [[bin]]
 name = "render_song"
 path = "src/bin/render_song.rs"
+required-features = ["native"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ cargo run --release -- --list
 Defaults to MPK mini 3 (or first available MIDI input port) and the system
 default audio output device.
 
+## Web demo (GitHub Pages)
+
+A trimmed wasm32 build of the modelling engines runs in the browser. No
+SF2/SFZ samples, no live MIDI controller — input is the on-screen keyboard
+or PC keyboard (`zsxdcvgbhnjm` lower octave, `qwerty…` upper octave).
+
+```bash
+# One-off prerequisites
+rustup target add wasm32-unknown-unknown
+cargo install trunk
+
+# Local dev server at http://localhost:8080
+trunk serve --release
+
+# Static build under dist/  (what GitHub Actions deploys to gh-pages)
+trunk build --release
+```
+
+The Cargo features and bin selection live in `web/index.html` via the
+`data-cargo-*` / `data-bin` attributes on the trunk rust link. CI is at
+`.github/workflows/deploy-pages.yml`; enable Pages once in repo settings
+(Source: GitHub Actions) and pushes to `main`/`master` will auto-deploy
+to `https://<user>.github.io/keysynth/`.
+
 ### CLI
 
 ```

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -21,6 +21,12 @@ dist = "dist"
 public_url = "/"
 
 [serve]
-address = "0.0.0.0"
+addresses = ["0.0.0.0"]
 port = 8080
 open = false
+
+[tools]
+# wasm-bindgen-cli MUST match the wasm-bindgen library version cargo
+# resolved; otherwise the generated JS glue panics with a schema
+# mismatch. Bump together when upgrading eframe / web-sys.
+wasm_bindgen = "0.2.118"

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,0 +1,26 @@
+# Trunk config for the GitHub Pages demo build.
+#
+# Build:
+#   trunk build --release
+# Serve locally:
+#   trunk serve --release
+# Output:
+#   dist/  — static site (index.html + wasm + JS glue) suitable for any
+#            static host (GitHub Pages, Netlify, etc.).
+#
+# Cargo features (`--no-default-features --features web`) and the target
+# bin (`keysynth-web`) are declared in `web/index.html` via the
+# `data-cargo-*` and `data-bin` attributes on the trunk rust link, so
+# `trunk build` works with no extra flags.
+
+[build]
+target = "web/index.html"
+dist = "dist"
+# `--public-url /<repo>/` is appended in CI for the GitHub Pages subpath
+# (https://<user>.github.io/<repo>/). Local `trunk serve` leaves it as `/`.
+public_url = "/"
+
+[serve]
+address = "0.0.0.0"
+port = 8080
+open = false

--- a/src/bin/render_chord.rs
+++ b/src/bin/render_chord.rs
@@ -169,11 +169,7 @@ fn parse_args() -> Result<Args, String> {
     })
 }
 
-fn write_wav_stereo(
-    path: &std::path::Path,
-    left: &[f32],
-    right: &[f32],
-) -> Result<(), String> {
+fn write_wav_stereo(path: &std::path::Path, left: &[f32], right: &[f32]) -> Result<(), String> {
     if let Some(p) = path.parent() {
         std::fs::create_dir_all(p).map_err(|e| format!("create_dir_all {}: {e}", p.display()))?;
     }
@@ -214,8 +210,8 @@ fn render_sfz(args: &Args) -> Result<(Vec<f32>, Vec<f32>), String> {
         .sfz_path
         .as_ref()
         .ok_or("--sfz PATH required for engine sfz-piano")?;
-    let mut player = SfzPlayer::load(sfz_path, SR as f32)
-        .map_err(|e| format!("SfzPlayer::load: {e}"))?;
+    let mut player =
+        SfzPlayer::load(sfz_path, SR as f32).map_err(|e| format!("SfzPlayer::load: {e}"))?;
     let total_samples = (args.duration_sec * SR as f32) as usize;
     let release_at = ((args.hold_sec * SR as f32) as usize).min(total_samples);
     let jitter_samples = (args.onset_jitter_ms * SR as f32 / 1000.0) as usize;
@@ -247,7 +243,10 @@ fn render_sfz(args: &Args) -> Result<(Vec<f32>, Vec<f32>), String> {
         player.note_on(0, note, args.velocity);
     }
     if cursor < release_at {
-        player.render(&mut left[cursor..release_at], &mut right[cursor..release_at]);
+        player.render(
+            &mut left[cursor..release_at],
+            &mut right[cursor..release_at],
+        );
     }
     for &note in &args.notes {
         player.note_off(0, note);

--- a/src/bin/render_song.rs
+++ b/src/bin/render_song.rs
@@ -62,11 +62,11 @@ fn piece_minor_cadence() -> Vec<NoteEvent> {
     // i – VI – III – VII / i in A minor. 8 s.
     let mut v = Vec::new();
     let chords: &[(f32, &[u8])] = &[
-        (0.0, &[33, 57, 60, 64, 69]),  // A minor
-        (1.6, &[41, 57, 60, 65, 69]),  // F major (VI of Am)
-        (3.2, &[40, 55, 59, 64, 67]),  // C major (III of Am)
-        (4.8, &[43, 59, 62, 67, 71]),  // G major (VII)
-        (6.4, &[33, 57, 60, 64, 69]),  // back to Am
+        (0.0, &[33, 57, 60, 64, 69]), // A minor
+        (1.6, &[41, 57, 60, 65, 69]), // F major (VI of Am)
+        (3.2, &[40, 55, 59, 64, 67]), // C major (III of Am)
+        (4.8, &[43, 59, 62, 67, 71]), // G major (VII)
+        (6.4, &[33, 57, 60, 64, 69]), // back to Am
     ];
     for (t, notes) in chords {
         for &n in *notes {
@@ -263,11 +263,7 @@ fn parse_args() -> Result<Args, String> {
     })
 }
 
-fn write_wav_stereo(
-    path: &std::path::Path,
-    left: &[f32],
-    right: &[f32],
-) -> Result<(), String> {
+fn write_wav_stereo(path: &std::path::Path, left: &[f32], right: &[f32]) -> Result<(), String> {
     if let Some(p) = path.parent() {
         std::fs::create_dir_all(p).map_err(|e| format!("create_dir_all {}: {e}", p.display()))?;
     }
@@ -309,7 +305,10 @@ fn pan_for_note(midi_note: u8) -> f32 {
     ((midi_note as f32 - CENTRE) / SPAN).clamp(-1.0, 1.0)
 }
 
-fn render_keysynth_piece(args: &Args, events: &[NoteEvent]) -> Result<(Vec<f32>, Vec<f32>), String> {
+fn render_keysynth_piece(
+    args: &Args,
+    events: &[NoteEvent],
+) -> Result<(Vec<f32>, Vec<f32>), String> {
     if args.engine == Engine::PianoModal {
         let (lut, source) = ModalLut::auto_load(args.modal_lut_path.as_deref());
         eprintln!("render_song: modal LUT source = {source}");
@@ -362,8 +361,8 @@ fn render_sfz_piece(args: &Args, events: &[NoteEvent]) -> Result<(Vec<f32>, Vec<
         .sfz_path
         .as_ref()
         .ok_or("--sfz PATH required for engine sfz-piano")?;
-    let mut player = SfzPlayer::load(sfz_path, SR as f32)
-        .map_err(|e| format!("SfzPlayer::load: {e}"))?;
+    let mut player =
+        SfzPlayer::load(sfz_path, SR as f32).map_err(|e| format!("SfzPlayer::load: {e}"))?;
     let max_end = events
         .iter()
         .map(|e| e.start_sec + e.duration_sec)
@@ -381,7 +380,10 @@ fn render_sfz_piece(args: &Args, events: &[NoteEvent]) -> Result<(Vec<f32>, Vec<
     for ev in events {
         let on_at = (ev.start_sec * SR as f32) as usize;
         let off_at = ((ev.start_sec + ev.duration_sec) * SR as f32) as usize;
-        timeline.push((on_at.min(total_samples), Kind::On(ev.midi_note, ev.velocity)));
+        timeline.push((
+            on_at.min(total_samples),
+            Kind::On(ev.midi_note, ev.velocity),
+        ));
         timeline.push((off_at.min(total_samples), Kind::Off(ev.midi_note)));
     }
     timeline.sort_by_key(|(t, _)| *t);
@@ -406,7 +408,10 @@ fn render_sfz_piece(args: &Args, events: &[NoteEvent]) -> Result<(Vec<f32>, Vec<
         }
     }
     if cursor < total_samples {
-        player.render(&mut left[cursor..total_samples], &mut right[cursor..total_samples]);
+        player.render(
+            &mut left[cursor..total_samples],
+            &mut right[cursor..total_samples],
+        );
     }
     // Keep the SFZ player's native stereo image — that's what makes it
     // sound "spacious" vs the per-voice-pan modal stereo we synthesise.

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -1,0 +1,631 @@
+//! WASM / web entry point for the GitHub Pages demo build.
+//!
+//! Trims the live native synth down to: pure modelling engines (square / ks
+//! / piano / piano-modal etc.), an on-screen 2-octave keyboard driven by
+//! mouse + PC keyboard, and an optional Web MIDI bridge. No SF2, no SFZ,
+//! no live `midir` -- those are gated out at the Cargo feature level so
+//! this binary only sees the cross-target DSP code.
+//!
+//! Audio is built lazily on first user gesture (click the "Start audio"
+//! button) so the browser autoplay policy doesn't reject `AudioContext`
+//! creation.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::sync::{Arc, Mutex};
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::StreamConfig;
+use eframe::egui;
+use wasm_bindgen::JsCast;
+
+use keysynth::reverb::{self, Reverb};
+use keysynth::sympathetic::SympatheticBank;
+use keysynth::synth::{
+    make_voice, midi_to_freq, Engine, LiveParams, MixMode, ModalLut, Voice, MODAL_LUT,
+};
+
+// Engines exposed to the web UI. SfPiano / SfzPiano deliberately omitted —
+// they need a real SoundFont / SFZ library on disk that we don't ship to
+// GitHub Pages.
+const ENGINES_FOR_WEB: &[(Engine, &str)] = &[
+    (Engine::PianoModal, "piano-modal"),
+    (Engine::PianoLite, "piano-lite"),
+    (Engine::PianoThick, "piano-thick"),
+    (Engine::Piano, "piano"),
+    (Engine::Piano5AM, "piano-5am"),
+    (Engine::Koto, "koto"),
+    (Engine::KsRich, "ks-rich"),
+    (Engine::Ks, "ks"),
+    (Engine::Sub, "sub"),
+    (Engine::Fm, "fm"),
+    (Engine::Square, "square"),
+];
+
+// PC keyboard → MIDI semitone offset within the current octave.
+// Standard tracker layout: bottom row = white keys, q-row = upper octave.
+const PC_KEYMAP: &[(egui::Key, i32)] = &[
+    // Lower octave (white + black row)
+    (egui::Key::Z, 0),  // C
+    (egui::Key::S, 1),  // C#
+    (egui::Key::X, 2),  // D
+    (egui::Key::D, 3),  // D#
+    (egui::Key::C, 4),  // E
+    (egui::Key::V, 5),  // F
+    (egui::Key::G, 6),  // F#
+    (egui::Key::B, 7),  // G
+    (egui::Key::H, 8),  // G#
+    (egui::Key::N, 9),  // A
+    (egui::Key::J, 10), // A#
+    (egui::Key::M, 11), // B
+    // Upper octave
+    (egui::Key::Q, 12), // C
+    (egui::Key::Num2, 13),
+    (egui::Key::W, 14),
+    (egui::Key::Num3, 15),
+    (egui::Key::E, 16),
+    (egui::Key::R, 17),
+    (egui::Key::Num5, 18),
+    (egui::Key::T, 19),
+    (egui::Key::Num6, 20),
+    (egui::Key::Y, 21),
+    (egui::Key::Num7, 22),
+    (egui::Key::U, 23),
+    (egui::Key::I, 24),
+];
+
+// On-screen keyboard span in semitones (2 octaves + 1 = 25 keys).
+const KEYBOARD_SPAN: u8 = 25;
+
+// Hold the cpal stream so it isn't dropped (which kills audio). Stream is
+// not Send/Sync on wasm32 single-threaded, but `WebApp` only ever lives on
+// the main JS thread, so plain ownership is fine.
+struct AudioHandle {
+    _stream: cpal::Stream,
+}
+
+struct WebApp {
+    voices: Arc<Mutex<Vec<Voice>>>,
+    live: Arc<Mutex<LiveParams>>,
+    sample_rate: u32,
+    audio: Option<AudioHandle>,
+    audio_err: Option<String>,
+    /// Notes currently held by mouse/touch. PC keyboard tracking is via
+    /// egui's per-frame key state, not this set.
+    mouse_down_note: Option<u8>,
+    /// Base MIDI note for the leftmost on-screen key. Defaults to C3 (48).
+    base_note: u8,
+    /// Status string for Web MIDI (e.g. "not requested" / "connected: ..."
+    /// / error).
+    midi_status: String,
+}
+
+impl Default for WebApp {
+    fn default() -> Self {
+        // Initialise the modal LUT once. On wasm32 this pulls bytes from
+        // include_bytes! — the file lookup never touches a real
+        // filesystem.
+        let (lut, source) = ModalLut::auto_load(None);
+        let _ = MODAL_LUT.set(lut);
+        web_sys::console::log_1(&format!("keysynth-web: modal LUT source = {source}").into());
+
+        Self {
+            voices: Arc::new(Mutex::new(Vec::with_capacity(32))),
+            live: Arc::new(Mutex::new(LiveParams {
+                master: 1.5,
+                engine: Engine::PianoModal,
+                reverb_wet: 0.25,
+                sf_program: 0,
+                sf_bank: 0,
+                mix_mode: MixMode::ParallelComp,
+            })),
+            sample_rate: 0,
+            audio: None,
+            audio_err: None,
+            mouse_down_note: None,
+            base_note: 48, // C3
+            midi_status: "not requested".to_string(),
+        }
+    }
+}
+
+impl WebApp {
+    fn start_audio(&mut self) {
+        if self.audio.is_some() {
+            return;
+        }
+        match build_audio(self.voices.clone(), self.live.clone()) {
+            Ok((handle, sr)) => {
+                self.sample_rate = sr;
+                self.audio = Some(handle);
+                self.audio_err = None;
+                web_sys::console::log_1(
+                    &format!("keysynth-web: audio started @ {sr} Hz").into(),
+                );
+            }
+            Err(e) => {
+                web_sys::console::error_1(
+                    &format!("keysynth-web: audio start failed: {e}").into(),
+                );
+                self.audio_err = Some(e);
+            }
+        }
+    }
+
+    fn note_on(&mut self, note: u8, velocity: u8) {
+        if self.audio.is_none() || self.sample_rate == 0 {
+            return;
+        }
+        let engine = self.live.lock().unwrap().engine;
+        let freq = midi_to_freq(note);
+        let inner = make_voice(engine, self.sample_rate as f32, freq, velocity);
+        let v = Voice {
+            key: (0, note),
+            inner,
+        };
+        let mut pool = self.voices.lock().unwrap();
+        if let Some(slot) = pool.iter_mut().find(|x| x.key == (0, note)) {
+            *slot = v;
+        } else {
+            const MAX_VOICES: usize = 24;
+            if pool.len() >= MAX_VOICES {
+                let evict = pool
+                    .iter()
+                    .position(|x| x.inner.is_done() || x.inner.is_releasing())
+                    .unwrap_or(0);
+                pool.remove(evict);
+            }
+            pool.push(v);
+        }
+    }
+
+    fn note_off(&mut self, note: u8) {
+        let mut pool = self.voices.lock().unwrap();
+        if let Some(slot) = pool.iter_mut().find(|x| x.key == (0, note)) {
+            slot.inner.trigger_release();
+        }
+    }
+
+    /// Process PC keyboard input via egui's per-frame input snapshot.
+    /// Tracks key edges (just_pressed → note_on, just_released → note_off).
+    fn handle_pc_keyboard(&mut self, ctx: &egui::Context) {
+        ctx.input(|i| {
+            for &(key, semi) in PC_KEYMAP {
+                let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
+                if i.key_pressed(key) {
+                    self.note_on(note, 100);
+                }
+                if i.key_released(key) {
+                    self.note_off(note);
+                }
+            }
+        });
+    }
+
+    fn draw_on_screen_keyboard(&mut self, ui: &mut egui::Ui) {
+        // 2-octave (+1) keyboard. Lay out one wide rect per semitone with
+        // black-key inserts drawn on top so a click selects the right
+        // pitch class. Geometry is rough but legible.
+        let span = KEYBOARD_SPAN as i32;
+        let total_w = ui.available_width().min(720.0);
+        let key_h = 100.0;
+        let white_w = total_w / 15.0; // 15 white keys in a 2-octave span
+        let black_w = white_w * 0.6;
+        let black_h = key_h * 0.6;
+
+        // Allocate the full rect first so child painters share it.
+        let (rect, response) =
+            ui.allocate_exact_size(egui::vec2(white_w * 15.0, key_h), egui::Sense::click_and_drag());
+        let painter = ui.painter_at(rect);
+
+        // Pass 1: white keys.
+        let mut white_idx = 0usize;
+        let mut white_rects: Vec<(u8, egui::Rect)> = Vec::with_capacity(15);
+        for semi in 0..span {
+            if !is_black(semi as u8) {
+                let x0 = rect.left() + white_idx as f32 * white_w;
+                let r = egui::Rect::from_min_size(
+                    egui::pos2(x0, rect.top()),
+                    egui::vec2(white_w, key_h),
+                );
+                let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
+                let active = self.is_note_sounding(note);
+                let fill = if active {
+                    egui::Color32::from_rgb(160, 200, 240)
+                } else {
+                    egui::Color32::WHITE
+                };
+                painter.rect_filled(r, 2.0, fill);
+                painter.rect_stroke(r, 2.0, egui::Stroke::new(1.0, egui::Color32::BLACK));
+                white_rects.push((note, r));
+                white_idx += 1;
+            }
+        }
+
+        // Pass 2: black keys overlaid on top.
+        let mut black_rects: Vec<(u8, egui::Rect)> = Vec::with_capacity(10);
+        let mut white_idx = 0usize;
+        for semi in 0..span {
+            if is_black(semi as u8) {
+                // Black key sits at the right edge of the previous white key.
+                let prev_white_x = rect.left() + (white_idx as f32 - 0.5) * white_w
+                    + white_w
+                    - black_w * 0.5;
+                let r = egui::Rect::from_min_size(
+                    egui::pos2(prev_white_x, rect.top()),
+                    egui::vec2(black_w, black_h),
+                );
+                let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
+                let active = self.is_note_sounding(note);
+                let fill = if active {
+                    egui::Color32::from_rgb(80, 100, 140)
+                } else {
+                    egui::Color32::BLACK
+                };
+                painter.rect_filled(r, 1.0, fill);
+                painter.rect_stroke(r, 1.0, egui::Stroke::new(1.0, egui::Color32::DARK_GRAY));
+                black_rects.push((note, r));
+            } else {
+                white_idx += 1;
+            }
+        }
+
+        // Hit-test pointer against rects: black keys win over white when
+        // overlapping. Mouse drag = sustained note; release = note off.
+        let pointer_pos = response.interact_pointer_pos();
+        let mouse_down = response.is_pointer_button_down_on() && pointer_pos.is_some();
+
+        let hovered_note = pointer_pos.and_then(|p| {
+            // black first
+            for (n, r) in &black_rects {
+                if r.contains(p) {
+                    return Some(*n);
+                }
+            }
+            for (n, r) in &white_rects {
+                if r.contains(p) {
+                    return Some(*n);
+                }
+            }
+            None
+        });
+
+        match (mouse_down, hovered_note, self.mouse_down_note) {
+            (true, Some(new), None) => {
+                self.note_on(new, 100);
+                self.mouse_down_note = Some(new);
+            }
+            (true, Some(new), Some(old)) if new != old => {
+                self.note_off(old);
+                self.note_on(new, 100);
+                self.mouse_down_note = Some(new);
+            }
+            (false, _, Some(old)) => {
+                self.note_off(old);
+                self.mouse_down_note = None;
+            }
+            _ => {}
+        }
+    }
+
+    fn is_note_sounding(&self, note: u8) -> bool {
+        let pool = self.voices.lock().unwrap();
+        pool.iter()
+            .any(|v| v.key.1 == note && !v.inner.is_releasing())
+    }
+}
+
+fn is_black(semi: u8) -> bool {
+    matches!(semi % 12, 1 | 3 | 6 | 8 | 10)
+}
+
+impl eframe::App for WebApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Continuous repaint so the on-screen keyboard reflects PC-key
+        // and audio state immediately.
+        ctx.request_repaint();
+
+        if self.audio.is_some() {
+            self.handle_pc_keyboard(ctx);
+        }
+
+        egui::TopBottomPanel::top("top").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.heading("keysynth (web)");
+                ui.separator();
+                if self.audio.is_some() {
+                    ui.label(format!("audio @ {} Hz", self.sample_rate));
+                } else if let Some(err) = &self.audio_err {
+                    ui.colored_label(egui::Color32::RED, format!("audio error: {err}"));
+                    if ui.button("retry").clicked() {
+                        self.start_audio();
+                    }
+                } else if ui.button("Start audio").clicked() {
+                    self.start_audio();
+                }
+                ui.separator();
+                ui.label(format!("MIDI: {}", self.midi_status));
+            });
+        });
+
+        egui::TopBottomPanel::top("controls").show(ctx, |ui| {
+            let mut live = self.live.lock().unwrap();
+            ui.horizontal(|ui| {
+                ui.label("engine:");
+                let current_label = ENGINES_FOR_WEB
+                    .iter()
+                    .find(|(e, _)| *e == live.engine)
+                    .map(|(_, l)| *l)
+                    .unwrap_or("?");
+                egui::ComboBox::from_id_salt("engine")
+                    .selected_text(current_label)
+                    .show_ui(ui, |ui| {
+                        for (eng, label) in ENGINES_FOR_WEB {
+                            ui.selectable_value(&mut live.engine, *eng, *label);
+                        }
+                    });
+
+                ui.separator();
+                ui.label("master:");
+                ui.add(egui::Slider::new(&mut live.master, 0.0..=4.0).step_by(0.05));
+
+                ui.separator();
+                ui.label("reverb:");
+                ui.add(egui::Slider::new(&mut live.reverb_wet, 0.0..=1.0).step_by(0.01));
+
+                ui.separator();
+                ui.label("mix:");
+                egui::ComboBox::from_id_salt("mix")
+                    .selected_text(live.mix_mode.as_label())
+                    .show_ui(ui, |ui| {
+                        for &mm in MixMode::ALL {
+                            ui.selectable_value(&mut live.mix_mode, mm, mm.as_label());
+                        }
+                    });
+            });
+            drop(live);
+
+            ui.horizontal(|ui| {
+                ui.label("octave:");
+                if ui.button("◀").clicked() && self.base_note >= 12 {
+                    self.base_note -= 12;
+                }
+                ui.label(format!("{}", self.base_note / 12 - 1));
+                if ui.button("▶").clicked() && self.base_note <= 96 {
+                    self.base_note += 12;
+                }
+                ui.separator();
+                ui.label("PC keyboard: zsxdcvgbhnjm = lower octave, qweryt... = upper");
+            });
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.add_space(12.0);
+            self.draw_on_screen_keyboard(ui);
+            ui.add_space(20.0);
+            ui.collapsing("about", |ui| {
+                ui.label(
+                    "keysynth — pure-Rust real-time modelling synth. The web build \
+                     drops SF2/SFZ sample players and live MIDI input; the modelling \
+                     engines (Karplus-Strong, modal piano, FM, etc.) run unchanged.",
+                );
+                ui.label("source: https://github.com/YuujiKamura/keysynth");
+            });
+        });
+    }
+}
+
+// ===========================================================================
+// Audio thread setup
+// ===========================================================================
+
+fn build_audio(
+    voices: Arc<Mutex<Vec<Voice>>>,
+    live: Arc<Mutex<LiveParams>>,
+) -> Result<(AudioHandle, u32), String> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or_else(|| "no default output device".to_string())?;
+    let supported = device
+        .default_output_config()
+        .map_err(|e| format!("default output config: {e}"))?;
+    let sr = supported.sample_rate().0;
+    let channels = supported.channels();
+    let stream_cfg: StreamConfig = supported.into();
+
+    let ir = reverb::synthetic_body_ir(sr);
+    let mut reverb = Reverb::new(ir);
+    let mut sympathetic = SympatheticBank::new_piano(sr as f32);
+    let mut mono: Vec<f32> = Vec::new();
+    let mut mono_compressed: Vec<f32> = Vec::new();
+    let mut limiter_gain: f32 = 1.0;
+
+    let voices_cb = voices.clone();
+    let live_cb = live.clone();
+
+    let stream = device
+        .build_output_stream::<f32, _, _>(
+            &stream_cfg,
+            move |out: &mut [f32], _info| {
+                let (master, wet, engine, mix_mode) = {
+                    let lp = live_cb.lock().unwrap();
+                    (lp.master, lp.reverb_wet, lp.engine, lp.mix_mode)
+                };
+                audio_render(
+                    out,
+                    channels,
+                    &voices_cb,
+                    master,
+                    wet,
+                    &mut mono,
+                    &mut mono_compressed,
+                    &mut reverb,
+                    &mut sympathetic,
+                    &mut limiter_gain,
+                    engine,
+                    mix_mode,
+                );
+            },
+            move |err| {
+                web_sys::console::error_1(
+                    &format!("keysynth-web: stream error: {err}").into(),
+                );
+            },
+            None,
+        )
+        .map_err(|e| format!("build_output_stream: {e}"))?;
+
+    stream.play().map_err(|e| format!("stream.play: {e}"))?;
+    Ok((AudioHandle { _stream: stream }, sr))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn audio_render(
+    out: &mut [f32],
+    channels: u16,
+    voices: &Arc<Mutex<Vec<Voice>>>,
+    master: f32,
+    reverb_wet: f32,
+    mono: &mut Vec<f32>,
+    mono_compressed: &mut Vec<f32>,
+    reverb: &mut Reverb,
+    sympathetic: &mut SympatheticBank,
+    limiter_gain: &mut f32,
+    engine: Engine,
+    mix_mode: MixMode,
+) {
+    let frames = out.len() / channels as usize;
+    if mono.len() != frames {
+        mono.resize(frames, 0.0);
+    } else {
+        mono.fill(0.0);
+    }
+
+    {
+        let mut pool = voices.lock().unwrap();
+        for v in pool.iter_mut() {
+            v.inner.render_add(mono.as_mut_slice());
+        }
+        pool.retain(|v| !v.inner.is_done());
+    }
+
+    if engine.is_piano_family() {
+        const COUPLING: f32 = 0.0002;
+        const MIX: f32 = 0.3;
+        for sample in mono.iter_mut() {
+            let drive = *sample;
+            let sym_out = sympathetic.process(drive, COUPLING);
+            *sample += sym_out * MIX;
+        }
+    } else {
+        for _ in 0..mono.len() {
+            let _ = sympathetic.process(0.0, 0.0);
+        }
+    }
+
+    for s in mono.iter_mut() {
+        if !s.is_finite() {
+            *s = 0.0;
+        }
+    }
+
+    reverb.process(mono.as_mut_slice(), reverb_wet);
+
+    match mix_mode {
+        MixMode::Plain => {
+            for sample in mono.iter_mut() {
+                *sample = (*sample * master).tanh();
+            }
+        }
+        MixMode::Limiter => {
+            const ATTACK: f32 = 0.5;
+            const RELEASE: f32 = 0.0001;
+            for sample in mono.iter_mut() {
+                let abs_s = sample.abs();
+                if abs_s > *limiter_gain {
+                    *limiter_gain += (abs_s - *limiter_gain) * ATTACK;
+                } else {
+                    *limiter_gain += (abs_s - *limiter_gain) * RELEASE;
+                }
+                let gr = if *limiter_gain > 1.0 {
+                    1.0 / *limiter_gain
+                } else {
+                    1.0
+                };
+                *sample = (*sample * gr * master).tanh();
+            }
+        }
+        MixMode::ParallelComp => {
+            const ALPHA: f32 = 0.7;
+            const BETA: f32 = 0.6;
+            const ATTACK: f32 = 0.5;
+            const RELEASE: f32 = 0.0001;
+            if mono_compressed.len() != mono.len() {
+                mono_compressed.resize(mono.len(), 0.0);
+            }
+            for (i, sample) in mono.iter().enumerate() {
+                let abs_s = sample.abs();
+                if abs_s > *limiter_gain {
+                    *limiter_gain += (abs_s - *limiter_gain) * ATTACK;
+                } else {
+                    *limiter_gain += (abs_s - *limiter_gain) * RELEASE;
+                }
+                let gr = if *limiter_gain > 1.0 {
+                    1.0 / *limiter_gain
+                } else {
+                    1.0
+                };
+                mono_compressed[i] = sample * gr;
+            }
+            for (i, sample) in mono.iter_mut().enumerate() {
+                let combined = (*sample * ALPHA + mono_compressed[i] * BETA) * master;
+                *sample = combined.tanh();
+            }
+        }
+    }
+
+    for (frame_idx, frame) in out.chunks_mut(channels as usize).enumerate() {
+        let s = mono[frame_idx];
+        for slot in frame.iter_mut() {
+            *slot = s;
+        }
+    }
+}
+
+// ===========================================================================
+// wasm-bindgen entry. Trunk's `<link data-trunk rel="rust" />` snippet
+// invokes `main()` automatically; we just install the panic hook and hand
+// control to eframe's WebRunner.
+// ===========================================================================
+
+fn main() {
+    console_error_panic_hook::set_once();
+
+    let runner = eframe::WebRunner::new();
+    wasm_bindgen_futures::spawn_local(async move {
+        let canvas = pick_canvas("keysynth-canvas");
+        let result = runner
+            .start(
+                canvas,
+                eframe::WebOptions::default(),
+                Box::new(|_cc| Ok(Box::new(WebApp::default()))),
+            )
+            .await;
+        if let Err(e) = result {
+            web_sys::console::error_1(&format!("eframe start failed: {e:?}").into());
+        }
+    });
+}
+
+fn pick_canvas(id: &str) -> web_sys::HtmlCanvasElement {
+    let document = web_sys::window()
+        .expect("no window")
+        .document()
+        .expect("no document");
+    document
+        .get_element_by_id(id)
+        .unwrap_or_else(|| panic!("missing <canvas id=\"{id}\">"))
+        .dyn_into::<web_sys::HtmlCanvasElement>()
+        .expect("element is not a canvas")
+}

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -9,623 +9,646 @@
 //! Audio is built lazily on first user gesture (click the "Start audio"
 //! button) so the browser autoplay policy doesn't reject `AudioContext`
 //! creation.
+//!
+//! All wasm-only code lives in `imp` and is gated to `target_arch =
+//! "wasm32"`. On non-wasm targets `main()` is a no-op stub so
+//! `cargo check --all-features --bins` (or any host-side build that
+//! happens to enable the `web` feature) still resolves a `main` symbol.
 
-#![cfg(target_arch = "wasm32")]
-
-use std::sync::{Arc, Mutex};
-
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::StreamConfig;
-use eframe::egui;
-use wasm_bindgen::JsCast;
-
-use keysynth::reverb::{self, Reverb};
-use keysynth::sympathetic::SympatheticBank;
-use keysynth::synth::{
-    make_voice, midi_to_freq, Engine, LiveParams, MixMode, ModalLut, Voice, MODAL_LUT,
-};
-
-// Engines exposed to the web UI. SfPiano / SfzPiano deliberately omitted —
-// they need a real SoundFont / SFZ library on disk that we don't ship to
-// GitHub Pages.
-const ENGINES_FOR_WEB: &[(Engine, &str)] = &[
-    (Engine::PianoModal, "piano-modal"),
-    (Engine::PianoLite, "piano-lite"),
-    (Engine::PianoThick, "piano-thick"),
-    (Engine::Piano, "piano"),
-    (Engine::Piano5AM, "piano-5am"),
-    (Engine::Koto, "koto"),
-    (Engine::KsRich, "ks-rich"),
-    (Engine::Ks, "ks"),
-    (Engine::Sub, "sub"),
-    (Engine::Fm, "fm"),
-    (Engine::Square, "square"),
-];
-
-// PC keyboard → MIDI semitone offset within the current octave.
-// Standard tracker layout: bottom row = white keys, q-row = upper octave.
-const PC_KEYMAP: &[(egui::Key, i32)] = &[
-    // Lower octave (white + black row)
-    (egui::Key::Z, 0),  // C
-    (egui::Key::S, 1),  // C#
-    (egui::Key::X, 2),  // D
-    (egui::Key::D, 3),  // D#
-    (egui::Key::C, 4),  // E
-    (egui::Key::V, 5),  // F
-    (egui::Key::G, 6),  // F#
-    (egui::Key::B, 7),  // G
-    (egui::Key::H, 8),  // G#
-    (egui::Key::N, 9),  // A
-    (egui::Key::J, 10), // A#
-    (egui::Key::M, 11), // B
-    // Upper octave
-    (egui::Key::Q, 12), // C
-    (egui::Key::Num2, 13),
-    (egui::Key::W, 14),
-    (egui::Key::Num3, 15),
-    (egui::Key::E, 16),
-    (egui::Key::R, 17),
-    (egui::Key::Num5, 18),
-    (egui::Key::T, 19),
-    (egui::Key::Num6, 20),
-    (egui::Key::Y, 21),
-    (egui::Key::Num7, 22),
-    (egui::Key::U, 23),
-    (egui::Key::I, 24),
-];
-
-// On-screen keyboard span in semitones (2 octaves + 1 = 25 keys).
-const KEYBOARD_SPAN: u8 = 25;
-
-// Hold the cpal stream so it isn't dropped (which kills audio). Stream is
-// not Send/Sync on wasm32 single-threaded, but `WebApp` only ever lives on
-// the main JS thread, so plain ownership is fine.
-struct AudioHandle {
-    _stream: cpal::Stream,
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    eprintln!(
+        "keysynth-web is a wasm32-only binary. Build it via `trunk build` from \
+         the repo root; this stub exists so host-side `cargo check` passes."
+    );
 }
 
-struct WebApp {
-    voices: Arc<Mutex<Vec<Voice>>>,
-    live: Arc<Mutex<LiveParams>>,
-    sample_rate: u32,
-    audio: Option<AudioHandle>,
-    audio_err: Option<String>,
-    /// Notes currently held by mouse/touch. PC keyboard tracking is via
-    /// egui's per-frame key state, not this set.
-    mouse_down_note: Option<u8>,
-    /// Base MIDI note for the leftmost on-screen key. Defaults to C3 (48).
-    base_note: u8,
-    /// Status string for Web MIDI (e.g. "not requested" / "connected: ..."
-    /// / error).
-    midi_status: String,
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    imp::start();
 }
 
-impl Default for WebApp {
-    fn default() -> Self {
-        // Initialise the modal LUT once. On wasm32 this pulls bytes from
-        // include_bytes! — the file lookup never touches a real
-        // filesystem.
-        let (lut, source) = ModalLut::auto_load(None);
-        let _ = MODAL_LUT.set(lut);
-        web_sys::console::log_1(&format!("keysynth-web: modal LUT source = {source}").into());
+#[cfg(target_arch = "wasm32")]
+mod imp {
 
-        Self {
-            voices: Arc::new(Mutex::new(Vec::with_capacity(32))),
-            live: Arc::new(Mutex::new(LiveParams {
-                master: 1.5,
-                engine: Engine::PianoModal,
-                reverb_wet: 0.25,
-                sf_program: 0,
-                sf_bank: 0,
-                mix_mode: MixMode::ParallelComp,
-            })),
-            sample_rate: 0,
-            audio: None,
-            audio_err: None,
-            mouse_down_note: None,
-            base_note: 48, // C3
-            midi_status: "not requested".to_string(),
-        }
+    use std::sync::{Arc, Mutex};
+
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use cpal::StreamConfig;
+    use eframe::egui;
+    use wasm_bindgen::JsCast;
+
+    use keysynth::reverb::{self, Reverb};
+    use keysynth::sympathetic::SympatheticBank;
+    use keysynth::synth::{
+        make_voice, midi_to_freq, Engine, LiveParams, MixMode, ModalLut, Voice, MODAL_LUT,
+    };
+
+    // Engines exposed to the web UI. SfPiano / SfzPiano deliberately omitted —
+    // they need a real SoundFont / SFZ library on disk that we don't ship to
+    // GitHub Pages.
+    const ENGINES_FOR_WEB: &[(Engine, &str)] = &[
+        (Engine::PianoModal, "piano-modal"),
+        (Engine::PianoLite, "piano-lite"),
+        (Engine::PianoThick, "piano-thick"),
+        (Engine::Piano, "piano"),
+        (Engine::Piano5AM, "piano-5am"),
+        (Engine::Koto, "koto"),
+        (Engine::KsRich, "ks-rich"),
+        (Engine::Ks, "ks"),
+        (Engine::Sub, "sub"),
+        (Engine::Fm, "fm"),
+        (Engine::Square, "square"),
+    ];
+
+    // PC keyboard → MIDI semitone offset within the current octave.
+    // Standard tracker layout: bottom row = white keys, q-row = upper octave.
+    const PC_KEYMAP: &[(egui::Key, i32)] = &[
+        // Lower octave (white + black row)
+        (egui::Key::Z, 0),  // C
+        (egui::Key::S, 1),  // C#
+        (egui::Key::X, 2),  // D
+        (egui::Key::D, 3),  // D#
+        (egui::Key::C, 4),  // E
+        (egui::Key::V, 5),  // F
+        (egui::Key::G, 6),  // F#
+        (egui::Key::B, 7),  // G
+        (egui::Key::H, 8),  // G#
+        (egui::Key::N, 9),  // A
+        (egui::Key::J, 10), // A#
+        (egui::Key::M, 11), // B
+        // Upper octave
+        (egui::Key::Q, 12), // C
+        (egui::Key::Num2, 13),
+        (egui::Key::W, 14),
+        (egui::Key::Num3, 15),
+        (egui::Key::E, 16),
+        (egui::Key::R, 17),
+        (egui::Key::Num5, 18),
+        (egui::Key::T, 19),
+        (egui::Key::Num6, 20),
+        (egui::Key::Y, 21),
+        (egui::Key::Num7, 22),
+        (egui::Key::U, 23),
+        (egui::Key::I, 24),
+    ];
+
+    // On-screen keyboard span in semitones (2 octaves + 1 = 25 keys).
+    const KEYBOARD_SPAN: u8 = 25;
+
+    // Hold the cpal stream so it isn't dropped (which kills audio). Stream is
+    // not Send/Sync on wasm32 single-threaded, but `WebApp` only ever lives on
+    // the main JS thread, so plain ownership is fine.
+    struct AudioHandle {
+        _stream: cpal::Stream,
     }
-}
 
-impl WebApp {
-    fn start_audio(&mut self) {
-        if self.audio.is_some() {
-            return;
-        }
-        match build_audio(self.voices.clone(), self.live.clone()) {
-            Ok((handle, sr)) => {
-                self.sample_rate = sr;
-                self.audio = Some(handle);
-                self.audio_err = None;
-                web_sys::console::log_1(
-                    &format!("keysynth-web: audio started @ {sr} Hz").into(),
-                );
-            }
-            Err(e) => {
-                web_sys::console::error_1(
-                    &format!("keysynth-web: audio start failed: {e}").into(),
-                );
-                self.audio_err = Some(e);
+    struct WebApp {
+        voices: Arc<Mutex<Vec<Voice>>>,
+        live: Arc<Mutex<LiveParams>>,
+        sample_rate: u32,
+        audio: Option<AudioHandle>,
+        audio_err: Option<String>,
+        /// Notes currently held by mouse/touch. PC keyboard tracking is via
+        /// egui's per-frame key state, not this set.
+        mouse_down_note: Option<u8>,
+        /// Base MIDI note for the leftmost on-screen key. Defaults to C3 (48).
+        base_note: u8,
+        /// Status string for Web MIDI (e.g. "not requested" / "connected: ..."
+        /// / error).
+        midi_status: String,
+    }
+
+    impl Default for WebApp {
+        fn default() -> Self {
+            // Initialise the modal LUT once. On wasm32 this pulls bytes from
+            // include_bytes! — the file lookup never touches a real
+            // filesystem.
+            let (lut, source) = ModalLut::auto_load(None);
+            let _ = MODAL_LUT.set(lut);
+            web_sys::console::log_1(&format!("keysynth-web: modal LUT source = {source}").into());
+
+            Self {
+                voices: Arc::new(Mutex::new(Vec::with_capacity(32))),
+                live: Arc::new(Mutex::new(LiveParams {
+                    master: 1.5,
+                    engine: Engine::PianoModal,
+                    reverb_wet: 0.25,
+                    sf_program: 0,
+                    sf_bank: 0,
+                    mix_mode: MixMode::ParallelComp,
+                })),
+                sample_rate: 0,
+                audio: None,
+                audio_err: None,
+                mouse_down_note: None,
+                base_note: 48, // C3
+                midi_status: "not requested".to_string(),
             }
         }
     }
 
-    fn note_on(&mut self, note: u8, velocity: u8) {
-        if self.audio.is_none() || self.sample_rate == 0 {
-            return;
-        }
-        let engine = self.live.lock().unwrap().engine;
-        let freq = midi_to_freq(note);
-        let inner = make_voice(engine, self.sample_rate as f32, freq, velocity);
-        let v = Voice {
-            key: (0, note),
-            inner,
-        };
-        let mut pool = self.voices.lock().unwrap();
-        if let Some(slot) = pool.iter_mut().find(|x| x.key == (0, note)) {
-            *slot = v;
-        } else {
-            const MAX_VOICES: usize = 24;
-            if pool.len() >= MAX_VOICES {
-                let evict = pool
-                    .iter()
-                    .position(|x| x.inner.is_done() || x.inner.is_releasing())
-                    .unwrap_or(0);
-                pool.remove(evict);
+    impl WebApp {
+        fn start_audio(&mut self) {
+            if self.audio.is_some() {
+                return;
             }
-            pool.push(v);
-        }
-    }
-
-    fn note_off(&mut self, note: u8) {
-        let mut pool = self.voices.lock().unwrap();
-        if let Some(slot) = pool.iter_mut().find(|x| x.key == (0, note)) {
-            slot.inner.trigger_release();
-        }
-    }
-
-    /// Process PC keyboard input via egui's per-frame input snapshot.
-    /// Tracks key edges (just_pressed → note_on, just_released → note_off).
-    fn handle_pc_keyboard(&mut self, ctx: &egui::Context) {
-        ctx.input(|i| {
-            for &(key, semi) in PC_KEYMAP {
-                let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
-                if i.key_pressed(key) {
-                    self.note_on(note, 100);
+            match build_audio(self.voices.clone(), self.live.clone()) {
+                Ok((handle, sr)) => {
+                    self.sample_rate = sr;
+                    self.audio = Some(handle);
+                    self.audio_err = None;
+                    web_sys::console::log_1(
+                        &format!("keysynth-web: audio started @ {sr} Hz").into(),
+                    );
                 }
-                if i.key_released(key) {
-                    self.note_off(note);
+                Err(e) => {
+                    web_sys::console::error_1(
+                        &format!("keysynth-web: audio start failed: {e}").into(),
+                    );
+                    self.audio_err = Some(e);
                 }
             }
-        });
-    }
-
-    fn draw_on_screen_keyboard(&mut self, ui: &mut egui::Ui) {
-        // 2-octave (+1) keyboard. Lay out one wide rect per semitone with
-        // black-key inserts drawn on top so a click selects the right
-        // pitch class. Geometry is rough but legible.
-        let span = KEYBOARD_SPAN as i32;
-        let total_w = ui.available_width().min(720.0);
-        let key_h = 100.0;
-        let white_w = total_w / 15.0; // 15 white keys in a 2-octave span
-        let black_w = white_w * 0.6;
-        let black_h = key_h * 0.6;
-
-        // Allocate the full rect first so child painters share it.
-        let (rect, response) =
-            ui.allocate_exact_size(egui::vec2(white_w * 15.0, key_h), egui::Sense::click_and_drag());
-        let painter = ui.painter_at(rect);
-
-        // Pass 1: white keys.
-        let mut white_idx = 0usize;
-        let mut white_rects: Vec<(u8, egui::Rect)> = Vec::with_capacity(15);
-        for semi in 0..span {
-            if !is_black(semi as u8) {
-                let x0 = rect.left() + white_idx as f32 * white_w;
-                let r = egui::Rect::from_min_size(
-                    egui::pos2(x0, rect.top()),
-                    egui::vec2(white_w, key_h),
-                );
-                let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
-                let active = self.is_note_sounding(note);
-                let fill = if active {
-                    egui::Color32::from_rgb(160, 200, 240)
-                } else {
-                    egui::Color32::WHITE
-                };
-                painter.rect_filled(r, 2.0, fill);
-                painter.rect_stroke(r, 2.0, egui::Stroke::new(1.0, egui::Color32::BLACK));
-                white_rects.push((note, r));
-                white_idx += 1;
-            }
         }
 
-        // Pass 2: black keys overlaid on top.
-        let mut black_rects: Vec<(u8, egui::Rect)> = Vec::with_capacity(10);
-        let mut white_idx = 0usize;
-        for semi in 0..span {
-            if is_black(semi as u8) {
-                // Black key sits at the right edge of the previous white key.
-                let prev_white_x = rect.left() + (white_idx as f32 - 0.5) * white_w
-                    + white_w
-                    - black_w * 0.5;
-                let r = egui::Rect::from_min_size(
-                    egui::pos2(prev_white_x, rect.top()),
-                    egui::vec2(black_w, black_h),
-                );
-                let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
-                let active = self.is_note_sounding(note);
-                let fill = if active {
-                    egui::Color32::from_rgb(80, 100, 140)
-                } else {
-                    egui::Color32::BLACK
-                };
-                painter.rect_filled(r, 1.0, fill);
-                painter.rect_stroke(r, 1.0, egui::Stroke::new(1.0, egui::Color32::DARK_GRAY));
-                black_rects.push((note, r));
+        fn note_on(&mut self, note: u8, velocity: u8) {
+            if self.audio.is_none() || self.sample_rate == 0 {
+                return;
+            }
+            let engine = self.live.lock().unwrap().engine;
+            let freq = midi_to_freq(note);
+            let inner = make_voice(engine, self.sample_rate as f32, freq, velocity);
+            let v = Voice {
+                key: (0, note),
+                inner,
+            };
+            let mut pool = self.voices.lock().unwrap();
+            if let Some(slot) = pool.iter_mut().find(|x| x.key == (0, note)) {
+                *slot = v;
             } else {
-                white_idx += 1;
+                const MAX_VOICES: usize = 24;
+                if pool.len() >= MAX_VOICES {
+                    let evict = pool
+                        .iter()
+                        .position(|x| x.inner.is_done() || x.inner.is_releasing())
+                        .unwrap_or(0);
+                    pool.remove(evict);
+                }
+                pool.push(v);
             }
         }
 
-        // Hit-test pointer against rects: black keys win over white when
-        // overlapping. Mouse drag = sustained note; release = note off.
-        let pointer_pos = response.interact_pointer_pos();
-        let mouse_down = response.is_pointer_button_down_on() && pointer_pos.is_some();
+        fn note_off(&mut self, note: u8) {
+            let mut pool = self.voices.lock().unwrap();
+            if let Some(slot) = pool.iter_mut().find(|x| x.key == (0, note)) {
+                slot.inner.trigger_release();
+            }
+        }
 
-        let hovered_note = pointer_pos.and_then(|p| {
-            // black first
-            for (n, r) in &black_rects {
-                if r.contains(p) {
-                    return Some(*n);
+        /// Process PC keyboard input via egui's per-frame input snapshot.
+        /// Tracks key edges (just_pressed → note_on, just_released → note_off).
+        fn handle_pc_keyboard(&mut self, ctx: &egui::Context) {
+            ctx.input(|i| {
+                for &(key, semi) in PC_KEYMAP {
+                    let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
+                    if i.key_pressed(key) {
+                        self.note_on(note, 100);
+                    }
+                    if i.key_released(key) {
+                        self.note_off(note);
+                    }
+                }
+            });
+        }
+
+        fn draw_on_screen_keyboard(&mut self, ui: &mut egui::Ui) {
+            // 2-octave (+1) keyboard. Lay out one wide rect per semitone with
+            // black-key inserts drawn on top so a click selects the right
+            // pitch class. Geometry is rough but legible.
+            let span = KEYBOARD_SPAN as i32;
+            let total_w = ui.available_width().min(720.0);
+            let key_h = 100.0;
+            let white_w = total_w / 15.0; // 15 white keys in a 2-octave span
+            let black_w = white_w * 0.6;
+            let black_h = key_h * 0.6;
+
+            // Allocate the full rect first so child painters share it.
+            let (rect, response) = ui.allocate_exact_size(
+                egui::vec2(white_w * 15.0, key_h),
+                egui::Sense::click_and_drag(),
+            );
+            let painter = ui.painter_at(rect);
+
+            // Pass 1: white keys.
+            let mut white_idx = 0usize;
+            let mut white_rects: Vec<(u8, egui::Rect)> = Vec::with_capacity(15);
+            for semi in 0..span {
+                if !is_black(semi as u8) {
+                    let x0 = rect.left() + white_idx as f32 * white_w;
+                    let r = egui::Rect::from_min_size(
+                        egui::pos2(x0, rect.top()),
+                        egui::vec2(white_w, key_h),
+                    );
+                    let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
+                    let active = self.is_note_sounding(note);
+                    let fill = if active {
+                        egui::Color32::from_rgb(160, 200, 240)
+                    } else {
+                        egui::Color32::WHITE
+                    };
+                    painter.rect_filled(r, 2.0, fill);
+                    painter.rect_stroke(r, 2.0, egui::Stroke::new(1.0, egui::Color32::BLACK));
+                    white_rects.push((note, r));
+                    white_idx += 1;
                 }
             }
-            for (n, r) in &white_rects {
-                if r.contains(p) {
-                    return Some(*n);
+
+            // Pass 2: black keys overlaid on top.
+            let mut black_rects: Vec<(u8, egui::Rect)> = Vec::with_capacity(10);
+            let mut white_idx = 0usize;
+            for semi in 0..span {
+                if is_black(semi as u8) {
+                    // Black key sits at the right edge of the previous white key.
+                    let prev_white_x =
+                        rect.left() + (white_idx as f32 - 0.5) * white_w + white_w - black_w * 0.5;
+                    let r = egui::Rect::from_min_size(
+                        egui::pos2(prev_white_x, rect.top()),
+                        egui::vec2(black_w, black_h),
+                    );
+                    let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
+                    let active = self.is_note_sounding(note);
+                    let fill = if active {
+                        egui::Color32::from_rgb(80, 100, 140)
+                    } else {
+                        egui::Color32::BLACK
+                    };
+                    painter.rect_filled(r, 1.0, fill);
+                    painter.rect_stroke(r, 1.0, egui::Stroke::new(1.0, egui::Color32::DARK_GRAY));
+                    black_rects.push((note, r));
+                } else {
+                    white_idx += 1;
                 }
             }
-            None
-        });
 
-        match (mouse_down, hovered_note, self.mouse_down_note) {
-            (true, Some(new), None) => {
-                self.note_on(new, 100);
-                self.mouse_down_note = Some(new);
+            // Hit-test pointer against rects: black keys win over white when
+            // overlapping. Mouse drag = sustained note; release = note off.
+            let pointer_pos = response.interact_pointer_pos();
+            let mouse_down = response.is_pointer_button_down_on() && pointer_pos.is_some();
+
+            let hovered_note = pointer_pos.and_then(|p| {
+                // black first
+                for (n, r) in &black_rects {
+                    if r.contains(p) {
+                        return Some(*n);
+                    }
+                }
+                for (n, r) in &white_rects {
+                    if r.contains(p) {
+                        return Some(*n);
+                    }
+                }
+                None
+            });
+
+            match (mouse_down, hovered_note, self.mouse_down_note) {
+                (true, Some(new), None) => {
+                    self.note_on(new, 100);
+                    self.mouse_down_note = Some(new);
+                }
+                (true, Some(new), Some(old)) if new != old => {
+                    self.note_off(old);
+                    self.note_on(new, 100);
+                    self.mouse_down_note = Some(new);
+                }
+                (false, _, Some(old)) => {
+                    self.note_off(old);
+                    self.mouse_down_note = None;
+                }
+                _ => {}
             }
-            (true, Some(new), Some(old)) if new != old => {
-                self.note_off(old);
-                self.note_on(new, 100);
-                self.mouse_down_note = Some(new);
-            }
-            (false, _, Some(old)) => {
-                self.note_off(old);
-                self.mouse_down_note = None;
-            }
-            _ => {}
+        }
+
+        fn is_note_sounding(&self, note: u8) -> bool {
+            let pool = self.voices.lock().unwrap();
+            pool.iter()
+                .any(|v| v.key.1 == note && !v.inner.is_releasing())
         }
     }
 
-    fn is_note_sounding(&self, note: u8) -> bool {
-        let pool = self.voices.lock().unwrap();
-        pool.iter()
-            .any(|v| v.key.1 == note && !v.inner.is_releasing())
+    fn is_black(semi: u8) -> bool {
+        matches!(semi % 12, 1 | 3 | 6 | 8 | 10)
     }
-}
 
-fn is_black(semi: u8) -> bool {
-    matches!(semi % 12, 1 | 3 | 6 | 8 | 10)
-}
+    impl eframe::App for WebApp {
+        fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+            // Continuous repaint so the on-screen keyboard reflects PC-key
+            // and audio state immediately.
+            ctx.request_repaint();
 
-impl eframe::App for WebApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Continuous repaint so the on-screen keyboard reflects PC-key
-        // and audio state immediately.
-        ctx.request_repaint();
+            if self.audio.is_some() {
+                self.handle_pc_keyboard(ctx);
+            }
 
-        if self.audio.is_some() {
-            self.handle_pc_keyboard(ctx);
-        }
-
-        egui::TopBottomPanel::top("top").show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.heading("keysynth (web)");
-                ui.separator();
-                if self.audio.is_some() {
-                    ui.label(format!("audio @ {} Hz", self.sample_rate));
-                } else if let Some(err) = &self.audio_err {
-                    ui.colored_label(egui::Color32::RED, format!("audio error: {err}"));
-                    if ui.button("retry").clicked() {
+            egui::TopBottomPanel::top("top").show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading("keysynth (web)");
+                    ui.separator();
+                    if self.audio.is_some() {
+                        ui.label(format!("audio @ {} Hz", self.sample_rate));
+                    } else if let Some(err) = &self.audio_err {
+                        ui.colored_label(egui::Color32::RED, format!("audio error: {err}"));
+                        if ui.button("retry").clicked() {
+                            self.start_audio();
+                        }
+                    } else if ui.button("Start audio").clicked() {
                         self.start_audio();
                     }
-                } else if ui.button("Start audio").clicked() {
-                    self.start_audio();
-                }
-                ui.separator();
-                ui.label(format!("MIDI: {}", self.midi_status));
+                    ui.separator();
+                    ui.label(format!("MIDI: {}", self.midi_status));
+                });
             });
-        });
 
-        egui::TopBottomPanel::top("controls").show(ctx, |ui| {
-            let mut live = self.live.lock().unwrap();
-            ui.horizontal(|ui| {
-                ui.label("engine:");
-                let current_label = ENGINES_FOR_WEB
-                    .iter()
-                    .find(|(e, _)| *e == live.engine)
-                    .map(|(_, l)| *l)
-                    .unwrap_or("?");
-                egui::ComboBox::from_id_salt("engine")
-                    .selected_text(current_label)
-                    .show_ui(ui, |ui| {
-                        for (eng, label) in ENGINES_FOR_WEB {
-                            ui.selectable_value(&mut live.engine, *eng, *label);
-                        }
-                    });
+            egui::TopBottomPanel::top("controls").show(ctx, |ui| {
+                let mut live = self.live.lock().unwrap();
+                ui.horizontal(|ui| {
+                    ui.label("engine:");
+                    let current_label = ENGINES_FOR_WEB
+                        .iter()
+                        .find(|(e, _)| *e == live.engine)
+                        .map(|(_, l)| *l)
+                        .unwrap_or("?");
+                    egui::ComboBox::from_id_salt("engine")
+                        .selected_text(current_label)
+                        .show_ui(ui, |ui| {
+                            for (eng, label) in ENGINES_FOR_WEB {
+                                ui.selectable_value(&mut live.engine, *eng, *label);
+                            }
+                        });
 
-                ui.separator();
-                ui.label("master:");
-                ui.add(egui::Slider::new(&mut live.master, 0.0..=4.0).step_by(0.05));
+                    ui.separator();
+                    ui.label("master:");
+                    ui.add(egui::Slider::new(&mut live.master, 0.0..=4.0).step_by(0.05));
 
-                ui.separator();
-                ui.label("reverb:");
-                ui.add(egui::Slider::new(&mut live.reverb_wet, 0.0..=1.0).step_by(0.01));
+                    ui.separator();
+                    ui.label("reverb:");
+                    ui.add(egui::Slider::new(&mut live.reverb_wet, 0.0..=1.0).step_by(0.01));
 
-                ui.separator();
-                ui.label("mix:");
-                egui::ComboBox::from_id_salt("mix")
-                    .selected_text(live.mix_mode.as_label())
-                    .show_ui(ui, |ui| {
-                        for &mm in MixMode::ALL {
-                            ui.selectable_value(&mut live.mix_mode, mm, mm.as_label());
-                        }
-                    });
+                    ui.separator();
+                    ui.label("mix:");
+                    egui::ComboBox::from_id_salt("mix")
+                        .selected_text(live.mix_mode.as_label())
+                        .show_ui(ui, |ui| {
+                            for &mm in MixMode::ALL {
+                                ui.selectable_value(&mut live.mix_mode, mm, mm.as_label());
+                            }
+                        });
+                });
+                drop(live);
+
+                ui.horizontal(|ui| {
+                    ui.label("octave:");
+                    if ui.button("◀").clicked() && self.base_note >= 12 {
+                        self.base_note -= 12;
+                    }
+                    // Cast to i32 BEFORE the subtraction. base_note is u8 and
+                    // can step down to 0 (C-1 in MIDI octave numbering),
+                    // where `0u8 / 12 - 1` panics in debug / wraps to 255 in
+                    // release.
+                    ui.label(format!("C{}", self.base_note as i32 / 12 - 1));
+                    if ui.button("▶").clicked() && self.base_note <= 96 {
+                        self.base_note += 12;
+                    }
+                    ui.separator();
+                    ui.label("PC keyboard: zsxdcvgbhnjm = lower octave, qweryt... = upper");
+                });
             });
-            drop(live);
 
-            ui.horizontal(|ui| {
-                ui.label("octave:");
-                if ui.button("◀").clicked() && self.base_note >= 12 {
-                    self.base_note -= 12;
-                }
-                ui.label(format!("{}", self.base_note / 12 - 1));
-                if ui.button("▶").clicked() && self.base_note <= 96 {
-                    self.base_note += 12;
-                }
-                ui.separator();
-                ui.label("PC keyboard: zsxdcvgbhnjm = lower octave, qweryt... = upper");
-            });
-        });
-
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.add_space(12.0);
-            self.draw_on_screen_keyboard(ui);
-            ui.add_space(20.0);
-            ui.collapsing("about", |ui| {
-                ui.label(
-                    "keysynth — pure-Rust real-time modelling synth. The web build \
+            egui::CentralPanel::default().show(ctx, |ui| {
+                ui.add_space(12.0);
+                self.draw_on_screen_keyboard(ui);
+                ui.add_space(20.0);
+                ui.collapsing("about", |ui| {
+                    ui.label(
+                        "keysynth — pure-Rust real-time modelling synth. The web build \
                      drops SF2/SFZ sample players and live MIDI input; the modelling \
                      engines (Karplus-Strong, modal piano, FM, etc.) run unchanged.",
-                );
-                ui.label("source: https://github.com/YuujiKamura/keysynth");
+                    );
+                    ui.label("source: https://github.com/YuujiKamura/keysynth");
+                });
             });
+        }
+    }
+
+    // ===========================================================================
+    // Audio thread setup
+    // ===========================================================================
+
+    fn build_audio(
+        voices: Arc<Mutex<Vec<Voice>>>,
+        live: Arc<Mutex<LiveParams>>,
+    ) -> Result<(AudioHandle, u32), String> {
+        let host = cpal::default_host();
+        let device = host
+            .default_output_device()
+            .ok_or_else(|| "no default output device".to_string())?;
+        let supported = device
+            .default_output_config()
+            .map_err(|e| format!("default output config: {e}"))?;
+        let sr = supported.sample_rate().0;
+        let channels = supported.channels();
+        let stream_cfg: StreamConfig = supported.into();
+
+        let ir = reverb::synthetic_body_ir(sr);
+        let mut reverb = Reverb::new(ir);
+        let mut sympathetic = SympatheticBank::new_piano(sr as f32);
+        let mut mono: Vec<f32> = Vec::new();
+        let mut mono_compressed: Vec<f32> = Vec::new();
+        let mut limiter_gain: f32 = 1.0;
+
+        let voices_cb = voices.clone();
+        let live_cb = live.clone();
+
+        let stream = device
+            .build_output_stream::<f32, _, _>(
+                &stream_cfg,
+                move |out: &mut [f32], _info| {
+                    let (master, wet, engine, mix_mode) = {
+                        let lp = live_cb.lock().unwrap();
+                        (lp.master, lp.reverb_wet, lp.engine, lp.mix_mode)
+                    };
+                    audio_render(
+                        out,
+                        channels,
+                        &voices_cb,
+                        master,
+                        wet,
+                        &mut mono,
+                        &mut mono_compressed,
+                        &mut reverb,
+                        &mut sympathetic,
+                        &mut limiter_gain,
+                        engine,
+                        mix_mode,
+                    );
+                },
+                move |err| {
+                    web_sys::console::error_1(&format!("keysynth-web: stream error: {err}").into());
+                },
+                None,
+            )
+            .map_err(|e| format!("build_output_stream: {e}"))?;
+
+        stream.play().map_err(|e| format!("stream.play: {e}"))?;
+        Ok((AudioHandle { _stream: stream }, sr))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn audio_render(
+        out: &mut [f32],
+        channels: u16,
+        voices: &Arc<Mutex<Vec<Voice>>>,
+        master: f32,
+        reverb_wet: f32,
+        mono: &mut Vec<f32>,
+        mono_compressed: &mut Vec<f32>,
+        reverb: &mut Reverb,
+        sympathetic: &mut SympatheticBank,
+        limiter_gain: &mut f32,
+        engine: Engine,
+        mix_mode: MixMode,
+    ) {
+        let frames = out.len() / channels as usize;
+        if mono.len() != frames {
+            mono.resize(frames, 0.0);
+        } else {
+            mono.fill(0.0);
+        }
+
+        {
+            let mut pool = voices.lock().unwrap();
+            for v in pool.iter_mut() {
+                v.inner.render_add(mono.as_mut_slice());
+            }
+            pool.retain(|v| !v.inner.is_done());
+        }
+
+        if engine.is_piano_family() {
+            const COUPLING: f32 = 0.0002;
+            const MIX: f32 = 0.3;
+            for sample in mono.iter_mut() {
+                let drive = *sample;
+                let sym_out = sympathetic.process(drive, COUPLING);
+                *sample += sym_out * MIX;
+            }
+        } else {
+            for _ in 0..mono.len() {
+                let _ = sympathetic.process(0.0, 0.0);
+            }
+        }
+
+        for s in mono.iter_mut() {
+            if !s.is_finite() {
+                *s = 0.0;
+            }
+        }
+
+        reverb.process(mono.as_mut_slice(), reverb_wet);
+
+        match mix_mode {
+            MixMode::Plain => {
+                for sample in mono.iter_mut() {
+                    *sample = (*sample * master).tanh();
+                }
+            }
+            MixMode::Limiter => {
+                const ATTACK: f32 = 0.5;
+                const RELEASE: f32 = 0.0001;
+                for sample in mono.iter_mut() {
+                    let abs_s = sample.abs();
+                    if abs_s > *limiter_gain {
+                        *limiter_gain += (abs_s - *limiter_gain) * ATTACK;
+                    } else {
+                        *limiter_gain += (abs_s - *limiter_gain) * RELEASE;
+                    }
+                    let gr = if *limiter_gain > 1.0 {
+                        1.0 / *limiter_gain
+                    } else {
+                        1.0
+                    };
+                    *sample = (*sample * gr * master).tanh();
+                }
+            }
+            MixMode::ParallelComp => {
+                const ALPHA: f32 = 0.7;
+                const BETA: f32 = 0.6;
+                const ATTACK: f32 = 0.5;
+                const RELEASE: f32 = 0.0001;
+                if mono_compressed.len() != mono.len() {
+                    mono_compressed.resize(mono.len(), 0.0);
+                }
+                for (i, sample) in mono.iter().enumerate() {
+                    let abs_s = sample.abs();
+                    if abs_s > *limiter_gain {
+                        *limiter_gain += (abs_s - *limiter_gain) * ATTACK;
+                    } else {
+                        *limiter_gain += (abs_s - *limiter_gain) * RELEASE;
+                    }
+                    let gr = if *limiter_gain > 1.0 {
+                        1.0 / *limiter_gain
+                    } else {
+                        1.0
+                    };
+                    mono_compressed[i] = sample * gr;
+                }
+                for (i, sample) in mono.iter_mut().enumerate() {
+                    let combined = (*sample * ALPHA + mono_compressed[i] * BETA) * master;
+                    *sample = combined.tanh();
+                }
+            }
+        }
+
+        for (frame_idx, frame) in out.chunks_mut(channels as usize).enumerate() {
+            let s = mono[frame_idx];
+            for slot in frame.iter_mut() {
+                *slot = s;
+            }
+        }
+    }
+
+    // ===========================================================================
+    // wasm-bindgen entry. The outer real `main` (above the `mod imp` wrapper)
+    // dispatches into `imp::start`; we install the panic hook and hand control
+    // to eframe's WebRunner from there.
+    // ===========================================================================
+
+    pub fn start() {
+        console_error_panic_hook::set_once();
+
+        let runner = eframe::WebRunner::new();
+        wasm_bindgen_futures::spawn_local(async move {
+            let canvas = pick_canvas("keysynth-canvas");
+            let result = runner
+                .start(
+                    canvas,
+                    eframe::WebOptions::default(),
+                    Box::new(|_cc| Ok(Box::new(WebApp::default()))),
+                )
+                .await;
+            if let Err(e) = result {
+                web_sys::console::error_1(&format!("eframe start failed: {e:?}").into());
+            }
         });
     }
-}
 
-// ===========================================================================
-// Audio thread setup
-// ===========================================================================
-
-fn build_audio(
-    voices: Arc<Mutex<Vec<Voice>>>,
-    live: Arc<Mutex<LiveParams>>,
-) -> Result<(AudioHandle, u32), String> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or_else(|| "no default output device".to_string())?;
-    let supported = device
-        .default_output_config()
-        .map_err(|e| format!("default output config: {e}"))?;
-    let sr = supported.sample_rate().0;
-    let channels = supported.channels();
-    let stream_cfg: StreamConfig = supported.into();
-
-    let ir = reverb::synthetic_body_ir(sr);
-    let mut reverb = Reverb::new(ir);
-    let mut sympathetic = SympatheticBank::new_piano(sr as f32);
-    let mut mono: Vec<f32> = Vec::new();
-    let mut mono_compressed: Vec<f32> = Vec::new();
-    let mut limiter_gain: f32 = 1.0;
-
-    let voices_cb = voices.clone();
-    let live_cb = live.clone();
-
-    let stream = device
-        .build_output_stream::<f32, _, _>(
-            &stream_cfg,
-            move |out: &mut [f32], _info| {
-                let (master, wet, engine, mix_mode) = {
-                    let lp = live_cb.lock().unwrap();
-                    (lp.master, lp.reverb_wet, lp.engine, lp.mix_mode)
-                };
-                audio_render(
-                    out,
-                    channels,
-                    &voices_cb,
-                    master,
-                    wet,
-                    &mut mono,
-                    &mut mono_compressed,
-                    &mut reverb,
-                    &mut sympathetic,
-                    &mut limiter_gain,
-                    engine,
-                    mix_mode,
-                );
-            },
-            move |err| {
-                web_sys::console::error_1(
-                    &format!("keysynth-web: stream error: {err}").into(),
-                );
-            },
-            None,
-        )
-        .map_err(|e| format!("build_output_stream: {e}"))?;
-
-    stream.play().map_err(|e| format!("stream.play: {e}"))?;
-    Ok((AudioHandle { _stream: stream }, sr))
-}
-
-#[allow(clippy::too_many_arguments)]
-fn audio_render(
-    out: &mut [f32],
-    channels: u16,
-    voices: &Arc<Mutex<Vec<Voice>>>,
-    master: f32,
-    reverb_wet: f32,
-    mono: &mut Vec<f32>,
-    mono_compressed: &mut Vec<f32>,
-    reverb: &mut Reverb,
-    sympathetic: &mut SympatheticBank,
-    limiter_gain: &mut f32,
-    engine: Engine,
-    mix_mode: MixMode,
-) {
-    let frames = out.len() / channels as usize;
-    if mono.len() != frames {
-        mono.resize(frames, 0.0);
-    } else {
-        mono.fill(0.0);
+    fn pick_canvas(id: &str) -> web_sys::HtmlCanvasElement {
+        let document = web_sys::window()
+            .expect("no window")
+            .document()
+            .expect("no document");
+        document
+            .get_element_by_id(id)
+            .unwrap_or_else(|| panic!("missing <canvas id=\"{id}\">"))
+            .dyn_into::<web_sys::HtmlCanvasElement>()
+            .expect("element is not a canvas")
     }
-
-    {
-        let mut pool = voices.lock().unwrap();
-        for v in pool.iter_mut() {
-            v.inner.render_add(mono.as_mut_slice());
-        }
-        pool.retain(|v| !v.inner.is_done());
-    }
-
-    if engine.is_piano_family() {
-        const COUPLING: f32 = 0.0002;
-        const MIX: f32 = 0.3;
-        for sample in mono.iter_mut() {
-            let drive = *sample;
-            let sym_out = sympathetic.process(drive, COUPLING);
-            *sample += sym_out * MIX;
-        }
-    } else {
-        for _ in 0..mono.len() {
-            let _ = sympathetic.process(0.0, 0.0);
-        }
-    }
-
-    for s in mono.iter_mut() {
-        if !s.is_finite() {
-            *s = 0.0;
-        }
-    }
-
-    reverb.process(mono.as_mut_slice(), reverb_wet);
-
-    match mix_mode {
-        MixMode::Plain => {
-            for sample in mono.iter_mut() {
-                *sample = (*sample * master).tanh();
-            }
-        }
-        MixMode::Limiter => {
-            const ATTACK: f32 = 0.5;
-            const RELEASE: f32 = 0.0001;
-            for sample in mono.iter_mut() {
-                let abs_s = sample.abs();
-                if abs_s > *limiter_gain {
-                    *limiter_gain += (abs_s - *limiter_gain) * ATTACK;
-                } else {
-                    *limiter_gain += (abs_s - *limiter_gain) * RELEASE;
-                }
-                let gr = if *limiter_gain > 1.0 {
-                    1.0 / *limiter_gain
-                } else {
-                    1.0
-                };
-                *sample = (*sample * gr * master).tanh();
-            }
-        }
-        MixMode::ParallelComp => {
-            const ALPHA: f32 = 0.7;
-            const BETA: f32 = 0.6;
-            const ATTACK: f32 = 0.5;
-            const RELEASE: f32 = 0.0001;
-            if mono_compressed.len() != mono.len() {
-                mono_compressed.resize(mono.len(), 0.0);
-            }
-            for (i, sample) in mono.iter().enumerate() {
-                let abs_s = sample.abs();
-                if abs_s > *limiter_gain {
-                    *limiter_gain += (abs_s - *limiter_gain) * ATTACK;
-                } else {
-                    *limiter_gain += (abs_s - *limiter_gain) * RELEASE;
-                }
-                let gr = if *limiter_gain > 1.0 {
-                    1.0 / *limiter_gain
-                } else {
-                    1.0
-                };
-                mono_compressed[i] = sample * gr;
-            }
-            for (i, sample) in mono.iter_mut().enumerate() {
-                let combined = (*sample * ALPHA + mono_compressed[i] * BETA) * master;
-                *sample = combined.tanh();
-            }
-        }
-    }
-
-    for (frame_idx, frame) in out.chunks_mut(channels as usize).enumerate() {
-        let s = mono[frame_idx];
-        for slot in frame.iter_mut() {
-            *slot = s;
-        }
-    }
-}
-
-// ===========================================================================
-// wasm-bindgen entry. Trunk's `<link data-trunk rel="rust" />` snippet
-// invokes `main()` automatically; we just install the panic hook and hand
-// control to eframe's WebRunner.
-// ===========================================================================
-
-fn main() {
-    console_error_panic_hook::set_once();
-
-    let runner = eframe::WebRunner::new();
-    wasm_bindgen_futures::spawn_local(async move {
-        let canvas = pick_canvas("keysynth-canvas");
-        let result = runner
-            .start(
-                canvas,
-                eframe::WebOptions::default(),
-                Box::new(|_cc| Ok(Box::new(WebApp::default()))),
-            )
-            .await;
-        if let Err(e) = result {
-            web_sys::console::error_1(&format!("eframe start failed: {e:?}").into());
-        }
-    });
-}
-
-fn pick_canvas(id: &str) -> web_sys::HtmlCanvasElement {
-    let document = web_sys::window()
-        .expect("no window")
-        .document()
-        .expect("no document");
-    document
-        .get_element_by_id(id)
-        .unwrap_or_else(|| panic!("missing <canvas id=\"{id}\">"))
-        .dyn_into::<web_sys::HtmlCanvasElement>()
-        .expect("element is not a canvas")
-}
+} // mod imp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,18 +4,29 @@
 //! `synth` holds the engines, voices, ADSR, hammer/pluck excitations, and
 //! MIDI math. `ui` is the egui dashboard, kept here so both bins (or
 //! future tools) can re-skin or embed it.
+//!
+//! Native-only modules (offline analysis, SFZ sampler, IR-WAV reverb
+//! loader, midir-driven dashboard) are gated behind the `native` Cargo
+//! feature so the wasm32 build for the GitHub Pages demo doesn't try to
+//! pull in midir / hound / rustfft / image / rustysynth.
 
-pub mod analysis;
-pub mod extract;
 pub mod gm;
 pub mod reverb;
-pub mod score;
-pub mod sfz;
 pub mod soundboard;
 pub mod sympathetic;
 pub mod synth;
-pub mod ui;
 pub mod voices;
+
+#[cfg(feature = "native")]
+pub mod analysis;
+#[cfg(feature = "native")]
+pub mod extract;
+#[cfg(feature = "native")]
+pub mod score;
+#[cfg(feature = "native")]
+pub mod sfz;
+#[cfg(feature = "native")]
+pub mod ui;
 
 // Re-export the dashboard-facing types at the crate root so older callers
 // that imported them via `crate::{LiveParams, DashState, Engine}` keep

--- a/src/reverb.rs
+++ b/src/reverb.rs
@@ -16,6 +16,7 @@
 //! ~150 ms (~6600 samples @ 44.1 kHz) so the per-callback cost stays
 //! bounded and we don't need an FFT path.
 
+#[cfg(feature = "native")]
 use std::path::Path;
 
 /// Hard cap on IR length in samples. ~150 ms at 44.1 kHz; the tail of a
@@ -152,6 +153,7 @@ pub fn synthetic_body_ir(sr: u32) -> Vec<f32> {
 /// Load an impulse response from a WAV file. Accepts mono or stereo,
 /// 16/24/32-bit Int or 32-bit Float. Stereo is downmixed to mono (L+R)/2.
 /// Result is normalised to peak ~1.0 and truncated to `MAX_IR_SAMPLES`.
+#[cfg(feature = "native")]
 pub fn load_ir_wav(path: &Path) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
     let mut reader =
         hound::WavReader::open(path).map_err(|e| format!("opening IR WAV {:?}: {e}", path))?;

--- a/src/voices/piano_modal.rs
+++ b/src/voices/piano_modal.rs
@@ -385,8 +385,7 @@ impl ModalPianoVoice {
                     // -3 dB per partial in the upper range.
                     let dn = (i + 1 - last_n) as f32;
                     let amp = last_amp * 0.85_f32.powf(dn);
-                    let t60 = (last_t60 * 0.85_f32.powf(dn))
-                        .max(t60_floor_for_partial(i + 1));
+                    let t60 = (last_t60 * 0.85_f32.powf(dn)).max(t60_floor_for_partial(i + 1));
                     modes.push(Mode {
                         freq_hz: f_extra,
                         t60_sec: t60,
@@ -443,9 +442,8 @@ fn build_hammer_excitation(sr: f32, midi_note: u8) -> Vec<f32> {
     let mut buf = vec![0.0_f32; total + 1];
     buf[0] = 1.0;
 
-    let mut state: u32 = 0x9E37_79B9
-        ^ (midi_note as u32).wrapping_mul(2_654_435_761)
-        ^ (sr.to_bits() ^ 0xDEAD_BEEF);
+    let mut state: u32 =
+        0x9E37_79B9 ^ (midi_note as u32).wrapping_mul(2_654_435_761) ^ (sr.to_bits() ^ 0xDEAD_BEEF);
     let mut hp_prev_x = 0.0_f32;
     let mut hp_prev_y = 0.0_f32;
     let mut lp_prev = 0.0_f32;
@@ -491,8 +489,7 @@ fn build_hammer_excitation(sr: f32, midi_note: u8) -> Vec<f32> {
             if stage_b_pos < stage_b_attack_n {
                 (stage_b_pos as f32) / (stage_b_attack_n as f32) * STAGE_B_GAIN
             } else {
-                let t = (stage_b_pos - stage_b_attack_n) as f32
-                    / (n_b - stage_b_attack_n) as f32;
+                let t = (stage_b_pos - stage_b_attack_n) as f32 / (n_b - stage_b_attack_n) as f32;
                 0.5 * (1.0 + (std::f32::consts::PI * t).cos()) * STAGE_B_GAIN
             }
         };

--- a/src/voices/piano_modal.rs
+++ b/src/voices/piano_modal.rs
@@ -627,7 +627,14 @@ impl ModalLut {
     /// modal pipeline (`Mode::init_amp` is always linear).
     pub fn from_json_path(path: &Path) -> Result<Self, ModalLutError> {
         let raw = std::fs::read(path)?;
-        let json: ModalLutJson = serde_json::from_slice(&raw)?;
+        Self::from_json_bytes(&raw)
+    }
+
+    /// Same as `from_json_path` but parses already-loaded bytes. Used by
+    /// the wasm32 build to consume `include_bytes!`-embedded LUTs without
+    /// touching the filesystem (which is empty on wasm32-unknown-unknown).
+    pub fn from_json_bytes(raw: &[u8]) -> Result<Self, ModalLutError> {
+        let json: ModalLutJson = serde_json::from_slice(raw)?;
         if json.schema_version != 1 {
             return Err(ModalLutError::SchemaVersion(json.schema_version));
         }
@@ -708,20 +715,44 @@ impl ModalLut {
     /// caller can log which path was actually used (real JSON vs C4
     /// fallback).
     pub fn auto_load(explicit: Option<&Path>) -> (Self, String) {
-        let default_path = Path::new("bench-out/REF/sfz_salamander_multi/modal_lut.json");
-        let candidate = explicit.unwrap_or(default_path);
-        match Self::from_json_path(candidate) {
-            Ok(lut) => {
-                let n = lut.entries.len();
-                (lut, format!("{} ({n} entries)", candidate.display()))
-            }
-            Err(e) => (
-                Self::fallback_c4(),
-                format!(
-                    "hardcoded C4 fallback (loading {} failed: {e})",
-                    candidate.display()
+        // Wasm32 has no filesystem on GitHub Pages — `std::fs::read` always
+        // returns NotFound. Skip the disk probe entirely and parse the LUT
+        // bytes baked in at compile time. Path argument is accepted for
+        // API parity with the native build but is ignored on wasm32.
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = explicit;
+            const EMBEDDED: &[u8] =
+                include_bytes!("../../bench-out/REF/sfz_salamander_multi/modal_lut.json");
+            return match Self::from_json_bytes(EMBEDDED) {
+                Ok(lut) => {
+                    let n = lut.entries.len();
+                    (lut, format!("embedded modal_lut.json ({n} entries)"))
+                }
+                Err(e) => (
+                    Self::fallback_c4(),
+                    format!("hardcoded C4 fallback (embedded LUT parse failed: {e})"),
                 ),
-            ),
+            };
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let default_path = Path::new("bench-out/REF/sfz_salamander_multi/modal_lut.json");
+            let candidate = explicit.unwrap_or(default_path);
+            match Self::from_json_path(candidate) {
+                Ok(lut) => {
+                    let n = lut.entries.len();
+                    (lut, format!("{} ({n} entries)", candidate.display()))
+                }
+                Err(e) => (
+                    Self::fallback_c4(),
+                    format!(
+                        "hardcoded C4 fallback (loading {} failed: {e})",
+                        candidate.display()
+                    ),
+                ),
+            }
         }
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta name="description" content="keysynth — pure-Rust real-time modelling synth, running in the browser via WebAssembly + Web Audio." />
+    <title>keysynth (web)</title>
+
+    <!-- Trunk picks up this <link> and emits the wasm/JS glue beside it.
+         data-cargo-no-default-features + data-cargo-features="web" select
+         the trimmed wasm build that drops midir / SF2 / SFZ / offline bins. -->
+    <link
+      data-trunk
+      rel="rust"
+      data-bin="keysynth-web"
+      data-cargo-no-default-features
+      data-cargo-features="web"
+    />
+
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #1a1a1f;
+        color: #ddd;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+      }
+      #keysynth-canvas {
+        width: 100%;
+        height: 100%;
+        outline: none;
+        touch-action: none;
+      }
+      #loading {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 18px;
+        color: #888;
+      }
+      noscript {
+        padding: 1em;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <noscript>
+      keysynth needs JavaScript + WebAssembly. Please enable both.
+    </noscript>
+    <div id="loading">loading keysynth …</div>
+    <canvas id="keysynth-canvas"></canvas>
+
+    <script type="module">
+      // Hide the "loading" splash once the wasm module is fetched + the
+      // egui canvas has had a frame to paint. Trunk's snippet resolves
+      // when wasm-bindgen `init()` returns, which is before the first
+      // egui frame, so wait one rAF tick more.
+      const loading = document.getElementById("loading");
+      const observer = new MutationObserver(() => {
+        const canvas = document.getElementById("keysynth-canvas");
+        if (canvas && canvas.width > 0 && loading) {
+          requestAnimationFrame(() => {
+            loading.style.display = "none";
+          });
+          observer.disconnect();
+        }
+      });
+      observer.observe(document.getElementById("keysynth-canvas"), {
+        attributes: true,
+        attributeFilter: ["width", "height"],
+      });
+    </script>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,7 @@
     <link
       data-trunk
       rel="rust"
+      href="../Cargo.toml"
       data-bin="keysynth-web"
       data-cargo-no-default-features
       data-cargo-features="web"


### PR DESCRIPTION
## Summary
- Trims the modelling engines into a `wasm32-unknown-unknown` build hosted on GitHub Pages — pure DSP only (square / ks / piano / piano-modal / etc.), no SF2 / SFZ / live MIDI in this build.
- Adds `Cargo.toml` `native` (default) / `web` feature split. All offline bins (`bench`, `analyse`, `cpubench`, `extract_dump`, `render_*`, `score`, `build_modal_lut`) marked `required-features = ["native"]` so the wasm build only sees `keysynth-web`.
- Embeds the 10 KB `bench-out/REF/sfz_salamander_multi/modal_lut.json` via `include_bytes!` for `Engine::PianoModal` on web (no filesystem on wasm32-unknown-unknown).
- New `src/bin/web.rs`: eframe `WebRunner` + cpal Web Audio backend + 25-key on-screen keyboard with mouse + PC keyboard input (`zsxdcvgbhnjm` lower octave, `qwerty…` upper). Click-gated audio start to satisfy browser autoplay policy. Audio callback mirrors the native one minus SF2/SFZ paths.
- `web/index.html` + `Trunk.toml` + `.github/workflows/deploy-pages.yml` for end-to-end CI deploy. Workflow builds with stable Rust + wasm32 target, runs trunk + wasm-bindgen, uploads as a Pages artifact, deploys via `actions/deploy-pages@v4`. Uses `${GITHUB_REPOSITORY##*/}` so `--public-url` is portable.

End-to-end verification: `trunk build --release` ran locally and produced 2.7 MB wasm + 70 KB JS glue under `dist/`. `--public-url /keysynth/` correctly rewrites asset URLs for the Pages subpath.

## Test plan
- [x] `cargo check --bins --tests` (native) clean
- [x] `cargo check --bin keysynth-web --no-default-features --features web --target wasm32-unknown-unknown` clean
- [x] `cargo build --release --bin keysynth-web --no-default-features --features web --target wasm32-unknown-unknown` produces 4.3 MB wasm
- [x] `trunk build --release` end-to-end produces dist/ with index.html + JS glue + wasm
- [x] `trunk build --release --public-url /keysynth/` rewrites asset URLs to subpath
- [ ] CI workflow (`Deploy keysynth web demo to GitHub Pages`) green on this PR's merge to main
- [ ] Live demo at https://yuujikamura.github.io/keysynth/ loads, "Start audio" produces sound on key press

https://claude.ai/code/session_01R5qSm2Lx3bfbXxsgbtcBZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qSm2Lx3bfbXxsgbtcBZd)_