### PR TITLE
chore: speed up CI + drop PianoModal debug instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,18 @@ on:
   push:
     branches: [main]
 
+# Cancel superseded runs on the same ref so a quick succession of
+# pushes to a branch doesn't queue stale CI work.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  check:
-    name: fmt + clippy + test + build
+  # `fmt` is its own job so it can fail in seconds without holding up
+  # the longer test/build path. Pure check, no toolchain other than
+  # rustfmt needed.
+  fmt:
+    name: cargo fmt --check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,7 +26,29 @@ jobs:
       - name: Install Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: rustfmt
+
+      - name: cargo fmt --check
+        run: cargo fmt -- --check
+
+  # Clippy + test + build run together because they share the same
+  # cargo build artifact cache; splitting them further would force
+  # repeated dependency rebuilds and would actually be slower under
+  # cold cache. Clippy runs informationally for now — main has 16
+  # pre-existing warnings (loop-index, div_ceil, clamp-pattern).
+  # Tightening to `-D warnings` is tracked in issue #2. Once main is
+  # clean, change to: `cargo clippy --all-targets -- -D warnings`.
+  check:
+    name: clippy + test + build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache cargo registry / target
         uses: Swatinem/rust-cache@v2
@@ -28,14 +59,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libasound2-dev
 
-      - name: cargo fmt --check
-        run: cargo fmt -- --check
-
-      # Clippy runs informationally for now — main has 16 pre-existing
-      # warnings in analysis.rs / reverb.rs / synth.rs (loop-index,
-      # div_ceil, clamp-pattern). Tightening to `-D warnings` is tracked
-      # alongside the cleanup pass in issue #2. Once main is clean,
-      # change to: `cargo clippy --all-targets -- -D warnings`.
       - name: cargo clippy
         run: cargo clippy --all-targets
 

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -152,13 +152,6 @@ mod imp {
         sample_rate: u32,
         audio: Option<AudioHandle>,
         audio_err: Option<String>,
-        /// Realtime bus peak (linear), written by the audio callback as
-        /// f32::to_bits and logged from the egui update loop at low
-        /// frequency. None until audio starts.
-        bus_peak: Option<Arc<std::sync::atomic::AtomicU32>>,
-        /// Frame counter so we can rate-limit peak logging from the egui
-        /// update loop (~once per ~30 frames ≈ 0.5 s at 60 fps).
-        peak_log_frame: u32,
         /// Notes currently held by mouse/touch. PC keyboard tracking is via
         /// the separate `pc_held` set below — egui's `key_pressed` returns
         /// true on every browser KeyDown including auto-repeat, so we
@@ -219,25 +212,17 @@ mod imp {
                     // while every other engine still saturated tanh.
                     master: 3.0,
                     engine: Engine::PianoModal,
-                    reverb_wet: 0.0,
+                    reverb_wet: 0.25,
                     sf_program: 0,
                     sf_bank: 0,
                     // Plain tanh matches native default and avoids the
                     // ParallelComp limiter swallowing PianoModal's already
                     // low-amplitude bus into silence on the first hit.
                     mix_mode: MixMode::Plain,
-                    // NOTE: reverb_wet is overridden below to 0.0 to debug
-                    // PianoModal silence on web. The 6600-tap direct
-                    // convolution may be busting the wasm32 audio
-                    // deadline; skip it for now and let the user re-enable
-                    // via the slider once we confirm whether reverb is
-                    // the culprit.
                 })),
                 sample_rate: 0,
                 audio: None,
                 audio_err: None,
-                bus_peak: None,
-                peak_log_frame: 0,
                 mouse_down_note: None,
                 pc_held: 0,
                 base_note: 48, // C3
@@ -255,10 +240,9 @@ mod imp {
                 return;
             }
             match build_audio(self.voices.clone(), self.live.clone()) {
-                Ok((handle, sr, peak)) => {
+                Ok((handle, sr)) => {
                     self.sample_rate = sr;
                     self.audio = Some(handle);
-                    self.bus_peak = Some(peak);
                     self.audio_err = None;
                     web_sys::console::log_1(
                         &format!("keysynth-web: audio started @ {sr} Hz").into(),
@@ -346,17 +330,6 @@ mod imp {
             }
             let engine = self.live.lock().unwrap().engine;
             let freq = midi_to_freq(note);
-            // Diagnostic: log on the UI thread (no audio-callback overhead)
-            // so we can verify a voice is actually being constructed for
-            // each key press. Only fires for the first 10 note_ons to
-            // avoid spamming.
-            web_sys::console::log_1(
-                &format!(
-                    "keysynth-web: note_on n={note} f={freq:.1} engine={engine:?} pool_before={}",
-                    self.voices.lock().unwrap().len()
-                )
-                .into(),
-            );
             let inner = make_voice(engine, self.sample_rate as f32, freq, velocity);
             let v = Voice {
                 key: (0, note),
@@ -568,24 +541,6 @@ mod imp {
             // burst of every key they pressed during setup.
             self.drain_midi_inbox();
 
-            // Diagnostic: every ~30 frames (~0.5 s @ 60 fps) log the
-            // most recent audio-callback bus peak. Lets us verify on
-            // the live page whether the audio thread is producing any
-            // signal at all when a key is held. Read is cheap: one
-            // atomic load + one f32::from_bits on the UI thread.
-            self.peak_log_frame = self.peak_log_frame.wrapping_add(1);
-            if self.peak_log_frame.is_multiple_of(30) {
-                if let Some(p) = &self.bus_peak {
-                    let bits = p.load(std::sync::atomic::Ordering::Relaxed);
-                    let peak = f32::from_bits(bits);
-                    if peak > 1e-5 {
-                        web_sys::console::log_1(
-                            &format!("keysynth-web: bus peak={peak:.5}").into(),
-                        );
-                    }
-                }
-            }
-
             egui::TopBottomPanel::top("top").show(ctx, |ui| {
                 ui.horizontal(|ui| {
                     ui.heading("keysynth (web)");
@@ -690,7 +645,7 @@ mod imp {
     fn build_audio(
         voices: Arc<Mutex<Vec<Voice>>>,
         live: Arc<Mutex<LiveParams>>,
-    ) -> Result<(AudioHandle, u32, Arc<std::sync::atomic::AtomicU32>), String> {
+    ) -> Result<(AudioHandle, u32), String> {
         let host = cpal::default_host();
         let device = host
             .default_output_device()
@@ -708,12 +663,6 @@ mod imp {
         let mut mono: Vec<f32> = Vec::new();
         let mut mono_compressed: Vec<f32> = Vec::new();
         let mut limiter_gain: f32 = 1.0;
-        // Diagnostic peak slot — written by the audio callback (one
-        // atomic store per callback, no allocation, no JS host call) and
-        // read + logged by the egui update loop. Stores f32 peak as raw
-        // u32 bits via f32::to_bits / from_bits.
-        let bus_peak_bits = Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let bus_peak_for_cb = bus_peak_bits.clone();
 
         let voices_cb = voices.clone();
         let live_cb = live.clone();
@@ -740,11 +689,6 @@ mod imp {
                         engine,
                         mix_mode,
                     );
-                    // Realtime-safe peak probe: just a max + one atomic
-                    // store. No format!, no JS host call. The egui
-                    // update loop reads and logs.
-                    let peak = out.iter().fold(0.0_f32, |a, &x| a.max(x.abs()));
-                    bus_peak_for_cb.store(peak.to_bits(), std::sync::atomic::Ordering::Relaxed);
                 },
                 move |err| {
                     web_sys::console::error_1(&format!("keysynth-web: stream error: {err}").into());
@@ -754,7 +698,7 @@ mod imp {
             .map_err(|e| format!("build_output_stream: {e}"))?;
 
         stream.play().map_err(|e| format!("stream.play: {e}"))?;
-        Ok((AudioHandle { _stream: stream }, sr, bus_peak_bits))
+        Ok((AudioHandle { _stream: stream }, sr))
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
User feedback: the per-PR CI cycle is too slow. Two cleanups bundled:

## 1. CI parallelism (`.github/workflows/ci.yml`)
Split the previous monolithic `fmt + clippy + test + build` job into:
- **`fmt`** — pure rustfmt check, fails in ~30 s when needed.
- **`check`** — clippy + test + build, all sharing the same cargo cache (splitting these further would force repeated dependency rebuilds and would actually be slower).

Plus a `concurrency: ci-${{ github.ref }}` group so a quick succession of pushes to a branch (review-fix loops) cancels superseded runs instead of queueing stale ones.

Practical effect: a fmt-only error surfaces in ~30 s instead of waiting through the full 1.5 min path.

## 2. Drop PianoModal debug instrumentation (`src/bin/web.rs`)
Root cause of the silence was the per-engine output amplitude mismatch in #14, confirmed live. The diagnostic added in #12 has done its job; remove:
- `bus_peak` AtomicU32 slot + audio-callback atomic store + egui-update peak log
- `peak_log_frame` rate-limit counter
- `note_on n=… engine=…` UI-thread log
- `build_audio` return tuple shrinks back to `(AudioHandle, u32)`

Also restored `reverb_wet: 0.25` default (the 0.0 in #12 was the debug knob to test whether reverb CPU was the issue — turned out denormal + output gain were the real causes, reverb is fine). The `if reverb_wet > 0.0` short-circuit in `audio_render` stays since it's a real CPU win when the user dials reverb to 0.

Surviving startup logs: `modal LUT source = …` and `audio started @ N Hz`.

## Test plan
- [x] `cargo check --bin keysynth-web --no-default-features --features web --target wasm32-unknown-unknown` clean
- [x] `cargo check --bins --tests` (native) clean
- [x] `cargo fmt -- --check` clean
- [ ] CI green (and notably, fmt and check now run in parallel)
- [ ] Auto-merge once green

https://claude.ai/code/session_01R5qSm2Lx3bfbXxsgbtcBZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qSm2Lx3bfbXxsgbtcBZd)_