### PR TITLE
fix(tests): update piano_modal asserts for new mode expansion (closes #9)

### DIFF
--- a/src/voices/piano_modal.rs
+++ b/src/voices/piano_modal.rs
@@ -910,7 +910,12 @@ mod tests {
         assert!(!v.is_releasing());
         v.trigger_release();
         assert!(v.is_releasing());
-        let _ = render(&mut v, (SR * 0.7) as usize);
+        // ReleaseEnvelope is constructed with release_sec = 0.8 s
+        // (line ~213) and the default done_threshold = 1e-4. The
+        // multiplicative decay reaches 1e-3 at exactly release_sec, so
+        // is_done() (rel_mul ≤ 1e-4) lands at t = 0.8 · ln(1e-4)/ln(1e-3)
+        // = 0.8 · 4/3 ≈ 1.067 s. Render slightly past that with margin.
+        let _ = render(&mut v, (SR * 1.2) as usize);
         assert!(v.is_done());
     }
 
@@ -963,10 +968,18 @@ mod tests {
             ],
         );
         let v = ModalPianoVoice::from_lut(&lut, SR, 60, 100);
-        // 2 modes × 3 detune sub-modes = 6 resonators, frequency-ordered
-        // around their centres. Recover each centre frequency from the
-        // resonator's `cos_omega` and compare against the LUT.
-        assert_eq!(v.resonators.len(), 6);
+        // `from_lut` runs through `from_lut_with_excitation`, which
+        // since 469ba90 also extrapolates higher partials when the
+        // last measured partial sits below ~3 kHz (bass-fill toward
+        // TARGET_MAX_PARTIALS = 32, halting once the projected freq
+        // exceeds 8 kHz). For these two LUT modes (261.6 / 523.1 Hz),
+        // f1 = 261.6 drives the extrapolation and adds 28 partials →
+        // 30 modes total, then `with_modes` triples each into ±0.7-cent
+        // detune sub-modes → 30 × 3 = 90 resonators. The first 6
+        // (resonators[0..6]) are the 3-sub-mode expansions of the
+        // original f1 and f2 modes, so the bracket asserts below
+        // remain valid.
+        assert_eq!(v.resonators.len(), 90);
         let recovered: Vec<f32> = v
             .resonators
             .iter()
@@ -1016,7 +1029,12 @@ mod tests {
             ],
         );
         let v = ModalPianoVoice::from_lut(&lut, SR, 72, 100);
-        assert_eq!(v.resonators.len(), 6);
+        // Same expansion as `from_lut_exact_match_uses_lut_directly`:
+        // 2 input modes → +13 extrapolated → 15 → ×3 detune = 45
+        // resonators. The note-72 query just rescales every freq by
+        // ratio ≈ 2.0 before the resonator bank is built; the count
+        // is identical.
+        assert_eq!(v.resonators.len(), 45);
         // Recover sub-mode centres and check they scale by 2.0 (with
         // ratio = 440·2^((72-69)/12) / 261.63 = 523.25 / 261.63 ≈ 2.0).
         let recovered: Vec<f32> = v
@@ -1053,7 +1071,13 @@ mod tests {
             }],
         );
         let v = ModalPianoVoice::from_lut(&lut, SR, 60, 100);
-        assert_eq!(v.resonators.len(), 3);
+        // 1 LUT mode at 261.6 Hz — bass-fill extrapolation adds 26
+        // more partials (n=2..27, capped when projected freq passes
+        // 8 kHz) → 27 modes → ×3 detune = 81 resonators. The
+        // sentinel-T60 substitution downstream still applies to every
+        // resonator (incl. extrapolated ones) so the a2 > 0.999 check
+        // below remains the right invariant.
+        assert_eq!(v.resonators.len(), 81);
         // Pole radius for 12 s T60 at 44100 Hz: r ≈ 0.99987.
         // r² should be > 0.999.
         for r in &v.resonators {


### PR DESCRIPTION
Closes #9.

CI on main has been red since two pre-existing commits drifted runtime behaviour without updating tests:
- `92864a8` (modal: T60 floor + ...) bumped `ReleaseEnvelope::new(0.300, sr)` → `(0.800, sr)`
- `469ba90` (modal: supervised noise tail + bass partial extrapolation) added bass-fill extrapolation to `from_lut_with_excitation` (1 LUT mode → up to ~30 modes via `f_extra = n·f1·√(1+b·n²)` halted at 8 kHz)

## Summary
- 4 piano_modal tests rewritten to assert the post-469ba90 / post-92864a8 behaviour
- Each updated assert carries an inline comment explaining the expansion arithmetic so the next person changing the bass-fill or release envelope knows where to look
- No production code changes — only `src/voices/piano_modal.rs::tests`

## Diff math (verified locally)

| Test | Was | Is | Reason |
|---|---:|---:|---|
| `from_lut_exact_match_uses_lut_directly` | `6` | `90` | 2 LUT modes → 30 modes after extrapolation (f1=261.6, halts at n≈30) → ×3 detune |
| `from_lut_nearest_octave_scales_correctly` | `6` | `45` | 2 LUT modes scaled ×2 (note 60→72) → higher f1 halts earlier → 15 modes → ×3 |
| `from_lut_handles_t60_sentinel` | `3` | `81` | 1 LUT mode → 27 modes after extrapolation → ×3 |
| `release_lifecycle` (render duration) | `0.7 s` | `1.2 s` | `is_done()` lands at t = 0.8·ln(1e-4)/ln(1e-3) ≈ 1.067 s |

The bracket asserts that follow each count assert (`recovered[0..3]` for f1's 3-sub-mode triplet, `recovered[3..6]` for f2's) still apply: extrapolated modes are appended to the back of the list, so the first 6 resonators remain the original-mode expansions.

## Test plan
- [x] `cargo test --release --lib voices::piano_modal::tests` → 9 passed, 0 failed
- [x] `cargo test --release --lib` (full suite) → 180 passed, 0 failed
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets` no errors
- [ ] CI green on this PR
- [ ] Merge → main CI green for the first time since 92864a8

https://claude.ai/code/session_01R5qSm2Lx3bfbXxsgbtcBZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qSm2Lx3bfbXxsgbtcBZd)_