### PR TITLE
feat(web): Web MIDI input — connect a real keyboard to the demo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,15 @@ web-sys = { version = "0.3", optional = true, features = [
     "HtmlCanvasElement",
     "Navigator",
     "MidiAccess",
+    "MidiConnectionEvent",
     "MidiInput",
     "MidiInputMap",
     "MidiMessageEvent",
     "MidiOptions",
     "MidiPort",
+    "MidiPortConnectionState",
+    "MidiPortDeviceState",
+    "MidiPortType",
 ] }
 
 [profile.release]

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -31,12 +31,15 @@ fn main() {
 #[cfg(target_arch = "wasm32")]
 mod imp {
 
+    use std::cell::RefCell;
+    use std::rc::Rc;
     use std::sync::{Arc, Mutex};
 
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
     use cpal::StreamConfig;
     use eframe::egui;
-    use wasm_bindgen::JsCast;
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::{JsCast, JsValue};
 
     use keysynth::reverb::{self, Reverb};
     use keysynth::sympathetic::SympatheticBank;
@@ -103,6 +106,39 @@ mod imp {
         _stream: cpal::Stream,
     }
 
+    // ---------------------------------------------------------------------
+    // Web MIDI bridge
+    // ---------------------------------------------------------------------
+    //
+    // Browser fires MIDI events on the JS event loop; we translate each
+    // raw 3-byte status message into a `MidiMsg` and push it onto a shared
+    // inbox `Rc<RefCell<Vec<MidiMsg>>>`. The egui update loop drains the
+    // inbox once per frame and turns the messages into `note_on` /
+    // `note_off` calls against the existing voice pool. Single-threaded
+    // wasm32 → no Send/Sync requirement on the inbox, hence Rc/RefCell
+    // instead of Arc/Mutex.
+
+    #[derive(Clone, Copy, Debug)]
+    enum MidiMsg {
+        NoteOn { note: u8, velocity: u8 },
+        NoteOff { note: u8 },
+    }
+
+    type MidiInbox = Rc<RefCell<Vec<MidiMsg>>>;
+
+    /// Closures handed to the browser via `set_onmidimessage` /
+    /// `set_onstatechange`. We have to keep them alive for the life of
+    /// the page (the browser only holds a JsValue reference, which
+    /// doesn't keep the underlying Rust closure pinned), so park them
+    /// here as `Closure::into_js_value` can't be called while we still
+    /// want to drop them on `WebApp` teardown. Forgetting this is the
+    /// classic "MIDI works for one second then stops" wasm bug.
+    struct MidiHandles {
+        _access: web_sys::MidiAccess,
+        _on_message_closures: Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>>,
+        _on_state_change: Closure<dyn FnMut(web_sys::MidiConnectionEvent)>,
+    }
+
     struct WebApp {
         voices: Arc<Mutex<Vec<Voice>>>,
         live: Arc<Mutex<LiveParams>>,
@@ -132,8 +168,18 @@ mod imp {
         /// Base MIDI note for the leftmost on-screen key. Defaults to C3 (48).
         base_note: u8,
         /// Status string for Web MIDI (e.g. "not requested" / "connected: ..."
-        /// / error).
-        midi_status: String,
+        /// / error). `Rc<RefCell<String>>` because the async MIDI handshake
+        /// (which lives outside any `&mut self` borrow) needs to write into
+        /// it and the egui update loop needs to read it.
+        midi_status: Rc<RefCell<String>>,
+        /// Inbox shared with browser MIDI callbacks. Producer = JS event
+        /// handlers (`onmidimessage`), consumer = `WebApp::update` once
+        /// per frame.
+        midi_inbox: MidiInbox,
+        /// True once `request_midi()` has fired its async handshake. Stops
+        /// us re-requesting on every UI button click while the browser is
+        /// still resolving the first promise.
+        midi_requested: bool,
     }
 
     impl Default for WebApp {
@@ -178,7 +224,9 @@ mod imp {
                 mouse_down_note: None,
                 pc_held: 0,
                 base_note: 48, // C3
-                midi_status: "not requested".to_string(),
+                midi_status: Rc::new(RefCell::new("not requested".to_string())),
+                midi_inbox: Rc::new(RefCell::new(Vec::new())),
+                midi_requested: false,
             }
         }
     }
@@ -205,6 +253,61 @@ mod imp {
                     self.audio_err = Some(e);
                 }
             }
+        }
+
+        /// Drain the MIDI inbox. Called once per egui frame so MIDI
+        /// events line up with the rest of the per-frame edge handling
+        /// (PC keyboard, on-screen mouse). Each drained message turns
+        /// into a `note_on` / `note_off` against the shared voice pool.
+        fn drain_midi_inbox(&mut self) {
+            // Take ownership of the queued messages in one swap so the
+            // inbox borrow doesn't overlap with self.note_on / note_off
+            // (which lock self.voices and self.live).
+            let drained: Vec<MidiMsg> = {
+                let mut q = self.midi_inbox.borrow_mut();
+                std::mem::take(&mut *q)
+            };
+            for msg in drained {
+                match msg {
+                    MidiMsg::NoteOn { note, velocity } => self.note_on(note, velocity),
+                    MidiMsg::NoteOff { note } => self.note_off(note),
+                }
+            }
+        }
+
+        /// Kick off the Web MIDI handshake. `navigator.requestMIDIAccess()`
+        /// returns a Promise we await via `wasm_bindgen_futures::spawn_local`;
+        /// once it resolves we attach `onmidimessage` handlers to every
+        /// input port and an `onstatechange` handler so devices plugged in
+        /// AFTER the request still get wired up.
+        ///
+        /// The captured `inbox` and `status` are `Rc` clones — they're the
+        /// only state the async block needs from `self`, and they live as
+        /// long as the page does. The resulting `MidiHandles` is leaked
+        /// (`Box::leak`) so the browser-side closures stay valid forever;
+        /// `WebApp` is itself page-lifetime so this isn't a real leak in
+        /// practice and it spares us a channel dance to ship the handles
+        /// back through a `&mut self` boundary.
+        fn request_midi(&mut self) {
+            if self.midi_requested {
+                return;
+            }
+            self.midi_requested = true;
+            *self.midi_status.borrow_mut() = "requesting...".to_string();
+            let inbox = self.midi_inbox.clone();
+            let status = self.midi_status.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                match request_midi_access(inbox).await {
+                    Ok(handles) => {
+                        let n = handles._on_message_closures.len();
+                        *status.borrow_mut() = format!("{n} input(s) connected");
+                        Box::leak(Box::new(handles));
+                    }
+                    Err(e) => {
+                        *status.borrow_mut() = format!("error: {e}");
+                    }
+                }
+            });
         }
 
         fn note_on(&mut self, note: u8, velocity: u8) {
@@ -425,6 +528,7 @@ mod imp {
 
             if self.audio.is_some() {
                 self.handle_pc_keyboard(ctx);
+                self.drain_midi_inbox();
             }
 
             // Diagnostic: every ~30 frames (~0.5 s @ 60 fps) log the
@@ -460,7 +564,14 @@ mod imp {
                         self.start_audio();
                     }
                     ui.separator();
-                    ui.label(format!("MIDI: {}", self.midi_status));
+                    ui.label(format!("MIDI: {}", self.midi_status.borrow()));
+                    if !self.midi_requested && ui.button("Connect MIDI").clicked() {
+                        // Browser autoplay-style gating: requestMIDIAccess
+                        // also wants a user gesture to surface the
+                        // permission prompt, so bind it to a button click
+                        // rather than auto-firing on page load.
+                        self.request_midi();
+                    }
                 });
             });
 
@@ -763,6 +874,132 @@ mod imp {
                 web_sys::console::error_1(&format!("eframe start failed: {e:?}").into());
             }
         });
+    }
+
+    // ---------------------------------------------------------------------
+    // Web MIDI handshake
+    // ---------------------------------------------------------------------
+
+    /// Request MIDI access from the browser, attach an `onmidimessage`
+    /// handler to every input port, and set up `onstatechange` on the
+    /// `MidiAccess` so devices plugged in later also start producing
+    /// events. Returns a `MidiHandles` blob the caller must keep alive
+    /// for the lifetime of the page (the browser only stores function
+    /// references; if Rust drops the underlying `Closure`s the
+    /// references go dangling and MIDI silently stops).
+    async fn request_midi_access(inbox: MidiInbox) -> Result<MidiHandles, String> {
+        let window = web_sys::window().ok_or_else(|| "no window".to_string())?;
+        let nav: web_sys::Navigator = window.navigator();
+        // `requestMIDIAccess` is technically optional on the Navigator
+        // interface (Firefox without the flag returns undefined). Reach
+        // it via `Reflect::get` so we get a proper error message instead
+        // of a static-link compile dependency on the typed binding.
+        let request_fn = js_sys::Reflect::get(&nav, &JsValue::from_str("requestMIDIAccess"))
+            .map_err(|_| "navigator.requestMIDIAccess unavailable".to_string())?;
+        if request_fn.is_undefined() || request_fn.is_null() {
+            return Err("Web MIDI not supported in this browser".to_string());
+        }
+        let request_fn: js_sys::Function = request_fn
+            .dyn_into()
+            .map_err(|_| "requestMIDIAccess not callable".to_string())?;
+        let promise: js_sys::Promise = request_fn
+            .call0(&nav)
+            .map_err(|e| format!("requestMIDIAccess threw: {e:?}"))?
+            .dyn_into()
+            .map_err(|_| "requestMIDIAccess didn't return a Promise".to_string())?;
+        let access_jsv = wasm_bindgen_futures::JsFuture::from(promise)
+            .await
+            .map_err(|e| format!("MIDI access denied: {e:?}"))?;
+        let access: web_sys::MidiAccess = access_jsv
+            .dyn_into()
+            .map_err(|_| "MIDI access result wasn't a MIDIAccess".to_string())?;
+
+        // Walk every current input and attach a message handler.
+        let inputs = access.inputs();
+        let mut on_message_closures: Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>> =
+            Vec::new();
+        let entries: js_sys::Iterator = inputs.entries();
+        loop {
+            let next = entries
+                .next()
+                .map_err(|e| format!("MIDIInputMap.entries iter failed: {e:?}"))?;
+            if next.done() {
+                break;
+            }
+            let pair: js_sys::Array = next.value().into();
+            // [key, value] — value is the MIDIInput.
+            let port_jsv = pair.get(1);
+            let port: web_sys::MidiInput = match port_jsv.dyn_into() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            attach_midi_handler(&port, inbox.clone(), &mut on_message_closures);
+        }
+
+        // Hot-plug: handle devices that connect after the access grant.
+        let inbox_state = inbox.clone();
+        let on_state_change = Closure::<dyn FnMut(web_sys::MidiConnectionEvent)>::new(
+            move |ev: web_sys::MidiConnectionEvent| {
+                let Some(port) = ev.port() else { return };
+                if port.type_() != web_sys::MidiPortType::Input {
+                    return;
+                }
+                if port.state() != web_sys::MidiPortDeviceState::Connected {
+                    return;
+                }
+                let Ok(input) = port.dyn_into::<web_sys::MidiInput>() else {
+                    return;
+                };
+                // Hot-plugged input → leak its handler too. Cheap; same
+                // page-lifetime story as the initial handles.
+                let mut sink: Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>> = Vec::new();
+                attach_midi_handler(&input, inbox_state.clone(), &mut sink);
+                for c in sink {
+                    Box::leak(Box::new(c));
+                }
+            },
+        );
+        access.set_onstatechange(Some(on_state_change.as_ref().unchecked_ref()));
+
+        Ok(MidiHandles {
+            _access: access,
+            _on_message_closures: on_message_closures,
+            _on_state_change: on_state_change,
+        })
+    }
+
+    /// Wire one MIDI input port: set its `onmidimessage` to a closure
+    /// that parses the 3-byte status message and pushes a `MidiMsg` onto
+    /// the inbox. Pushes the created `Closure` onto `closures` so the
+    /// caller keeps it alive — letting it drop here would dangle the
+    /// browser's stored function reference.
+    fn attach_midi_handler(
+        port: &web_sys::MidiInput,
+        inbox: MidiInbox,
+        closures: &mut Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>>,
+    ) {
+        let on_message = Closure::<dyn FnMut(web_sys::MidiMessageEvent)>::new(
+            move |ev: web_sys::MidiMessageEvent| {
+                let Ok(data) = ev.data() else { return };
+                if data.len() < 2 {
+                    return;
+                }
+                let status = data[0];
+                let kind = status & 0xF0;
+                let note = data[1];
+                // Velocity is data[2] for note_on/off; absent on some
+                // status types but we only branch on 0x80 / 0x90 below.
+                let velocity = if data.len() >= 3 { data[2] } else { 0 };
+                let msg = match kind {
+                    0x90 if velocity > 0 => MidiMsg::NoteOn { note, velocity },
+                    0x80 | 0x90 => MidiMsg::NoteOff { note },
+                    _ => return,
+                };
+                inbox.borrow_mut().push(msg);
+            },
+        );
+        port.set_onmidimessage(Some(on_message.as_ref().unchecked_ref()));
+        closures.push(on_message);
     }
 
     fn pick_canvas(id: &str) -> web_sys::HtmlCanvasElement {

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -126,16 +126,23 @@ mod imp {
 
     type MidiInbox = Rc<RefCell<Vec<MidiMsg>>>;
 
-    /// Closures handed to the browser via `set_onmidimessage` /
-    /// `set_onstatechange`. We have to keep them alive for the life of
-    /// the page (the browser only holds a JsValue reference, which
-    /// doesn't keep the underlying Rust closure pinned), so park them
-    /// here as `Closure::into_js_value` can't be called while we still
-    /// want to drop them on `WebApp` teardown. Forgetting this is the
-    /// classic "MIDI works for one second then stops" wasm bug.
+    /// Shared registry of every per-port `onmidimessage` closure. Initial
+    /// inputs (resolved from `requestMIDIAccess`) and hot-plugged inputs
+    /// (added by the `onstatechange` callback) both push into the same
+    /// `Vec` so we don't have to leak per-event closures on hot-plug.
+    /// Lives behind `Rc<RefCell<…>>` because the onstatechange closure
+    /// owns a clone separate from the one stored on `WebApp::midi_handles`.
+    type MessageClosures = Rc<RefCell<Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>>>>;
+
+    /// Closures + access object handed to the browser. The browser only
+    /// stores function references; if we drop the underlying Rust
+    /// closures the references go dangling and MIDI silently stops.
+    /// Park everything here so `WebApp::midi_handles` keeps it alive
+    /// for the page lifetime — and so a future "Disconnect MIDI"
+    /// operation has a single place to drop from.
     struct MidiHandles {
         _access: web_sys::MidiAccess,
-        _on_message_closures: Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>>,
+        _closures: MessageClosures,
         _on_state_change: Closure<dyn FnMut(web_sys::MidiConnectionEvent)>,
     }
 
@@ -183,6 +190,13 @@ mod imp {
         /// reference. Set true synchronously in `request_midi()`, cleared
         /// in the async error branch, kept true on success.
         midi_requested: Rc<std::cell::Cell<bool>>,
+        /// Slot the async handshake populates with the resolved
+        /// `MidiHandles`. Stored in `Rc<RefCell<Option<…>>>` rather than
+        /// leaked via `Box::leak` so the resources have one named home,
+        /// hot-plugged closures get pushed into the existing handles
+        /// instead of leaking on every device reconnect, and a future
+        /// "Disconnect MIDI" path has somewhere to drop from.
+        midi_handles: Rc<RefCell<Option<MidiHandles>>>,
     }
 
     impl Default for WebApp {
@@ -230,6 +244,7 @@ mod imp {
                 midi_status: Rc::new(RefCell::new("not requested".to_string())),
                 midi_inbox: Rc::new(RefCell::new(Vec::new())),
                 midi_requested: Rc::new(std::cell::Cell::new(false)),
+                midi_handles: Rc::new(RefCell::new(None)),
             }
         }
     }
@@ -300,12 +315,17 @@ mod imp {
             let inbox = self.midi_inbox.clone();
             let status = self.midi_status.clone();
             let requested_flag = self.midi_requested.clone();
+            let handles_slot = self.midi_handles.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 match request_midi_access(inbox).await {
                     Ok(handles) => {
-                        let n = handles._on_message_closures.len();
+                        let n = handles._closures.borrow().len();
                         *status.borrow_mut() = format!("{n} input(s) connected");
-                        Box::leak(Box::new(handles));
+                        // Store on `WebApp` so the closures live as long
+                        // as the page does and have a named owner. No
+                        // `Box::leak` — drop happens with `WebApp` on
+                        // page teardown.
+                        *handles_slot.borrow_mut() = Some(handles);
                         // Leave `requested_flag` true on success so the
                         // Connect button stays out of the way.
                     }
@@ -931,30 +951,37 @@ mod imp {
             .dyn_into()
             .map_err(|_| "MIDI access result wasn't a MIDIAccess".to_string())?;
 
-        // Walk every current input and attach a message handler.
+        // Shared registry every onmidimessage closure pushes into —
+        // both the initial walk below and the hot-plug `onstatechange`
+        // closure further down. Keeping one named owner avoids the
+        // per-reconnect leak the original `Box::leak` path produced.
+        let closures: MessageClosures = Rc::new(RefCell::new(Vec::new()));
+
+        // Walk every current input and attach a message handler. Use
+        // `inputs.values()` rather than `entries()` so we get
+        // `MidiInput` directly without destructuring `[key, value]`.
         let inputs = access.inputs();
-        let mut on_message_closures: Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>> =
-            Vec::new();
-        let entries: js_sys::Iterator = inputs.entries();
+        let values: js_sys::Iterator = inputs.values();
         loop {
-            let next = entries
+            let next = values
                 .next()
-                .map_err(|e| format!("MIDIInputMap.entries iter failed: {e:?}"))?;
+                .map_err(|e| format!("MIDIInputMap.values iter failed: {e:?}"))?;
             if next.done() {
                 break;
             }
-            let pair: js_sys::Array = next.value().into();
-            // [key, value] — value is the MIDIInput.
-            let port_jsv = pair.get(1);
-            let port: web_sys::MidiInput = match port_jsv.dyn_into() {
+            let port: web_sys::MidiInput = match next.value().dyn_into() {
                 Ok(p) => p,
                 Err(_) => continue,
             };
-            attach_midi_handler(&port, inbox.clone(), &mut on_message_closures);
+            attach_midi_handler(&port, inbox.clone(), &closures);
         }
 
         // Hot-plug: handle devices that connect after the access grant.
+        // Capture clones of the inbox and the shared closure registry so
+        // a new `Connected` event can attach a handler and store its
+        // closure inside the same `MidiHandles` we hand back below.
         let inbox_state = inbox.clone();
+        let closures_state = closures.clone();
         let on_state_change = Closure::<dyn FnMut(web_sys::MidiConnectionEvent)>::new(
             move |ev: web_sys::MidiConnectionEvent| {
                 let Some(port) = ev.port() else { return };
@@ -967,33 +994,27 @@ mod imp {
                 let Ok(input) = port.dyn_into::<web_sys::MidiInput>() else {
                     return;
                 };
-                // Hot-plugged input → leak its handler too. Cheap; same
-                // page-lifetime story as the initial handles.
-                let mut sink: Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>> = Vec::new();
-                attach_midi_handler(&input, inbox_state.clone(), &mut sink);
-                for c in sink {
-                    Box::leak(Box::new(c));
-                }
+                attach_midi_handler(&input, inbox_state.clone(), &closures_state);
             },
         );
         access.set_onstatechange(Some(on_state_change.as_ref().unchecked_ref()));
 
         Ok(MidiHandles {
             _access: access,
-            _on_message_closures: on_message_closures,
+            _closures: closures,
             _on_state_change: on_state_change,
         })
     }
 
     /// Wire one MIDI input port: set its `onmidimessage` to a closure
     /// that parses the 3-byte status message and pushes a `MidiMsg` onto
-    /// the inbox. Pushes the created `Closure` onto `closures` so the
-    /// caller keeps it alive — letting it drop here would dangle the
-    /// browser's stored function reference.
+    /// the inbox. Pushes the created `Closure` into the shared
+    /// `MessageClosures` registry so the caller keeps it alive — letting
+    /// it drop here would dangle the browser's stored function reference.
     fn attach_midi_handler(
         port: &web_sys::MidiInput,
         inbox: MidiInbox,
-        closures: &mut Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>>,
+        closures: &MessageClosures,
     ) {
         let on_message = Closure::<dyn FnMut(web_sys::MidiMessageEvent)>::new(
             move |ev: web_sys::MidiMessageEvent| {
@@ -1016,7 +1037,7 @@ mod imp {
             },
         );
         port.set_onmidimessage(Some(on_message.as_ref().unchecked_ref()));
-        closures.push(on_message);
+        closures.borrow_mut().push(on_message);
     }
 
     fn pick_canvas(id: &str) -> web_sys::HtmlCanvasElement {

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -176,10 +176,13 @@ mod imp {
         /// handlers (`onmidimessage`), consumer = `WebApp::update` once
         /// per frame.
         midi_inbox: MidiInbox,
-        /// True once `request_midi()` has fired its async handshake. Stops
-        /// us re-requesting on every UI button click while the browser is
-        /// still resolving the first promise.
-        midi_requested: bool,
+        /// Tracks whether a MIDI handshake is currently in-flight or has
+        /// succeeded. Held in `Rc<Cell<bool>>` so the async resolution
+        /// path can clear it on error (letting the user re-click "Connect
+        /// MIDI" without reloading the page) without needing a `&mut self`
+        /// reference. Set true synchronously in `request_midi()`, cleared
+        /// in the async error branch, kept true on success.
+        midi_requested: Rc<std::cell::Cell<bool>>,
     }
 
     impl Default for WebApp {
@@ -226,7 +229,7 @@ mod imp {
                 base_note: 48, // C3
                 midi_status: Rc::new(RefCell::new("not requested".to_string())),
                 midi_inbox: Rc::new(RefCell::new(Vec::new())),
-                midi_requested: false,
+                midi_requested: Rc::new(std::cell::Cell::new(false)),
             }
         }
     }
@@ -289,22 +292,29 @@ mod imp {
         /// practice and it spares us a channel dance to ship the handles
         /// back through a `&mut self` boundary.
         fn request_midi(&mut self) {
-            if self.midi_requested {
+            if self.midi_requested.get() {
                 return;
             }
-            self.midi_requested = true;
+            self.midi_requested.set(true);
             *self.midi_status.borrow_mut() = "requesting...".to_string();
             let inbox = self.midi_inbox.clone();
             let status = self.midi_status.clone();
+            let requested_flag = self.midi_requested.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 match request_midi_access(inbox).await {
                     Ok(handles) => {
                         let n = handles._on_message_closures.len();
                         *status.borrow_mut() = format!("{n} input(s) connected");
                         Box::leak(Box::new(handles));
+                        // Leave `requested_flag` true on success so the
+                        // Connect button stays out of the way.
                     }
                     Err(e) => {
                         *status.borrow_mut() = format!("error: {e}");
+                        // Reset on failure so the user can press Connect
+                        // again — permission-denial is recoverable on a
+                        // second click that re-prompts the browser.
+                        requested_flag.set(false);
                     }
                 }
             });
@@ -528,8 +538,15 @@ mod imp {
 
             if self.audio.is_some() {
                 self.handle_pc_keyboard(ctx);
-                self.drain_midi_inbox();
             }
+            // Drain the MIDI inbox every frame regardless of audio state.
+            // If audio isn't started yet `note_on` early-returns, so the
+            // queued events get consumed silently — the alternative
+            // (gating drain on audio_started) lets the queue grow
+            // unbounded between page load and the first click on
+            // "Start audio", and on resumption the user hears a stale
+            // burst of every key they pressed during setup.
+            self.drain_midi_inbox();
 
             // Diagnostic: every ~30 frames (~0.5 s @ 60 fps) log the
             // most recent audio-callback bus peak. Lets us verify on
@@ -565,7 +582,7 @@ mod imp {
                     }
                     ui.separator();
                     ui.label(format!("MIDI: {}", self.midi_status.borrow()));
-                    if !self.midi_requested && ui.button("Connect MIDI").clicked() {
+                    if !self.midi_requested.get() && ui.button("Connect MIDI").clicked() {
                         // Browser autoplay-style gating: requestMIDIAccess
                         // also wants a user gesture to surface the
                         // permission prompt, so bind it to a button click


### PR DESCRIPTION
User asked for MIDI keyboard input on the web demo. The native build uses `midir` which doesn't compile to wasm32 — that's why #8 gated it behind the `native` Cargo feature. This PR fills the gap with a Web MIDI API bridge.

## Summary
- Click "Connect MIDI" → browser permission prompt → every connected input port pipes `note_on` / `note_off` into the existing voice pool the same way the on-screen keyboard does.
- Hot-plug supported via `MIDIAccess.onstatechange` — a keyboard plugged in AFTER the initial grant gets its handler attached on the fly.
- Status label flips through `not requested` → `requesting...` → `N input(s) connected` / `error: ...`.

## Bridge design (single-threaded wasm32)
- `MidiInbox = Rc<RefCell<Vec<MidiMsg>>>` shared between browser callbacks (producer) and the egui update loop (consumer). Drained once per frame so MIDI events line up with the existing per-frame edge handling for PC keyboard / mouse.
- `MidiMsg` only carries `note_on` / `note_off` for now (status `0x80` / `0x90`, including the running-status note_on-with-velocity-0 form). CC / pitch bend dropped at the parse boundary; lift into a wider enum when there's a UI control to bind them to.
- `MidiHandles` keeps the access handle + every `Closure` we hand the browser alive. Forgetting to keep these is the canonical "MIDI works for one second then stops" wasm-bindgen bug — the browser only stores function references, not the underlying Rust closure. `Box::leak` on async resolution since `WebApp` is page-lifetime anyway.
- `navigator.requestMIDIAccess` is reached through `Reflect::get` instead of a typed `web-sys` binding so a Firefox without the flag enabled returns a clean `"Web MIDI not supported in this browser"` status instead of a link error.

## Browser support
- Chrome / Edge / Opera: works out of the box
- Safari 18+ (2024-): works
- Firefox: requires `dom.webmidi.enabled` flag; without it the status reports `Web MIDI not supported in this browser` and the Connect button stays harmless.

## Cargo.toml
Added `MidiConnectionEvent` / `MidiPortConnectionState` / `MidiPortDeviceState` / `MidiPortType` web-sys features for the hot-plug path.

## Test plan
- [x] `cargo check --bin keysynth-web --no-default-features --features web --target wasm32-unknown-unknown` clean
- [x] `cargo check --bins --tests` (native) clean — only existing warnings
- [x] `cargo fmt -- --check` clean
- [ ] CI green
- [ ] Live: plug in MIDI keyboard, click "Connect MIDI", press keys, hear the right pitches with velocity

https://claude.ai/code/session_01R5qSm2Lx3bfbXxsgbtcBZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qSm2Lx3bfbXxsgbtcBZd)_