### PR TITLE
feat(web): Kira-based audio backend + minimal UI (parallel dispatch)

### DIFF
--- a/.dispatch/kira-codex-brief.md
+++ b/.dispatch/kira-codex-brief.md
@@ -1,0 +1,203 @@
+# Brief B (Codex): KiraEngine + custom Sound impl in src/audio_kira.rs
+
+## Context
+
+The user is replacing the hand-rolled AudioWorkletProcessor + chunk-
+render path in `src/bin/web.rs` with Kira (`kira = "0.12"`). The
+work is split between two parallel agents:
+
+- **Gemini (other deck)** — main-thread glue layer in
+  `src/bin/web.rs` + `Cargo.toml`. Calls into the API you build.
+- **You (Codex)** — `src/audio_kira.rs` implementation.
+
+DO NOT TOUCH `src/bin/web.rs` or `Cargo.toml`. Gemini owns those.
+You own ONLY `src/audio_kira.rs`. If you need a Cargo dep added,
+note it in the PR description; do not edit `Cargo.toml`.
+
+## Working tree
+
+- Worktree: `C:\Users\yuuji\AppData\Local\Temp\keysynth-web`
+  (Unix: `/tmp/keysynth-web`)
+- Branch: `claude/web-kira-experiment` (already checked out, based
+  on `origin/main`)
+- `src/audio_kira.rs` exists as a skeleton. Replace the
+  placeholder body with your implementation. Top-of-file doc
+  comment lists the public API contract; that's the integration
+  point with Gemini.
+- `Cargo.toml` already has `kira = { version = "0.12",
+  default-features = false, features = ["cpal"], optional = true }`
+  gated under the `web` feature. You can use it freely.
+
+## Goal
+
+Implement `KiraEngine` in `src/audio_kira.rs`. Public API:
+
+```rust
+pub struct KiraEngine {
+    // private: AudioManager, voice handle map, current engine,
+    //          current modal preset, sample rate, …
+}
+
+impl KiraEngine {
+    /// Initialise Kira's AudioManager with default settings.
+    /// Fails loudly if Kira can't acquire an AudioContext (e.g.
+    /// because no user gesture preceded the call) — return a
+    /// `Result<Self, String>` with the error stringified for UI
+    /// display.
+    pub fn new() -> Result<Self, String>;
+
+    /// Trigger a note. Constructs a `keysynth::Voice` via
+    /// `make_voice(engine, sr, freq, velocity)` and plays it
+    /// through Kira. Stash the resulting handle in an internal
+    /// `HashMap<u8, SoundHandle>` keyed by MIDI note so
+    /// `note_off` can find it.
+    pub fn note_on(&mut self, engine: keysynth::synth::Engine,
+                   note: u8, velocity: u8);
+
+    /// Release a held note. Looks up the handle for `note`,
+    /// triggers Kira's stop with a short fade, drops from the
+    /// map.
+    pub fn note_off(&mut self, note: u8);
+
+    /// Update the active engine. Doesn't retroactively affect
+    /// already-playing voices; only the next `note_on` uses it.
+    pub fn set_engine(&mut self, engine: keysynth::synth::Engine);
+
+    /// Apply a `ModalPreset` — writes to the global MODAL_PARAMS
+    /// cell + MODAL_PHYSICS atomic that `make_voice(PianoModal,
+    /// …)` reads on construction. (Note: the main-thread wasm
+    /// has its OWN MODAL_PARAMS cell since wasm32 single-instance
+    /// — the existing `preset.apply()` from `keysynth::synth`
+    /// already writes to that cell. Calling it here just makes
+    /// the API ergonomic for the UI side.)
+    pub fn set_modal_preset(&mut self,
+                            preset: keysynth::synth::ModalPreset);
+
+    /// Sample rate the AudioManager negotiated with the platform.
+    /// Used for downstream frequency math (`midi_to_freq`).
+    pub fn sample_rate(&self) -> u32;
+}
+```
+
+Internally:
+
+1. **AudioManager** — `kira::AudioManager::<DefaultBackend>::new(
+   AudioManagerSettings::default())` on `KiraEngine::new()`.
+2. **VoiceSound** — implement `kira::sound::Sound` +
+   `kira::sound::SoundData`. Wraps a `Box<dyn keysynth::synth::
+   VoiceImpl + Send>` and renders into Kira's `Frame` buffer
+   each `process()` call. Mono → stereo (`frame.left =
+   frame.right = sample`).
+3. **Bus chain** — for now, run the live audio bus chain INLINE in
+   the VoiceSound's `process()` per voice (sympathetic + reverb +
+   MixMode). Wrong-ish for sympathetic (should be shared) but
+   simplest. Document the limitation in a doc comment; promote to
+   shared state in a follow-up.
+   - Or, if Kira's `Effect` trait is clean, add a sub-track with
+     a custom `BusEffect` implementation. Either is acceptable;
+     pick whichever lets you ship sound first.
+4. **Map** — `HashMap<u8, SoundHandle>` keyed on MIDI note.
+   `note_on` evicts the previous handle for that note (stop +
+   replace). `note_off` removes + stops.
+
+## Bus chain DSP (mirror of native `src/main.rs::audio_callback`)
+
+After voice render, in the same `process()` (or in the BusEffect):
+- Sympathetic-string bank drive on piano-family engines: `COUPLING
+  = 0.0002`, `MIX = 0.3`. Tick the bank silently for non-piano so
+  state doesn't go stale. Use `keysynth::sympathetic::
+  SympatheticBank::new_piano(sr)`.
+- NaN/Inf + denormal flush: `if !s.is_finite() { *s = 0.0; }
+  else if s.abs() < 1e-30 { *s = 0.0; }`.
+- Body IR reverb: `keysynth::reverb::Reverb::new(reverb::
+  synthetic_body_ir(sr_u))`. Apply `process(samples, wet)` with
+  default wet=0.3.
+- MixMode: default ParallelComp, master=1.0. Same constants as
+  `src/main.rs::audio_callback`:
+  - Plain: `(s * master).tanh()`
+  - ParallelComp: ALPHA=0.7, BETA=0.6, ATTACK=0.5, RELEASE=0.0001
+  - Limiter: ATTACK=0.5, RELEASE=0.0001
+
+## What "play it through Kira" means concretely
+
+Skim https://docs.rs/kira/0.12/kira/sound/index.html for the
+current trait shape. Implement `SoundData::into_sound(self) ->
+Box<dyn Sound>` on a `VoiceSoundData` builder; implement `Sound`
+on `VoiceSound`.
+
+Likely process signature (verify against actual 0.12 docs):
+```rust
+fn process(&mut self, out: &mut [Frame], info: &Info)
+```
+
+Pre-allocate the mono scratch buffer once at construction; do NOT
+allocate inside `process()`.
+
+## Verification
+
+1. `cargo check --no-default-features --features web --target
+   wasm32-unknown-unknown --bin keysynth-web` — clean. The bin's
+   build is what tests your module's compile.
+2. `cargo check --bin keysynth` (native) — clean. `audio_kira` is
+   gated to `#[cfg(feature = "web")]` so native shouldn't see it.
+3. `cargo fmt --check` — clean.
+4. Wait for Gemini to land their `src/bin/web.rs` rewrite (will
+   call into your API). Pull, rebuild, verify both compile
+   together.
+5. `trunk serve web/index.html --port 8090 --no-autoreload`. Wait
+   for ✅ success. Browser at http://localhost:8090/, ▶ Start,
+   click "Square" voice slot, press `Z`. Should produce a clean
+   square tone with no clicks under sustained playback.
+
+## Hard constraints
+
+- **No silent fallbacks.** If Kira's AudioManager fails to
+  initialise, return `Err(message)` from `KiraEngine::new()`. The
+  UI splash gate already shows errors via `audio_err`. Don't
+  retry, don't paper over, don't fake-succeed with silence. The
+  user has explicitly said this rule: silent failure < no sound.
+- **No allocations on `process()`.** Pre-allocate scratch buffers
+  in the `Sound` constructor.
+- **Native build doesn't break.** `audio_kira` module is gated to
+  `feature = "web"` (see `src/lib.rs`); preserve the gate.
+- **Use the same DSP code keysynth ships.** Don't reimplement
+  modal piano, sympathetic, reverb. Use `keysynth::voices`,
+  `keysynth::sympathetic::SympatheticBank`, `keysynth::reverb::
+  Reverb`. Same Rust source = same audio as native.
+
+## Out of scope
+
+- SF2 / `Engine::SfPiano` — separate problem (rustysynth doesn't
+  fit Kira's Sound shape cleanly without a multi-voice wrapper).
+  Stub `Engine::SfPiano` to log "not yet supported" and skip.
+- Master/reverb/mix UI sliders affecting Kira's track. Just
+  default values for first cut.
+- Modal preset propagation when slots clicked while a Modal voice
+  is held. The new voice picks up the new params; the old one
+  finishes its release at old params. Acceptable.
+
+## When stuck
+
+- Kira docs: https://docs.rs/kira/0.12
+- Kira github: https://github.com/tesselode/kira
+- bevy_kira_audio for AudioContext / web wiring patterns:
+  https://github.com/NiklasEi/bevy_kira_audio
+
+If Kira's CpalBackend on wasm32 has an unfixable issue (e.g.
+requires a feature flag we can't enable, or fails at runtime in a
+way I can't repro headlessly), STOP and report it in your commit
+message rather than hacking around it. The point of this
+experiment is to find out empirically whether Kira works on web —
+honest "no" is more useful than fake "yes".
+
+## Deliverable
+
+A commit on `claude/web-kira-experiment` that:
+- Implements the public API documented above.
+- Passes `cargo check` for both targets.
+- Passes `cargo fmt --check`.
+- Has a clear commit message describing what landed and what
+  defaults the bus chain ships with.
+
+Push when done. Gemini will pull and integrate. Joint PR opens
+once both halves land.

--- a/.dispatch/kira-gemini-brief.md
+++ b/.dispatch/kira-gemini-brief.md
@@ -1,0 +1,153 @@
+# Brief A (Gemini): main-thread glue for Kira-backed web audio
+
+## Context
+
+The user is abandoning the hand-rolled AudioWorkletProcessor + chunk-
+render path in `src/bin/web.rs`. New audio backend is Kira
+(`kira = "0.12"`, already added to `[dependencies]` and to the `web`
+feature in `Cargo.toml`).
+
+Architecture is split between two parallel agents:
+
+- **You (Gemini)** — main-thread glue layer in `src/bin/web.rs`.
+- **Codex (other deck)** — `src/audio_kira.rs` implementation.
+
+DO NOT TOUCH `src/audio_kira.rs`. Codex owns that file. Treat it as
+a black box that exposes the public API documented at the top of
+the file. If the API is missing something you need, comment in your
+PR description; do not edit Codex's file.
+
+## Working tree
+
+- Worktree: `C:\Users\yuuji\AppData\Local\Temp\keysynth-web`
+  (Unix: `/tmp/keysynth-web`)
+- Branch: `claude/web-kira-experiment` (already checked out, based
+  on `origin/main`)
+- Local serve: `trunk serve web/index.html --port 8090
+  --no-autoreload`. Use `localhost:8090` or `192.168.2.100:8090`
+  (deckpilot occupies 127.0.0.1:8080).
+
+## Goal
+
+In `src/bin/web.rs`:
+
+1. Delete the `WORKLET_PROCESSOR_JS` const and all the
+   AudioWorkletNode handshake / chunk-render plumbing in
+   `build_audio`.
+2. Replace it with a `KiraEngine` instance held by `WebApp`.
+   Initialise via `audio_kira::KiraEngine::new()` on the splash
+   gate's `▶ Start` click. Stash in `WebApp` (Rc<RefCell<Option<…>>>
+   or just `Option<…>` if you can avoid sharing).
+3. Rewrite `WebApp::note_on` / `note_off` to delegate to
+   `KiraEngine::note_on(engine, note, velocity)` /
+   `note_off(note)`. The current `voices: Arc<Mutex<Vec<Voice>>>`
+   pool on the main thread goes away — Kira owns the pool.
+4. Voice slot click: call `KiraEngine::set_engine(slot.engine)`. If
+   `slot.modal_preset.is_some()`, call
+   `KiraEngine::set_modal_preset(preset)` too.
+5. Master / reverb / mix UI changes don't need Kira sync for this
+   first cut — leave `KiraEngine` at its default values. Note in
+   the PR description what's deferred.
+
+## What to keep
+
+- The egui UI: voice browser side panel, MIDI log, on-screen
+  keyboard, master/reverb sliders, mix-mode row, GM 128 patch
+  picker. Only the audio backend swap; UI is fine.
+- `WebApp` struct minus the audio-thread plumbing (drop the cpal /
+  AudioContext / AudioWorkletNode fields, the `voices` pool, the
+  `synth` SharedSynth, the SF2 fetch path).
+- Splash gate. The `▶ Start` button is a user gesture required for
+  AudioContext creation; same here for Kira's manager.
+- PC keyboard handling (`pc_held`, `handle_pc_keyboard`,
+  panic_release).
+- Web MIDI handshake (`request_midi`, MIDI inbox).
+
+## What to throw away
+
+- `WORKLET_PROCESSOR_JS` constant.
+- `WORKLET_PROCESSOR_JS`-specific blob URL / addModule plumbing in
+  `build_audio`.
+- `AudioWorkletNode::new_with_options` call.
+- `port.onmessage` / postMessage chunk pump.
+- `RenderState`, `render_mono_chunk`, `mono_compressed`,
+  `limiter_gain` fields if they live in `web.rs` — Codex owns the
+  bus chain now.
+- The `synth: SharedSynth` (rustysynth) path. SF2 / `Engine::SfPiano`
+  is OUT OF SCOPE for this experiment; leave a stub that logs
+  "SfPiano not yet supported on Kira backend" and does nothing on
+  note_on. Future work.
+- The `recording: Rc<RefCell<Option<Vec<f32>>>>` capture button.
+  Kira renders inline; capturing requires a different approach.
+  Drop the button, drop the field, drop the encode/download
+  helpers. Note in PR description.
+- The async SF2 fetch (`fetch_and_load_sf2`). Drop it.
+
+## Cargo.toml
+
+- `web` feature already lists `dep:kira` (added in the scaffold
+  commit). Keep it.
+- DROP `dep:rustysynth` from the `web` feature (no SfPiano path
+  for now). Keep `dep:rustysynth` available under `native` only.
+- DROP `Response`, `HtmlAnchorElement` from web-sys features (the
+  fetch + download paths are gone). Verify nothing else needs them.
+- Keep `wasm-bindgen`, `wasm-bindgen-futures`, `web-sys` (Window,
+  Document, Navigator, MIDI features), `js-sys`,
+  `console_error_panic_hook`, `cpal/wasm-bindgen` (kira's cpal
+  needs it).
+
+## Verification
+
+After your edits, all of these must pass before opening the PR:
+
+1. `cargo check --bin keysynth` (native) — clean. The native
+   binary must keep compiling.
+2. `cargo check --no-default-features --features web --target
+   wasm32-unknown-unknown --bin keysynth-web` — clean.
+3. `cargo fmt --check` — clean.
+4. `cargo build --release --no-default-features --features web
+   --target wasm32-unknown-unknown --bin keysynth-web` — clean.
+   Note the wasm size.
+5. Trunk: `trunk serve web/index.html --port 8090
+   --no-autoreload`. Wait for ✅ success.
+6. Wait for Codex to finish `src/audio_kira.rs`. Once their commit
+   lands on the same branch, pull, recompile.
+7. Browser at http://localhost:8090/: ▶ Start, click "Square"
+   voice, press `Z`. Should produce a clean square tone.
+8. Test sustained: hold `Z` 5+ seconds while scrolling the egui
+   panel — should NOT cut out (this is the whole point of the
+   Kira swap).
+
+## Coordination with Codex
+
+- **Both branches push to `claude/web-kira-experiment`**. Pull
+  before pushing.
+- File-level no overlap: Gemini owns `src/bin/web.rs` +
+  `Cargo.toml`. Codex owns `src/audio_kira.rs`.
+- Public API contract (the doc-comment block at the top of
+  `src/audio_kira.rs`) is the integration boundary. If the actual
+  signatures differ from the doc, prefer the actual signatures —
+  Codex is the authoritative source for the audio_kira API.
+- Don't block on Codex finishing. You can stub-call the API and
+  rely on the placeholder `audio_kira` module compiling. Once
+  Codex lands their impl, your code links against the real thing.
+
+## When stuck
+
+- Kira docs: https://docs.rs/kira/0.12
+- If Kira's `AudioManager::new()` fails on wasm32 with a missing
+  AudioContext / cpal-wasm-bindgen error, that's a real finding —
+  report it explicitly in the PR description rather than hiding.
+
+## Deliverable
+
+Commits on `claude/web-kira-experiment` with:
+- `Cargo.toml` cleaned of dead deps (rustysynth in web, Response,
+  HtmlAnchorElement)
+- `src/bin/web.rs` migrated to `KiraEngine`
+- `cargo check / fmt` clean
+- A clear PR-ready commit message describing what moved where
+
+When both you and Codex are done, open one PR
+`feat(web): Kira-based audio backend (experiment)` to `main` with
+both halves of the work in the description. CI must be green.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "alsa-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +304,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "atomic-arena"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e8ed45f88ed32e6827a96b62d8fd4086d72defc754c5c6bd08470c1aaf648e"
 
 [[package]]
 name = "atomic-waker"
@@ -641,6 +659,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "coreaudio-sys"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,14 +708,14 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
 dependencies = [
- "alsa",
+ "alsa 0.9.1",
  "core-foundation-sys",
- "coreaudio-rs",
+ "coreaudio-rs 0.11.3",
  "dasp_sample",
  "jni 0.21.1",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.4.3",
  "ndk 0.8.0",
  "ndk-context",
  "oboe",
@@ -691,6 +723,36 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.54.0",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1f9c7312f19fc2fa12fd7acaf38de54e8320ba10d1a02dcbe21038def51ccb"
+dependencies = [
+ "alsa 0.10.0",
+ "coreaudio-rs 0.13.0",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2 0.5.0",
+ "ndk 0.9.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2 0.6.4",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1264,6 +1326,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+dependencies = [
+ "mint",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,7 +1684,7 @@ name = "keysynth"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "cpal",
+ "cpal 0.15.3",
  "ctrlc",
  "eframe",
  "egui",
@@ -1621,6 +1692,7 @@ dependencies = [
  "hound",
  "image",
  "js-sys",
+ "kira",
  "midir",
  "midly",
  "rfd",
@@ -1640,6 +1712,22 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kira"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22dc6835b2ca4b48601f11df172781f5e7677d40a6a466b1b873adcb34ec5d55"
+dependencies = [
+ "atomic-arena",
+ "cpal 0.17.1",
+ "glam",
+ "mint",
+ "pastey",
+ "rtrb",
+ "send_wrapper",
+ "triple_buffer",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1735,6 +1823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,7 +1870,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56542e359bb7e4bd1a77cb79042be32d4af0713a9ce58160355eaf72df9db87c"
 dependencies = [
- "alsa",
+ "alsa 0.9.1",
  "bitflags 1.3.2",
  "coremidi",
  "js-sys",
@@ -1808,6 +1905,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "moxcms"
@@ -2048,6 +2151,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2200,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,7 +2241,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -2157,6 +2310,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2368,6 +2523,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -2698,12 +2859,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
 dependencies = [
  "claxon",
- "cpal",
+ "cpal 0.15.3",
  "hound",
  "lewton",
  "symphonia",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "rtrb"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
 
 [[package]]
 name = "rustc-hash"
@@ -2798,6 +2965,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -3258,6 +3431,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "triple_buffer"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420466259f9fa5decc654c490b9ab538400e5420df8237f84ecbe20368bcf72b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,12 +3814,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-result",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -3647,10 +3850,34 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3658,6 +3885,17 @@ name = "windows-implement"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3676,10 +3914,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3688,6 +3947,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3805,6 +4082,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ web = [
     "dep:web-sys",
     "dep:console_error_panic_hook",
     "dep:js-sys",
-    "dep:rustysynth",
     "dep:kira",
     "cpal/wasm-bindgen",
 ]
@@ -98,7 +97,6 @@ web-sys = { version = "0.3", optional = true, features = [
     "MessageEvent",
     "MessagePort",
     "Url",
-    "Response",
     "MidiAccess",
     "MidiConnectionEvent",
     "MidiInput",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ web = [
     "dep:console_error_panic_hook",
     "dep:js-sys",
     "dep:rustysynth",
+    "dep:kira",
     "cpal/wasm-bindgen",
 ]
 
@@ -51,6 +52,11 @@ serde_json = "1"
 midir = { version = "0.10", optional = true }
 ctrlc = { version = "3.4", optional = true }
 rustysynth = { version = "1.3", optional = true }
+# Kira: high-level Rust audio engine. Used as the web build's audio
+# backend (replaces hand-rolled AudioWorkletProcessor + chunk-render).
+# Internally uses cpal which on wasm32 talks to AudioContext via the
+# `cpal/wasm-bindgen` feature flag enabled by the `web` cargo feature.
+kira = { version = "0.12", default-features = false, features = ["cpal"], optional = true }
 hound = { version = "3.5", optional = true }
 rustfft = { version = "6", optional = true }
 image = { version = "0.25", default-features = false, features = ["png"], optional = true }

--- a/src/audio_kira.rs
+++ b/src/audio_kira.rs
@@ -1,0 +1,31 @@
+//! Kira-backed audio engine for the web build.
+//!
+//! This module owns:
+//!   - the `kira::AudioManager<DefaultBackend>` (page-lifetime)
+//!   - a custom `Sound` impl wrapping a keysynth `Voice`
+//!   - an optional bus `Effect` (sympathetic + reverb + MixMode tanh)
+//!   - a `HashMap<u8, SoundHandle>` so `note_off(midi_note)` can find
+//!     the right active sound to release
+//!
+//! Public API expected by `src/bin/web.rs`:
+//!
+//! ```ignore
+//! pub struct KiraEngine { /* … */ }
+//!
+//! impl KiraEngine {
+//!     pub fn new() -> Result<Self, String>;
+//!     pub fn note_on(&mut self, engine: Engine, note: u8, velocity: u8);
+//!     pub fn note_off(&mut self, note: u8);
+//!     pub fn set_engine(&mut self, engine: Engine);
+//!     pub fn set_modal_preset(&mut self, preset: ModalPreset);
+//!     pub fn sample_rate(&self) -> u32;
+//! }
+//! ```
+//!
+//! The Codex dispatch fills in the body. This skeleton exists so the
+//! Gemini side (web.rs glue) can compile against the public type
+//! while Codex iterates on the implementation.
+
+#![cfg(feature = "web")]
+
+// IMPLEMENTATION GOES HERE — see .dispatch/kira-codex-brief.md

--- a/src/audio_kira.rs
+++ b/src/audio_kira.rs
@@ -74,7 +74,19 @@ pub struct KiraEngine {
     voices: HashMap<u8, VoiceSoundHandle>,
     current_engine: Engine,
     current_modal_preset: ModalPreset,
-    sample_rate: u32,
+    /// Live sample rate, written by the probe `Effect` whenever Kira
+    /// reports a rate (`init` and `on_change_sample_rate`). Read by
+    /// `note_on` so each voice is constructed at the rate that's
+    /// actually feeding the platform output. Atomic because the
+    /// audio thread writes and the JS main thread reads.
+    ///
+    /// Crucial for KS-family voices: `PianoVoice` builds its delay
+    /// line with length `sr / freq` and chooses dispersion all-pass
+    /// coefficients per `sr`. Constructing a voice at the wrong sr
+    /// (e.g. the 48 kHz default before Kira reports the actual
+    /// 44.1 kHz the platform negotiated) gives audibly the wrong
+    /// pitch + completely different timbre.
+    sample_rate: Arc<AtomicU32>,
 }
 
 impl KiraEngine {
@@ -83,18 +95,20 @@ impl KiraEngine {
         let mut manager = AudioManager::<DefaultBackend>::new(AudioManagerSettings::default())
             .map_err(|err| format!("AudioManager::new failed: {err:?}"))?;
 
-        let sample_rate_cell = Arc::new(AtomicU32::new(0));
+        let sample_rate = Arc::new(AtomicU32::new(0));
         let mut bus_builder = TrackBuilder::new();
-        bus_builder.add_effect(SampleRateProbeBuilder::new(sample_rate_cell.clone()));
+        bus_builder.add_effect(SampleRateProbeBuilder::new(sample_rate.clone()));
         bus_builder.add_effect(BusEffectBuilder);
         let bus_track = manager
             .add_sub_track(bus_builder)
             .map_err(|err| format!("bus sub-track failed: {err:?}"))?;
 
-        let sample_rate = sample_rate_cell.load(Ordering::SeqCst);
-        if sample_rate == 0 {
-            return Err("Kira initialised, but no sample rate was reported".to_string());
-        }
+        // Don't error out on `sample_rate == 0` here. Kira may not
+        // call `Effect::init` until the audio thread spins up, which
+        // can be after `add_sub_track` returns. `note_on` re-reads
+        // the atomic and gates voice construction on a non-zero
+        // value; that guarantees voices use the actual platform sr,
+        // not our guess.
 
         let preset = ModalPreset::Default;
         preset.apply();
@@ -122,12 +136,33 @@ impl KiraEngine {
             return;
         }
 
+        // Re-read sr on every note_on so we always use whatever rate
+        // Kira's most recent `Effect::init` / `on_change_sample_rate`
+        // reported. Drop the request if the audio thread hasn't
+        // delivered a non-zero rate yet — better silence than a
+        // voice constructed at the wrong delay-line length.
+        let sr = self.sample_rate.load(Ordering::Relaxed);
+        if sr == 0 {
+            eprintln!(
+                "KiraEngine note_on: sample rate not yet reported by audio thread; \
+                 dropping note {note}"
+            );
+            return;
+        }
+
         if let Some(mut old_handle) = self.voices.remove(&note) {
             old_handle.stop(default_stop_tween());
         }
 
-        let sound_data =
-            VoiceSoundData::new(engine, self.sample_rate, midi_to_freq(note), velocity);
+        // One-shot diagnostic on the first note: log the actual sr +
+        // the engine that's about to play. Lets the user verify the
+        // platform sr in the browser console rather than guessing
+        // why the timbre differs from native.
+        if self.voices.is_empty() {
+            eprintln!("KiraEngine: first note_on with engine={:?} sr={sr}", engine);
+        }
+
+        let sound_data = VoiceSoundData::new(engine, sr, midi_to_freq(note), velocity);
         match self.bus_track.play(sound_data) {
             Ok(handle) => {
                 self.voices.insert(note, handle);
@@ -156,7 +191,7 @@ impl KiraEngine {
     }
 
     pub fn sample_rate(&self) -> u32 {
-        self.sample_rate
+        self.sample_rate.load(Ordering::Relaxed)
     }
 }
 

--- a/src/audio_kira.rs
+++ b/src/audio_kira.rs
@@ -43,7 +43,7 @@ use kira::{
     effect::{Effect, EffectBuilder},
     info::Info,
     sound::{Sound, SoundData},
-    track::TrackBuilder,
+    track::{TrackBuilder, TrackHandle},
     AudioManager, AudioManagerSettings, Easing, Frame, Tween,
 };
 
@@ -61,7 +61,16 @@ const SYMPATHETIC_COUPLING: f32 = 0.0002;
 const SYMPATHETIC_MIX: f32 = 0.3;
 
 pub struct KiraEngine {
+    #[allow(dead_code)]
     manager: AudioManager<DefaultBackend>,
+    /// Sub-track that hosts the shared bus chain (sympathetic →
+    /// reverb → MixMode). Every voice plays into THIS track so the
+    /// chain runs once on the summed mix instead of being smeared
+    /// across N independent voice instances. Without this, 3 keys
+    /// pressed together = 3 reverb tails layered + 3 sympathetic
+    /// banks ringing in isolation + 3 ParallelComp+tanh saturations
+    /// summed — exactly the "ゴミ" the user reported.
+    bus_track: TrackHandle,
     voices: HashMap<u8, VoiceSoundHandle>,
     current_engine: Engine,
     current_modal_preset: ModalPreset,
@@ -75,12 +84,12 @@ impl KiraEngine {
             .map_err(|err| format!("AudioManager::new failed: {err:?}"))?;
 
         let sample_rate_cell = Arc::new(AtomicU32::new(0));
-        let mut probe_builder = TrackBuilder::new();
-        probe_builder.add_effect(SampleRateProbeBuilder::new(sample_rate_cell.clone()));
-        let probe_track = manager
-            .add_sub_track(probe_builder)
-            .map_err(|err| format!("sample-rate probe track failed: {err:?}"))?;
-        drop(probe_track);
+        let mut bus_builder = TrackBuilder::new();
+        bus_builder.add_effect(SampleRateProbeBuilder::new(sample_rate_cell.clone()));
+        bus_builder.add_effect(BusEffectBuilder);
+        let bus_track = manager
+            .add_sub_track(bus_builder)
+            .map_err(|err| format!("bus sub-track failed: {err:?}"))?;
 
         let sample_rate = sample_rate_cell.load(Ordering::SeqCst);
         if sample_rate == 0 {
@@ -92,6 +101,7 @@ impl KiraEngine {
 
         Ok(Self {
             manager,
+            bus_track,
             voices: HashMap::new(),
             current_engine: Engine::Square,
             current_modal_preset: preset,
@@ -118,7 +128,7 @@ impl KiraEngine {
 
         let sound_data =
             VoiceSoundData::new(engine, self.sample_rate, midi_to_freq(note), velocity);
-        match self.manager.play(sound_data) {
+        match self.bus_track.play(sound_data) {
             Ok(handle) => {
                 self.voices.insert(note, handle);
             }
@@ -207,21 +217,25 @@ impl VoiceSoundHandle {
     }
 }
 
-/// Per-voice Kira sound.
+/// Per-voice Kira sound. RAW voice render only — no sympathetic /
+/// reverb / MixMode. Those run once on the summed bus inside the
+/// shared `BusEffect` attached to `KiraEngine::bus_track`. Doing
+/// the bus chain per-voice (as the first-cut implementation did)
+/// gave 3 voices = 3 reverb tails + 3 sympathetic banks running
+/// in isolation + 3 saturation stages summed — the user heard
+/// that as completely broken audio.
 ///
-/// The bus DSP runs inline here instead of on a shared mixer effect. That
-/// keeps the implementation file-local and lets each voice gate the
-/// sympathetic bank from its own engine family. The tradeoff is that
-/// sympathetic resonance is per-voice instead of globally shared, so this is
-/// a first-cut approximation of the native callback.
+/// `engine` is kept for diagnostics / future per-voice tagging
+/// but does not influence the bus chain anymore (the bus has no
+/// way to know which engine each summed sample originated from;
+/// the sympathetic gate is permissive — it always runs but only
+/// drives audibly when piano-family voices feed in piano-shaped
+/// energy).
 struct VoiceSound {
+    #[allow(dead_code)]
     engine: Engine,
     voice: Box<dyn VoiceImpl + Send>,
     mono_scratch: Vec<f32>,
-    mono_compressed: Vec<f32>,
-    reverb: Reverb,
-    sympathetic: SympatheticBank,
-    limiter_gain: f32,
     control: Arc<Mutex<VoiceControl>>,
     stop_state: StopState,
 }
@@ -237,10 +251,6 @@ impl VoiceSound {
                 data.velocity,
             ),
             mono_scratch: vec![0.0; SCRATCH_CAPACITY_FRAMES],
-            mono_compressed: vec![0.0; SCRATCH_CAPACITY_FRAMES],
-            reverb: Reverb::new(reverb::synthetic_body_ir(data.sample_rate)),
-            sympathetic: SympatheticBank::new_piano(data.sample_rate as f32),
-            limiter_gain: 1.0,
             control,
             stop_state: StopState::Running,
         }
@@ -287,7 +297,7 @@ impl Sound for VoiceSound {
         }
 
         let frames = out.len();
-        if frames > self.mono_scratch.len() || frames > self.mono_compressed.len() {
+        if frames > self.mono_scratch.len() {
             eprintln!(
                 "KiraEngine voice buffer too large: requested {frames}, capacity {}",
                 self.mono_scratch.len()
@@ -300,17 +310,6 @@ impl Sound for VoiceSound {
         let mono = &mut self.mono_scratch[..frames];
         mono.fill(0.0);
         self.voice.render_add(mono);
-
-        apply_sympathetic(mono, &mut self.sympathetic, self.engine.is_piano_family());
-        sanitize_samples(mono);
-        self.reverb.process(mono, DEFAULT_REVERB_WET);
-        apply_mix_mode(
-            mono,
-            &mut self.mono_compressed[..frames],
-            &mut self.limiter_gain,
-            MixMode::ParallelComp,
-            DEFAULT_MASTER,
-        );
         apply_stop_fade(mono, dt, &mut self.stop_state);
 
         for (frame, sample) in out.iter_mut().zip(mono.iter().copied()) {
@@ -337,28 +336,6 @@ struct FadeOut {
     elapsed: f64,
     duration: f64,
     easing: Easing,
-}
-
-fn apply_sympathetic(samples: &mut [f32], bank: &mut SympatheticBank, use_bank: bool) {
-    if use_bank {
-        for sample in samples.iter_mut() {
-            let drive = *sample;
-            let sym_out = bank.process(drive, SYMPATHETIC_COUPLING);
-            *sample += sym_out * SYMPATHETIC_MIX;
-        }
-    } else {
-        for _ in 0..samples.len() {
-            let _ = bank.process(0.0, 0.0);
-        }
-    }
-}
-
-fn sanitize_samples(samples: &mut [f32]) {
-    for sample in samples.iter_mut() {
-        if !sample.is_finite() || sample.abs() < 1e-30 {
-            *sample = 0.0;
-        }
-    }
 }
 
 fn apply_mix_mode(
@@ -507,4 +484,135 @@ impl Effect for SampleRateProbeEffect {
     }
 
     fn process(&mut self, _input: &mut [Frame], _dt: f64, _info: &Info) {}
+}
+
+/// Builder for the shared bus chain effect. Lazily initialised by
+/// Kira with the actual sample rate.
+struct BusEffectBuilder;
+
+impl EffectBuilder for BusEffectBuilder {
+    type Handle = ();
+
+    fn build(self) -> (Box<dyn Effect>, Self::Handle) {
+        (Box::new(BusEffect::uninit()), ())
+    }
+}
+
+/// Shared bus chain — runs once on the summed mix of every voice
+/// playing into the bus track. Mirrors the native
+/// `src/main.rs::audio_callback` graph: incoming samples → drop
+/// stereo down to mono → sympathetic bank (always driven; we
+/// can't tell per-sample which voices are piano-family from a
+/// summed bus, so we run permissively at the same coupling/mix
+/// the native bus uses) → NaN/denormal flush → body IR reverb
+/// (single shared instance, single tail) → MixMode (default
+/// ParallelComp at master=1.0) → mirror back to stereo.
+struct BusEffect {
+    sample_rate: u32,
+    sympathetic: SympatheticBank,
+    reverb: Reverb,
+    limiter_gain: f32,
+    mono_scratch: Vec<f32>,
+    mono_compressed: Vec<f32>,
+}
+
+impl BusEffect {
+    fn uninit() -> Self {
+        Self {
+            sample_rate: 0,
+            sympathetic: SympatheticBank::new_piano(48_000.0),
+            reverb: Reverb::new(reverb::synthetic_body_ir(48_000)),
+            limiter_gain: 1.0,
+            mono_scratch: vec![0.0; SCRATCH_CAPACITY_FRAMES],
+            mono_compressed: vec![0.0; SCRATCH_CAPACITY_FRAMES],
+        }
+    }
+
+    fn rebuild(&mut self, sample_rate: u32) {
+        self.sample_rate = sample_rate;
+        self.sympathetic = SympatheticBank::new_piano(sample_rate as f32);
+        self.reverb = Reverb::new(reverb::synthetic_body_ir(sample_rate));
+        self.limiter_gain = 1.0;
+    }
+}
+
+impl Effect for BusEffect {
+    fn init(&mut self, sample_rate: u32, _internal_buffer_size: usize) {
+        self.rebuild(sample_rate);
+    }
+
+    fn on_change_sample_rate(&mut self, sample_rate: u32) {
+        self.rebuild(sample_rate);
+    }
+
+    fn process(&mut self, input: &mut [Frame], _dt: f64, _info: &Info) {
+        let frames = input.len();
+        if frames == 0 {
+            return;
+        }
+        if frames > self.mono_scratch.len() {
+            // Fail loudly instead of silently truncating. The user
+            // explicitly asked for hard failure over silent
+            // degradation; if Kira hands us a bigger buffer than
+            // SCRATCH_CAPACITY_FRAMES, that's a sizing assumption
+            // we got wrong and we want to know.
+            eprintln!(
+                "BusEffect: buffer too large (got {frames}, cap {}); zeroing",
+                self.mono_scratch.len()
+            );
+            for f in input.iter_mut() {
+                *f = Frame::ZERO;
+            }
+            return;
+        }
+
+        let mono = &mut self.mono_scratch[..frames];
+        let mono_compressed = &mut self.mono_compressed[..frames];
+
+        // Pull bus down to mono. VoiceSound mirrors mono → both
+        // channels via Frame::from_mono so left == right; either
+        // channel works. Average for safety in case future code
+        // routes a stereo synth here.
+        for (i, f) in input.iter().enumerate() {
+            mono[i] = 0.5 * (f.left + f.right);
+        }
+
+        // Sympathetic bank — drive permissively (can't tell which
+        // voices are piano-family from a summed bus). For non-
+        // piano-only sessions the bank stays near silent because
+        // square / FM / sub voices don't share modes with the
+        // piano-tuned strings. Native gates per-voice but the
+        // shared bus is the structural correct unit, so accept
+        // the slightly different gating semantics.
+        for sample in mono.iter_mut() {
+            let drive = *sample;
+            let sym_out = self.sympathetic.process(drive, SYMPATHETIC_COUPLING);
+            *sample += sym_out * SYMPATHETIC_MIX;
+        }
+
+        // NaN/Inf + denormal flush.
+        for sample in mono.iter_mut() {
+            if !sample.is_finite() || sample.abs() < 1e-30 {
+                *sample = 0.0;
+            }
+        }
+
+        // Body IR reverb — single shared tail.
+        self.reverb.process(mono, DEFAULT_REVERB_WET);
+
+        // MixMode (ParallelComp default, master=1.0). Same
+        // constants as `src/main.rs::audio_callback`.
+        apply_mix_mode(
+            mono,
+            mono_compressed,
+            &mut self.limiter_gain,
+            MixMode::ParallelComp,
+            DEFAULT_MASTER,
+        );
+
+        // Mirror back to stereo Frame.
+        for (f, &m) in input.iter_mut().zip(mono.iter()) {
+            *f = Frame::from_mono(m);
+        }
+    }
 }

--- a/src/audio_kira.rs
+++ b/src/audio_kira.rs
@@ -28,4 +28,483 @@
 
 #![cfg(feature = "web")]
 
-// IMPLEMENTATION GOES HERE — see .dispatch/kira-codex-brief.md
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+
+use kira::{
+    backend::DefaultBackend,
+    effect::{Effect, EffectBuilder},
+    info::Info,
+    sound::{Sound, SoundData},
+    track::TrackBuilder,
+    AudioManager, AudioManagerSettings, Easing, Frame, Tween,
+};
+
+use crate::{
+    reverb::{self, Reverb},
+    sympathetic::SympatheticBank,
+    synth::{make_voice, midi_to_freq, Engine, MixMode, ModalPreset, VoiceImpl},
+};
+
+const DEFAULT_MASTER: f32 = 1.0;
+const DEFAULT_REVERB_WET: f32 = 0.3;
+const NOTE_STOP_FADE: Duration = Duration::from_millis(25);
+const SCRATCH_CAPACITY_FRAMES: usize = 8192;
+const SYMPATHETIC_COUPLING: f32 = 0.0002;
+const SYMPATHETIC_MIX: f32 = 0.3;
+
+pub struct KiraEngine {
+    manager: AudioManager<DefaultBackend>,
+    voices: HashMap<u8, VoiceSoundHandle>,
+    current_engine: Engine,
+    current_modal_preset: ModalPreset,
+    sample_rate: u32,
+}
+
+impl KiraEngine {
+    /// Initialise Kira's AudioManager and capture the negotiated sample rate.
+    pub fn new() -> Result<Self, String> {
+        let mut manager = AudioManager::<DefaultBackend>::new(AudioManagerSettings::default())
+            .map_err(|err| format!("AudioManager::new failed: {err:?}"))?;
+
+        let sample_rate_cell = Arc::new(AtomicU32::new(0));
+        let mut probe_builder = TrackBuilder::new();
+        probe_builder.add_effect(SampleRateProbeBuilder::new(sample_rate_cell.clone()));
+        let probe_track = manager
+            .add_sub_track(probe_builder)
+            .map_err(|err| format!("sample-rate probe track failed: {err:?}"))?;
+        drop(probe_track);
+
+        let sample_rate = sample_rate_cell.load(Ordering::SeqCst);
+        if sample_rate == 0 {
+            return Err("Kira initialised, but no sample rate was reported".to_string());
+        }
+
+        let preset = ModalPreset::Default;
+        preset.apply();
+
+        Ok(Self {
+            manager,
+            voices: HashMap::new(),
+            current_engine: Engine::Square,
+            current_modal_preset: preset,
+            sample_rate,
+        })
+    }
+
+    pub fn note_on(&mut self, engine: Engine, note: u8, velocity: u8) {
+        let engine = if self.current_engine != engine {
+            self.current_engine = engine;
+            engine
+        } else {
+            self.current_engine
+        };
+
+        if is_unsupported_sample_engine(engine) {
+            eprintln!("KiraEngine note_on: {engine:?} is not yet supported");
+            return;
+        }
+
+        if let Some(mut old_handle) = self.voices.remove(&note) {
+            old_handle.stop(default_stop_tween());
+        }
+
+        let sound_data =
+            VoiceSoundData::new(engine, self.sample_rate, midi_to_freq(note), velocity);
+        match self.manager.play(sound_data) {
+            Ok(handle) => {
+                self.voices.insert(note, handle);
+            }
+            Err(err) => {
+                eprintln!("KiraEngine note_on failed for note {note}: {err:?}");
+            }
+        }
+    }
+
+    pub fn note_off(&mut self, note: u8) {
+        if let Some(mut handle) = self.voices.remove(&note) {
+            handle.stop(default_stop_tween());
+        }
+    }
+
+    pub fn set_engine(&mut self, engine: Engine) {
+        self.current_engine = engine;
+    }
+
+    pub fn set_modal_preset(&mut self, preset: ModalPreset) {
+        if self.current_modal_preset != preset {
+            self.current_modal_preset = preset;
+        }
+        preset.apply();
+    }
+
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+}
+
+fn default_stop_tween() -> Tween {
+    Tween {
+        duration: NOTE_STOP_FADE,
+        ..Tween::default()
+    }
+}
+
+fn is_unsupported_sample_engine(engine: Engine) -> bool {
+    matches!(engine, Engine::SfPiano | Engine::SfzPiano)
+}
+
+struct VoiceSoundData {
+    engine: Engine,
+    sample_rate: u32,
+    freq: f32,
+    velocity: u8,
+}
+
+impl VoiceSoundData {
+    fn new(engine: Engine, sample_rate: u32, freq: f32, velocity: u8) -> Self {
+        Self {
+            engine,
+            sample_rate,
+            freq,
+            velocity,
+        }
+    }
+}
+
+impl SoundData for VoiceSoundData {
+    type Error = Infallible;
+    type Handle = VoiceSoundHandle;
+
+    fn into_sound(self) -> Result<(Box<dyn Sound>, Self::Handle), Self::Error> {
+        let shared = Arc::new(Mutex::new(VoiceControl::default()));
+        let sound = VoiceSound::new(self, shared.clone());
+        Ok((Box::new(sound), VoiceSoundHandle { shared }))
+    }
+}
+
+#[derive(Default)]
+struct VoiceControl {
+    pending_stop: Option<Tween>,
+}
+
+struct VoiceSoundHandle {
+    shared: Arc<Mutex<VoiceControl>>,
+}
+
+impl VoiceSoundHandle {
+    fn stop(&mut self, tween: Tween) {
+        if let Ok(mut control) = self.shared.lock() {
+            control.pending_stop = Some(tween);
+        }
+    }
+}
+
+/// Per-voice Kira sound.
+///
+/// The bus DSP runs inline here instead of on a shared mixer effect. That
+/// keeps the implementation file-local and lets each voice gate the
+/// sympathetic bank from its own engine family. The tradeoff is that
+/// sympathetic resonance is per-voice instead of globally shared, so this is
+/// a first-cut approximation of the native callback.
+struct VoiceSound {
+    engine: Engine,
+    voice: Box<dyn VoiceImpl + Send>,
+    mono_scratch: Vec<f32>,
+    mono_compressed: Vec<f32>,
+    reverb: Reverb,
+    sympathetic: SympatheticBank,
+    limiter_gain: f32,
+    control: Arc<Mutex<VoiceControl>>,
+    stop_state: StopState,
+}
+
+impl VoiceSound {
+    fn new(data: VoiceSoundData, control: Arc<Mutex<VoiceControl>>) -> Self {
+        Self {
+            engine: data.engine,
+            voice: make_voice(
+                data.engine,
+                data.sample_rate as f32,
+                data.freq,
+                data.velocity,
+            ),
+            mono_scratch: vec![0.0; SCRATCH_CAPACITY_FRAMES],
+            mono_compressed: vec![0.0; SCRATCH_CAPACITY_FRAMES],
+            reverb: Reverb::new(reverb::synthetic_body_ir(data.sample_rate)),
+            sympathetic: SympatheticBank::new_piano(data.sample_rate as f32),
+            limiter_gain: 1.0,
+            control,
+            stop_state: StopState::Running,
+        }
+    }
+
+    fn begin_stop(&mut self, tween: Tween) {
+        if matches!(self.stop_state, StopState::Finished | StopState::Fading(_)) {
+            return;
+        }
+        self.voice.trigger_release();
+        let duration = tween.duration.as_secs_f64();
+        if duration <= 0.0 {
+            self.stop_state = StopState::Finished;
+        } else {
+            self.stop_state = StopState::Fading(FadeOut {
+                elapsed: 0.0,
+                duration,
+                easing: tween.easing,
+            });
+        }
+    }
+}
+
+impl Sound for VoiceSound {
+    fn on_start_processing(&mut self) {
+        let pending_stop = self
+            .control
+            .lock()
+            .ok()
+            .and_then(|mut control| control.pending_stop.take());
+        if let Some(tween) = pending_stop {
+            self.begin_stop(tween);
+        }
+    }
+
+    fn process(&mut self, out: &mut [Frame], dt: f64, _info: &Info) {
+        if out.is_empty() {
+            return;
+        }
+        if matches!(self.stop_state, StopState::Finished) || self.voice.is_done() {
+            out.fill(Frame::ZERO);
+            self.stop_state = StopState::Finished;
+            return;
+        }
+
+        let frames = out.len();
+        if frames > self.mono_scratch.len() || frames > self.mono_compressed.len() {
+            eprintln!(
+                "KiraEngine voice buffer too large: requested {frames}, capacity {}",
+                self.mono_scratch.len()
+            );
+            out.fill(Frame::ZERO);
+            self.stop_state = StopState::Finished;
+            return;
+        }
+
+        let mono = &mut self.mono_scratch[..frames];
+        mono.fill(0.0);
+        self.voice.render_add(mono);
+
+        apply_sympathetic(mono, &mut self.sympathetic, self.engine.is_piano_family());
+        sanitize_samples(mono);
+        self.reverb.process(mono, DEFAULT_REVERB_WET);
+        apply_mix_mode(
+            mono,
+            &mut self.mono_compressed[..frames],
+            &mut self.limiter_gain,
+            MixMode::ParallelComp,
+            DEFAULT_MASTER,
+        );
+        apply_stop_fade(mono, dt, &mut self.stop_state);
+
+        for (frame, sample) in out.iter_mut().zip(mono.iter().copied()) {
+            *frame = Frame::from_mono(sample);
+        }
+
+        if self.voice.is_done() {
+            self.stop_state = StopState::Finished;
+        }
+    }
+
+    fn finished(&self) -> bool {
+        matches!(self.stop_state, StopState::Finished) || self.voice.is_done()
+    }
+}
+
+enum StopState {
+    Running,
+    Fading(FadeOut),
+    Finished,
+}
+
+struct FadeOut {
+    elapsed: f64,
+    duration: f64,
+    easing: Easing,
+}
+
+fn apply_sympathetic(samples: &mut [f32], bank: &mut SympatheticBank, use_bank: bool) {
+    if use_bank {
+        for sample in samples.iter_mut() {
+            let drive = *sample;
+            let sym_out = bank.process(drive, SYMPATHETIC_COUPLING);
+            *sample += sym_out * SYMPATHETIC_MIX;
+        }
+    } else {
+        for _ in 0..samples.len() {
+            let _ = bank.process(0.0, 0.0);
+        }
+    }
+}
+
+fn sanitize_samples(samples: &mut [f32]) {
+    for sample in samples.iter_mut() {
+        if !sample.is_finite() || sample.abs() < 1e-30 {
+            *sample = 0.0;
+        }
+    }
+}
+
+fn apply_mix_mode(
+    mono: &mut [f32],
+    mono_compressed: &mut [f32],
+    limiter_gain: &mut f32,
+    mix_mode: MixMode,
+    master: f32,
+) {
+    match mix_mode {
+        MixMode::Plain => {
+            for sample in mono.iter_mut() {
+                *sample = (*sample * master).tanh();
+            }
+        }
+        MixMode::Limiter => {
+            const ATTACK: f32 = 0.5;
+            const RELEASE: f32 = 0.0001;
+            for sample in mono.iter_mut() {
+                let abs_s = sample.abs();
+                if abs_s > *limiter_gain {
+                    *limiter_gain += (abs_s - *limiter_gain) * ATTACK;
+                } else {
+                    *limiter_gain += (abs_s - *limiter_gain) * RELEASE;
+                }
+                let gr = if *limiter_gain > 1.0 {
+                    1.0 / *limiter_gain
+                } else {
+                    1.0
+                };
+                *sample = (*sample * gr * master).tanh();
+            }
+        }
+        MixMode::ParallelComp => {
+            const ALPHA: f32 = 0.7;
+            const BETA: f32 = 0.6;
+            const ATTACK: f32 = 0.5;
+            const RELEASE: f32 = 0.0001;
+
+            for (i, sample) in mono.iter().copied().enumerate() {
+                let abs_s = sample.abs();
+                if abs_s > *limiter_gain {
+                    *limiter_gain += (abs_s - *limiter_gain) * ATTACK;
+                } else {
+                    *limiter_gain += (abs_s - *limiter_gain) * RELEASE;
+                }
+                let gr = if *limiter_gain > 1.0 {
+                    1.0 / *limiter_gain
+                } else {
+                    1.0
+                };
+                mono_compressed[i] = sample * gr;
+            }
+
+            for (i, sample) in mono.iter_mut().enumerate() {
+                let combined = (*sample * ALPHA + mono_compressed[i] * BETA) * master;
+                *sample = combined.tanh();
+            }
+        }
+    }
+}
+
+fn apply_stop_fade(samples: &mut [f32], dt: f64, stop_state: &mut StopState) {
+    let StopState::Fading(fade) = stop_state else {
+        return;
+    };
+
+    for sample in samples.iter_mut() {
+        let progress = if fade.duration <= 0.0 {
+            1.0
+        } else {
+            (fade.elapsed / fade.duration).clamp(0.0, 1.0)
+        };
+        let gain = (1.0 - apply_easing(fade.easing, progress)).clamp(0.0, 1.0) as f32;
+        *sample *= gain;
+        fade.elapsed += dt;
+    }
+
+    if fade.elapsed >= fade.duration {
+        *stop_state = StopState::Finished;
+    }
+}
+
+fn apply_easing(easing: Easing, mut x: f64) -> f64 {
+    match easing {
+        Easing::Linear => x,
+        Easing::InPowi(power) => x.powi(power),
+        Easing::OutPowi(power) => 1.0 - apply_easing(Easing::InPowi(power), 1.0 - x),
+        Easing::InOutPowi(power) => {
+            x *= 2.0;
+            if x < 1.0 {
+                0.5 * apply_easing(Easing::InPowi(power), x)
+            } else {
+                x = 2.0 - x;
+                0.5 * (1.0 - apply_easing(Easing::InPowi(power), x)) + 0.5
+            }
+        }
+        Easing::InPowf(power) => x.powf(power),
+        Easing::OutPowf(power) => 1.0 - apply_easing(Easing::InPowf(power), 1.0 - x),
+        Easing::InOutPowf(power) => {
+            x *= 2.0;
+            if x < 1.0 {
+                0.5 * apply_easing(Easing::InPowf(power), x)
+            } else {
+                x = 2.0 - x;
+                0.5 * (1.0 - apply_easing(Easing::InPowf(power), x)) + 0.5
+            }
+        }
+    }
+}
+
+struct SampleRateProbeBuilder {
+    sample_rate: Arc<AtomicU32>,
+}
+
+impl SampleRateProbeBuilder {
+    fn new(sample_rate: Arc<AtomicU32>) -> Self {
+        Self { sample_rate }
+    }
+}
+
+impl EffectBuilder for SampleRateProbeBuilder {
+    type Handle = ();
+
+    fn build(self) -> (Box<dyn Effect>, Self::Handle) {
+        (
+            Box::new(SampleRateProbeEffect {
+                sample_rate: self.sample_rate,
+            }),
+            (),
+        )
+    }
+}
+
+struct SampleRateProbeEffect {
+    sample_rate: Arc<AtomicU32>,
+}
+
+impl Effect for SampleRateProbeEffect {
+    fn init(&mut self, sample_rate: u32, _internal_buffer_size: usize) {
+        self.sample_rate.store(sample_rate, Ordering::SeqCst);
+    }
+
+    fn on_change_sample_rate(&mut self, sample_rate: u32) {
+        self.sample_rate.store(sample_rate, Ordering::SeqCst);
+    }
+
+    fn process(&mut self, _input: &mut [Frame], _dt: f64, _info: &Info) {}
+}

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -1,19 +1,7 @@
 //! WASM / web entry point for the GitHub Pages demo build.
 //!
-//! Trims the live native synth down to: pure modelling engines (square / ks
-//! / piano / piano-modal etc.), an on-screen 2-octave keyboard driven by
-//! mouse + PC keyboard, and an optional Web MIDI bridge. No SF2, no SFZ,
-//! no live `midir` -- those are gated out at the Cargo feature level so
-//! this binary only sees the cross-target DSP code.
-//!
-//! Audio is built lazily on first user gesture (click the "Start audio"
-//! button) so the browser autoplay policy doesn't reject `AudioContext`
-//! creation.
-//!
-//! All wasm-only code lives in `imp` and is gated to `target_arch =
-//! "wasm32"`. On non-wasm targets `main()` is a no-op stub so
-//! `cargo check --all-features --bins` (or any host-side build that
-//! happens to enable the `web` feature) still resolves a `main` symbol.
+//! Minimalist UI version: focuses on instrument selection, volume, and
+//! the on-screen keyboard.
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
@@ -32,174 +20,32 @@ fn main() {
 mod imp {
 
     use std::cell::RefCell;
-    use std::io::Cursor;
     use std::rc::Rc;
     use std::sync::{Arc, Mutex};
 
     use eframe::egui;
-    use rustysynth::{SoundFont, Synthesizer, SynthesizerSettings};
     use wasm_bindgen::closure::Closure;
     use wasm_bindgen::{JsCast, JsValue};
 
-    use std::collections::VecDeque;
+    use keysynth::audio_kira::KiraEngine;
+    use keysynth::synth::{Engine, LiveParams, MixMode, ModalLut, ModalPreset, MODAL_LUT};
 
-    use keysynth::gm::{GM_FAMILIES, GM_INSTRUMENTS};
-    use keysynth::reverb::{self, Reverb};
-    use keysynth::sympathetic::SympatheticBank;
-    use keysynth::synth::{
-        make_voice, midi_to_freq, Engine, LiveParams, MixMode, ModalLut, ModalPreset, Voice,
-        MODAL_LUT,
-    };
-
-    /// Path of the GM SoundFont served alongside the wasm bundle. Trunk
-    /// copies `web/GeneralUser-GS.sf2` to the dist root via the
-    /// `rel="copy-file"` link in `web/index.html`, so the relative URL
-    /// works regardless of the Pages subpath (`/keysynth/` on prod,
-    /// `/` under `trunk serve`).
-    const SF2_URL: &str = "GeneralUser-GS.sf2";
-
-    /// Process-wide shared `rustysynth::Synthesizer` populated by an
-    /// async fetch that runs after the AudioContext is alive (the
-    /// Synthesizer takes the actual `ctx.sample_rate()` for its
-    /// interpolation, and we need the AudioContext sample rate before
-    /// kicking off the load). `None` before fetch + parse complete;
-    /// `Some` for the rest of the page lifetime once the bytes arrive.
-    /// `Mutex` mirrors the native `SharedSynth` pattern even though
-    /// wasm32 is single-threaded — the lock is uncontended and lets the
-    /// MIDI / render paths share the same reference shape as `main.rs`.
-    type SharedSynth = Arc<Mutex<Option<Synthesizer>>>;
-
-    /// Lifecycle of the SF2 asset fetch + parse, surfaced in the UI so
-    /// the user can tell whether picking `SfPiano` will actually make
-    /// sound or silently no-op while the bytes are still en route.
-    /// Held as `Rc<RefCell<…>>` because the async fetch closure mutates
-    /// it from outside any `&mut self` borrow.
-    #[derive(Clone, Debug)]
-    enum SfStatus {
-        /// Pre-`build_audio`. No fetch issued yet.
-        Idle,
-        /// Fetch (or fetch + parse) in flight.
-        Loading,
-        /// Synthesizer ready in `WebApp::synth`.
-        Ready,
-        /// Fetch or parse failed. Carries the error text so the UI can
-        /// surface it to the user.
-        Failed(String),
+    #[derive(Clone, Copy, Debug)]
+    enum MidiMsg {
+        NoteOn { note: u8, velocity: u8 },
+        NoteOff { note: u8 },
     }
 
-    /// Engines exposed to the web UI. Three columns:
-    ///
-    ///   1. The `Engine` variant.
-    ///   2. A short CLI-style label (matches `src/main.rs` `--engine`
-    ///      argument values: "square", "ks-rich", "piano-modal", …)
-    ///      so the row of selectable labels stays compact across the
-    ///      full engine list and the labels are A/B comparable with
-    ///      the native build's flags.
-    ///   3. A one-line description rendered under the row to explain
-    ///      what the *currently selected* engine actually does.
-    ///
-    /// Order mirrors the native `ENGINE_CHOICES` (`src/ui.rs:420`).
-    /// `SfzPiano` deliberately omitted — multi-GB sample bank we can't
-    /// ship to Pages. `SfPiano` ships because the GM SoundFont is
-    /// small enough (~32 MB) to fetch as a static asset alongside the
-    /// wasm; the wasm itself stays small (~5 MB) so first-paint isn't
-    /// blocked by the SF2 download (see `fetch_and_load_sf2`).
-    const ENGINES_FOR_WEB: &[(Engine, &str, &str)] = &[
-        (
-            Engine::Square,
-            "square",
-            "NES-style pulse + linear AR envelope. The cheapest \
-             reference tone — useful as a sanity check that the \
-             output path is alive.",
-        ),
-        (
-            Engine::Ks,
-            "ks",
-            "Single string, white-noise-excited delay loop with a \
-             2-tap lowpass. Phase-1 physical model — thin plucked \
-             string.",
-        ),
-        (
-            Engine::KsRich,
-            "ks-rich",
-            "3-string unison detune + 1-pole allpass dispersion in the \
-             feedback loop. Stiffer, chorused — closer to a piano-ish \
-             sustain than the basic KS.",
-        ),
-        (
-            Engine::Piano,
-            "piano",
-            "Original 3-string KS + asymmetric ms-scale hammer + \
-             frequency-dependent decay + sympathetic bank. The voice \
-             that all the variants above started from.",
-        ),
-        (
-            Engine::PianoThick,
-            "piano-thick",
-            "7-string KS + 12-mode lite soundboard, fuller body \
-             radiation than `lite`. Heavier but flabbier; nice for \
-             held chords.",
-        ),
-        (
-            Engine::PianoLite,
-            "piano-lite",
-            "3-string KS + 12-mode 'lite' soundboard, no shared \
-             sympathetic bank. Tuned against SFZ Salamander C4 T60 \
-             vector — closest per-partial decay match across the \
-             physical-model variants.",
-        ),
-        (
-            Engine::Piano5AM,
-            "piano-5am",
-            "Frozen snapshot of the perceptually-balanced state from \
-             commit 8f0df23 (3 strings, no soundboard, no sym bank). \
-             Kept reproducible so the morning's tone can be A/B'd \
-             against later builds.",
-        ),
-        (
-            Engine::PianoModal,
-            "piano-modal",
-            "Parallel-bandpass projection: per-note partials + T60 + \
-             init_amp lifted from SFZ Salamander Grand recordings, \
-             32-mode bass extrapolation, 3-string ±0.7 cent detune, \
-             coloured-noise hammer impulse. Most reference-faithful \
-             of the modelling engines.",
-        ),
-        (
-            Engine::Koto,
-            "koto",
-            "Single-string KS with a sharp narrow plectrum injected \
-             at ~1/4 string length. Long sustain, minimal stiffness.",
-        ),
-        (
-            Engine::Sub,
-            "sub",
-            "Sawtooth → state-variable lowpass with cutoff envelope + \
-             ADSR amp. Classic 1980s analog-synth voice.",
-        ),
-        (
-            Engine::Fm,
-            "fm",
-            "2-operator FM (sine carrier × sine modulator, ratio 14:1) \
-             with its own ADSR on the modulation index. Bell / \
-             e-piano flavour.",
-        ),
-        (
-            Engine::SfPiano,
-            "sf-piano",
-            "Real recorded samples played by rustysynth from the \
-             bundled GeneralUser-GS SoundFont. Pick a GM 128 patch in \
-             the left panel; closest match to the native build's \
-             `--engine sf-piano`.",
-        ),
-    ];
+    type MidiInbox = Rc<RefCell<Vec<MidiMsg>>>;
 
-    /// Top-level grouping in the voice browser side panel. Mirrors
-    /// `crate::voice_lib::Category` on the native (live-hotswap) build
-    /// minus the `Custom` category — Custom slots persist to
-    /// `~/.keysynth/voices.json` on native, which we have no
-    /// equivalent for on wasm32 so the category would always be
-    /// empty.
+    type MessageClosures = Rc<RefCell<Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>>>>;
+
+    struct MidiHandles {
+        _access: web_sys::MidiAccess,
+        _closures: MessageClosures,
+        _on_state_change: Closure<dyn FnMut(web_sys::MidiConnectionEvent)>,
+    }
+
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum VoiceCategory {
         Piano,
@@ -217,195 +63,114 @@ mod imp {
         }
     }
 
-    /// One row in the voice browser. Selecting a slot sets the live
-    /// `engine` and (when the slot points at `Engine::SfPiano`) the
-    /// SF2 program / bank in one click — same shape as the native
-    /// `VoiceSlot` apply path. The wasm build can't load arbitrary
-    /// SFZ / SF2 files at runtime so the slot list is hardcoded;
-    /// future work could persist user-added slots to localStorage.
     struct WebVoiceSlot {
         label: &'static str,
         category: VoiceCategory,
         engine: Engine,
-        /// `Engine::PianoModal` preset for the four `Modal (…)` slots.
-        /// Click handler calls `ModalPreset::apply()` which writes the
-        /// preset's `ModalParams` into the global cell read by every
-        /// subsequent `note_on` rendering through `ModalPianoVoice`.
-        /// `None` for non-modal slots (KS variants, synths, SF2).
         modal_preset: Option<ModalPreset>,
-        /// GM program for `Engine::SfPiano` slots; ignored otherwise.
-        sf_program: u8,
-        /// GM bank for `Engine::SfPiano` slots (0 = melodic, 128 =
-        /// drum kit); ignored otherwise.
-        sf_bank: u8,
     }
 
-    /// Built-in voice library shown in the left side panel. Slot
-    /// labels and order match the native `VoiceLibrary::builtins` on
-    /// the live-hotswap branch (`src/voice_lib.rs:186`) verbatim,
-    /// minus the SFZ Salamander slot (multi-GB, can't ship to Pages).
-    ///
-    /// CAVEAT: the four `Modal (…)` variants all currently route to
-    /// `Engine::PianoModal` with its compiled-in default params, so
-    /// the audio is identical across them on web — true preset
-    /// switching needs the `MODAL_PARAMS` cell + `ModalPreset::apply`
-    /// machinery from live-hotswap (`src/synth.rs::ModalPreset`),
-    /// which is not yet on `main`. Tracked as follow-up: porting that
-    /// stack is mechanical but touches `synth.rs` + `piano_modal.rs`,
-    /// own PR.
     const WEB_VOICE_SLOTS: &[WebVoiceSlot] = &[
-        // ── Piano family ────────────────────────────────────────────
-        // Modal preset variants. Each writes a distinct ModalParams
-        // set into MODAL_PARAMS on click via ModalPreset::apply, so
-        // the four entries produce audibly distinct sounds (Default
-        // = baseline, Round-16 = CDPAM-optimised muffled, Physics =
-        // pure Stulov+Valimaki path, Bright = minimal-detune lead).
         WebVoiceSlot {
             label: "Modal (default)",
             category: VoiceCategory::Piano,
             engine: Engine::PianoModal,
             modal_preset: Some(ModalPreset::Default),
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "Modal (Round-16)",
             category: VoiceCategory::Piano,
             engine: Engine::PianoModal,
             modal_preset: Some(ModalPreset::Round16),
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "Modal (Physics)",
             category: VoiceCategory::Piano,
             engine: Engine::PianoModal,
             modal_preset: Some(ModalPreset::Physics),
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "Modal (Bright)",
             category: VoiceCategory::Piano,
             engine: Engine::PianoModal,
             modal_preset: Some(ModalPreset::Bright),
-            sf_program: 0,
-            sf_bank: 0,
         },
-        // KS-string-based piano variants.
         WebVoiceSlot {
             label: "KS Piano",
             category: VoiceCategory::Piano,
             engine: Engine::Piano,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "KS Piano (thick)",
             category: VoiceCategory::Piano,
             engine: Engine::PianoThick,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "KS Piano (lite)",
             category: VoiceCategory::Piano,
             engine: Engine::PianoLite,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "KS Piano (5AM)",
             category: VoiceCategory::Piano,
             engine: Engine::Piano5AM,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
-        // Sample-based: SF2 only on web (SFZ Salamander too big).
-        // Label format mirrors live-hotswap's auto-discover format
-        // ("<stem> (SF2 piano)") so the web build's slot is visually
-        // identical to native when the same file is auto-discovered.
-        WebVoiceSlot {
-            label: "GeneralUser-GS (SF2 piano)",
-            category: VoiceCategory::Piano,
-            engine: Engine::SfPiano,
-            modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
-        },
-        // ── Synth family ────────────────────────────────────────────
         WebVoiceSlot {
             label: "Square",
             category: VoiceCategory::Synth,
             engine: Engine::Square,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "KS pluck",
             category: VoiceCategory::Synth,
             engine: Engine::Ks,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "KS rich",
             category: VoiceCategory::Synth,
             engine: Engine::KsRich,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "Sub (subtractive)",
             category: VoiceCategory::Synth,
             engine: Engine::Sub,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "FM bell",
             category: VoiceCategory::Synth,
             engine: Engine::Fm,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
         WebVoiceSlot {
             label: "Koto",
             category: VoiceCategory::Synth,
             engine: Engine::Koto,
             modal_preset: None,
-            sf_program: 0,
-            sf_bank: 0,
         },
     ];
 
-    // PC keyboard → MIDI semitone offset within the current octave.
-    // Standard tracker layout: bottom row = white keys, q-row = upper octave.
     const PC_KEYMAP: &[(egui::Key, i32)] = &[
-        // Lower octave (white + black row)
-        (egui::Key::Z, 0),  // C
-        (egui::Key::S, 1),  // C#
-        (egui::Key::X, 2),  // D
-        (egui::Key::D, 3),  // D#
-        (egui::Key::C, 4),  // E
-        (egui::Key::V, 5),  // F
-        (egui::Key::G, 6),  // F#
-        (egui::Key::B, 7),  // G
-        (egui::Key::H, 8),  // G#
-        (egui::Key::N, 9),  // A
-        (egui::Key::J, 10), // A#
-        (egui::Key::M, 11), // B
-        // Upper octave
-        (egui::Key::Q, 12), // C
+        (egui::Key::Z, 0),
+        (egui::Key::S, 1),
+        (egui::Key::X, 2),
+        (egui::Key::D, 3),
+        (egui::Key::C, 4),
+        (egui::Key::V, 5),
+        (egui::Key::G, 6),
+        (egui::Key::B, 7),
+        (egui::Key::H, 8),
+        (egui::Key::N, 9),
+        (egui::Key::J, 10),
+        (egui::Key::M, 11),
+        (egui::Key::Q, 12),
         (egui::Key::Num2, 13),
         (egui::Key::W, 14),
         (egui::Key::Num3, 15),
@@ -420,281 +185,32 @@ mod imp {
         (egui::Key::I, 24),
     ];
 
-    // On-screen keyboard span in semitones (2 octaves + 1 = 25 keys).
     const KEYBOARD_SPAN: u8 = 25;
 
-    // ---------------------------------------------------------------------
-    // Audio output via AudioWorklet
-    // ---------------------------------------------------------------------
-    //
-    // Earlier revisions used cpal's webaudio backend, which schedules a
-    // pair of AudioBufferSourceNodes and re-arms them via `setTimeout`
-    // polled on the main JS thread. That polling competes with egui paint
-    // for main-thread time, so a busy frame slips the next-buffer
-    // schedule and the output picks up clicks at every gap. The fix is
-    // to move the *output* side into an AudioWorkletProcessor, whose
-    // `process()` is driven from the audio thread at deterministic rate.
-    //
-    // Architecture:
-    //   - Main thread (Rust) renders mono samples in chunks and posts
-    //     them to the worklet via `port.postMessage`.
-    //   - Worklet (JS) holds a ring buffer; on each `process()` call
-    //     it copies samples out of the ring into the output channels.
-    //   - When the ring drops below half-full, the worklet posts a
-    //     `'need'` request back to the main thread, which renders one
-    //     more chunk and posts it. Closed-loop, no polling.
-    //
-    // No SharedArrayBuffer required, so this works on plain GitHub
-    // Pages without COOP/COEP service-worker shims. There's a
-    // postMessage hop per chunk, but with a generous ring (default
-    // 16384 frames ≈ 372 ms at 44.1 kHz) the main thread can stall
-    // for 100+ ms without the worklet ever running dry.
-    const WORKLET_PROCESSOR_JS: &str = r#"
-class KeysynthProcessor extends AudioWorkletProcessor {
-  constructor(options) {
-    super();
-    const opts = (options && options.processorOptions) || {};
-    this.cap = opts.ringCapacity || 16384;
-    this.ring = new Float32Array(this.cap);
-    this.read = 0;
-    this.write = 0;
-    this.size = 0;
-    this.requesting = false;
-    this.lowWatermark = Math.floor(this.cap / 2);
-    this.port.onmessage = (e) => {
-      // Reset the request flag at the very top so a malformed or
-      // unexpected message can't permanently hang the request loop.
-      this.requesting = false;
-      const msg = e.data;
-      if (!msg || msg.type !== 'fill' || !msg.samples) return;
-      const s = msg.samples;
-      const n = s.length;
-      // Drop overflow rather than overwrite — caller respects watermark.
-      const room = this.cap - this.size;
-      const copy = n < room ? n : room;
-      if (copy <= 0) return;
-      // typed-array `.set()` is a memcpy; faster than a per-sample
-      // loop and cheaper for v8's GC.
-      if (this.write + copy <= this.cap) {
-        this.ring.set(s.subarray(0, copy), this.write);
-      } else {
-        const first = this.cap - this.write;
-        this.ring.set(s.subarray(0, first), this.write);
-        this.ring.set(s.subarray(first, copy), 0);
-      }
-      this.write = (this.write + copy) % this.cap;
-      this.size += copy;
-    };
-    // Kick the main thread for the first fill so process() doesn't
-    // start emitting silence before the first chunk arrives.
-    this.port.postMessage({ type: 'need', want: this.cap });
-    this.requesting = true;
-  }
-  process(inputs, outputs, parameters) {
-    const channels = outputs[0];
-    const out0 = channels[0];
-    const n = out0.length;
-    if (this.size >= n) {
-      // Fast path: fully drain n samples in one go via subarray + set.
-      if (this.read + n <= this.cap) {
-        out0.set(this.ring.subarray(this.read, this.read + n));
-      } else {
-        const first = this.cap - this.read;
-        out0.set(this.ring.subarray(this.read, this.cap));
-        out0.set(this.ring.subarray(0, n - first), first);
-      }
-      this.read = (this.read + n) % this.cap;
-      this.size -= n;
-    } else {
-      const have = this.size;
-      if (have > 0) {
-        if (this.read + have <= this.cap) {
-          out0.set(this.ring.subarray(this.read, this.read + have));
-        } else {
-          const first = this.cap - this.read;
-          out0.set(this.ring.subarray(this.read, this.cap));
-          out0.set(this.ring.subarray(0, have - first), first);
-        }
-        this.read = (this.read + have) % this.cap;
-      }
-      out0.fill(0, have);
-      this.size = 0;
-    }
-    for (let c = 1; c < channels.length; c++) channels[c].set(out0);
-    if (this.size < this.lowWatermark && !this.requesting) {
-      this.requesting = true;
-      this.port.postMessage({ type: 'need', want: this.cap - this.size });
-    }
-    return true;
-  }
-}
-registerProcessor('keysynth-processor', KeysynthProcessor);
-"#;
-
-    /// Live audio output handle. Holds the AudioContext + worklet node
-    /// + the closure that handles fill requests so JS-side references
-    /// stay alive for the page lifetime.
-    struct AudioHandle {
-        _ctx: web_sys::AudioContext,
-        _node: web_sys::AudioWorkletNode,
-        _on_message: Closure<dyn FnMut(web_sys::MessageEvent)>,
-    }
-
-    // ---------------------------------------------------------------------
-    // Web MIDI bridge
-    // ---------------------------------------------------------------------
-    //
-    // Browser fires MIDI events on the JS event loop; we translate each
-    // raw 3-byte status message into a `MidiMsg` and push it onto a shared
-    // inbox `Rc<RefCell<Vec<MidiMsg>>>`. The egui update loop drains the
-    // inbox once per frame and turns the messages into `note_on` /
-    // `note_off` calls against the existing voice pool. Single-threaded
-    // wasm32 → no Send/Sync requirement on the inbox, hence Rc/RefCell
-    // instead of Arc/Mutex.
-
-    #[derive(Clone, Copy, Debug)]
-    enum MidiMsg {
-        NoteOn { note: u8, velocity: u8 },
-        NoteOff { note: u8 },
-    }
-
-    type MidiInbox = Rc<RefCell<Vec<MidiMsg>>>;
-
-    /// Shared registry of every per-port `onmidimessage` closure. Initial
-    /// inputs (resolved from `requestMIDIAccess`) and hot-plugged inputs
-    /// (added by the `onstatechange` callback) both push into the same
-    /// `Vec` so we don't have to leak per-event closures on hot-plug.
-    /// Lives behind `Rc<RefCell<…>>` because the onstatechange closure
-    /// owns a clone separate from the one stored on `WebApp::midi_handles`.
-    type MessageClosures = Rc<RefCell<Vec<Closure<dyn FnMut(web_sys::MidiMessageEvent)>>>>;
-
-    /// Closures + access object handed to the browser. The browser only
-    /// stores function references; if we drop the underlying Rust
-    /// closures the references go dangling and MIDI silently stops.
-    /// Park everything here so `WebApp::midi_handles` keeps it alive
-    /// for the page lifetime — and so a future "Disconnect MIDI"
-    /// operation has a single place to drop from.
-    struct MidiHandles {
-        _access: web_sys::MidiAccess,
-        _closures: MessageClosures,
-        _on_state_change: Closure<dyn FnMut(web_sys::MidiConnectionEvent)>,
-    }
-
     struct WebApp {
-        voices: Arc<Mutex<Vec<Voice>>>,
+        kira: Option<KiraEngine>,
         live: Arc<Mutex<LiveParams>>,
-        sample_rate: u32,
-        /// `AudioHandle` is moved here by the async worklet handshake
-        /// (see `build_audio`) so the splash gate can flip from "Start"
-        /// to the running UI as soon as the AudioContext is alive.
-        audio: Rc<RefCell<Option<AudioHandle>>>,
-        /// Set true synchronously by `start_audio()` and cleared by the
-        /// async worklet handshake on success/failure. Stops a frantic
-        /// double-click on the splash button from spawning two parallel
-        /// `AudioContext` + `addModule` flows — the second one would
-        /// fight the first for the voice pool's render closures and
-        /// race on which `AudioHandle` lands in `audio`.
-        audio_starting: Rc<std::cell::Cell<bool>>,
-        /// Async-populated error slot. `Rc<RefCell<…>>` because the
-        /// `spawn_local` block writes after `start_audio()` has
-        /// returned.
+        notes_held: [bool; 128],
         audio_err: Rc<RefCell<Option<String>>>,
-        /// Notes currently held by mouse/touch. PC keyboard tracking is via
-        /// the separate `pc_held` set below — egui's `key_pressed` returns
-        /// true on every browser KeyDown including auto-repeat, so we
-        /// track our own edge state instead.
         mouse_down_note: Option<u8>,
-        /// MIDI notes the PC keyboard is currently holding down, packed
-        /// as a 128-bit bitset (one bit per MIDI note 0..=127). Edge
-        /// transitions (bit set → note_on, bit cleared → note_off) drive
-        /// the voice pool so a held key produces ONE voice, not a stream
-        /// of re-triggered voices on each browser auto-repeat event.
-        /// Bitset over `HashSet<u8>` avoids per-frame heap traffic in
-        /// the egui input loop.
         pc_held: u128,
-        /// Whether the page had focus on the previous frame. Browsers
-        /// sometimes drop the `keyup` event when the user Alt-Tabs /
-        /// switches tabs / triggers IME mid-key — leaving the egui key
-        /// state stuck as "pressed" forever and our `pc_held` bitset
-        /// holding phantom notes. On a true→false focus edge we
-        /// release every pc-held note; on the next focus regain the
-        /// user starts from a clean slate.
         prev_focused: bool,
-        /// Base MIDI note for the leftmost on-screen key. Defaults to C3 (48).
         base_note: u8,
-        /// Status string for Web MIDI (e.g. "not requested" / "connected: ..."
-        /// / error). `Rc<RefCell<String>>` because the async MIDI handshake
-        /// (which lives outside any `&mut self` borrow) needs to write into
-        /// it and the egui update loop needs to read it.
-        midi_status: Rc<RefCell<String>>,
-        /// Inbox shared with browser MIDI callbacks. Producer = JS event
-        /// handlers (`onmidimessage`), consumer = `WebApp::update` once
-        /// per frame.
         midi_inbox: MidiInbox,
-        /// Tracks whether a MIDI handshake is currently in-flight or has
-        /// succeeded. Held in `Rc<Cell<bool>>` so the async resolution
-        /// path can clear it on error (letting the user re-click "Connect
-        /// MIDI" without reloading the page) without needing a `&mut self`
-        /// reference. Set true synchronously in `request_midi()`, cleared
-        /// in the async error branch, kept true on success.
         midi_requested: Rc<std::cell::Cell<bool>>,
-        /// Slot the async handshake populates with the resolved
-        /// `MidiHandles`. Stored in `Rc<RefCell<Option<…>>>` rather than
-        /// leaked via `Box::leak` so the resources have one named home,
-        /// hot-plugged closures get pushed into the existing handles
-        /// instead of leaking on every device reconnect, and a future
-        /// "Disconnect MIDI" path has somewhere to drop from.
         midi_handles: Rc<RefCell<Option<MidiHandles>>>,
-        /// Shared `rustysynth::Synthesizer` for `Engine::SfPiano`. Filled
-        /// in by an async fetch task that runs after `build_audio`
-        /// completes (Synthesizer needs `ctx.sample_rate()`). `None`
-        /// until the SF2 download + parse completes; SfPiano is silent
-        /// while loading. Other engines work normally throughout.
-        synth: SharedSynth,
-        /// Lifecycle of the SF2 fetch + parse, displayed in the UI so
-        /// `Engine::SfPiano` selection isn't a silent no-op while
-        /// loading.
-        synth_status: Rc<RefCell<SfStatus>>,
-        /// Index into `WEB_VOICE_SLOTS` for the currently-selected
-        /// voice. Disambiguates the four `Modal (…)` variants which
-        /// share `Engine::PianoModal` — without this the active-row
-        /// marker would highlight all four. Mirrors `VoiceLibrary::
-        /// active` on the native (live-hotswap) build.
         current_voice_idx: Rc<std::cell::Cell<usize>>,
-        /// Rolling log of recent MIDI events drawn in the right side
-        /// panel. Mirrors the native build's `DashState::recent` ring
-        /// (newest at the back, capped at 64). `Rc<RefCell<…>>` because
-        /// `note_on` / `note_off` are called through `&mut self` while
-        /// the side panel UI also wants to read it via egui's borrow
-        /// closure — using a separate Rc avoids re-entering `&mut
-        /// self` during update().
-        recent_events: Rc<RefCell<VecDeque<String>>>,
     }
 
     impl Default for WebApp {
         fn default() -> Self {
-            // Initialise the modal LUT once. On wasm32 this pulls bytes from
-            // include_bytes! — the file lookup never touches a real
-            // filesystem.
             let (lut, source) = ModalLut::auto_load(None);
             let _ = MODAL_LUT.set(lut);
             web_sys::console::log_1(&format!("keysynth-web: modal LUT source = {source}").into());
 
             Self {
-                voices: Arc::new(Mutex::new(Vec::with_capacity(32))),
+                kira: None,
                 live: Arc::new(Mutex::new(LiveParams {
-                    // Mirror `main.rs::Args::default` exactly. The
-                    // earlier 3.0 / Plain combo dated from when
-                    // PianoModal was ~300× quieter than KS / square
-                    // and master had to compensate; ModalPianoVoice
-                    // now ships an internal 50× output_gain that
-                    // level-matches the bus, so master=1.0 reaches
-                    // tanh(1.0) ≈ 0.76 (subtle warmth) on single
-                    // notes and ParallelComp catches chord peaks
-                    // without crushing transients. Plain tanh at
-                    // master=3 was hard-clipping the live-hotswap
-                    // DSP into harsh saturation — root cause of
-                    // "Web の音質が悪すぎる" vs native parity.
                     master: 1.0,
                     engine: Engine::PianoModal,
                     reverb_wet: 0.3,
@@ -702,91 +218,38 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
                     sf_bank: 0,
                     mix_mode: MixMode::ParallelComp,
                 })),
-                sample_rate: 0,
-                audio: Rc::new(RefCell::new(None)),
-                audio_starting: Rc::new(std::cell::Cell::new(false)),
+                notes_held: [false; 128],
                 audio_err: Rc::new(RefCell::new(None)),
                 mouse_down_note: None,
                 pc_held: 0,
                 prev_focused: true,
-                base_note: 48, // C3
-                midi_status: Rc::new(RefCell::new("not requested".to_string())),
+                base_note: 48,
                 midi_inbox: Rc::new(RefCell::new(Vec::new())),
                 midi_requested: Rc::new(std::cell::Cell::new(false)),
                 midi_handles: Rc::new(RefCell::new(None)),
-                synth: Arc::new(Mutex::new(None)),
-                synth_status: Rc::new(RefCell::new(SfStatus::Idle)),
-                // Default to slot 0 = "Modal (default)", matching the
-                // `Engine::PianoModal` default in `LiveParams` above.
                 current_voice_idx: Rc::new(std::cell::Cell::new(0)),
-                recent_events: Rc::new(RefCell::new(VecDeque::with_capacity(64))),
             }
         }
     }
 
     impl WebApp {
         fn start_audio(&mut self) {
-            // Reject re-entry while a previous startup is still
-            // resolving. `audio.is_some()` only flips after the async
-            // worklet handshake completes, so a frantic double-click
-            // would otherwise spawn two parallel AudioContext + module
-            // loads racing on which `AudioHandle` lands in `audio`.
-            if self.audio.borrow().is_some() || self.audio_starting.get() {
+            if self.kira.is_some() {
                 return;
             }
-            self.audio_starting.set(true);
-            // Clear any prior error so retries don't keep stale text.
             *self.audio_err.borrow_mut() = None;
-            match build_audio(
-                self.voices.clone(),
-                self.live.clone(),
-                self.synth.clone(),
-                self.audio.clone(),
-                self.audio_err.clone(),
-                self.audio_starting.clone(),
-            ) {
-                Ok(sr) => {
-                    self.sample_rate = sr;
-                    web_sys::console::log_1(
-                        &format!("keysynth-web: audio started @ {sr} Hz").into(),
-                    );
-                    // Same user-gesture context — request MIDI access in
-                    // the same click so the user doesn't have to hunt
-                    // for a second button. If the browser doesn't
-                    // support Web MIDI or the user denies the prompt,
-                    // `request_midi` writes the error into
-                    // `midi_status` and resets `midi_requested` so the
-                    // dedicated Retry button still appears below.
+            match KiraEngine::new() {
+                Ok(kira) => {
+                    self.kira = Some(kira);
                     self.request_midi();
-                    // Kick off the SF2 fetch + parse async. The page is
-                    // already responsive at this point (modelling
-                    // engines work immediately); SfPiano stays silent
-                    // until the bytes arrive and `synth_status` flips
-                    // to `Ready`.
-                    self.start_sf2_load();
                 }
                 Err(e) => {
-                    web_sys::console::error_1(
-                        &format!("keysynth-web: audio start failed: {e}").into(),
-                    );
                     *self.audio_err.borrow_mut() = Some(e);
-                    // `build_audio` already cleared `starting` on its
-                    // synchronous error path, but doing it here too is
-                    // a defence-in-depth so a future refactor that
-                    // forgets the inner reset still recovers.
-                    self.audio_starting.set(false);
                 }
             }
         }
 
-        /// Drain the MIDI inbox. Called once per egui frame so MIDI
-        /// events line up with the rest of the per-frame edge handling
-        /// (PC keyboard, on-screen mouse). Each drained message turns
-        /// into a `note_on` / `note_off` against the shared voice pool.
         fn drain_midi_inbox(&mut self) {
-            // Take ownership of the queued messages in one swap so the
-            // inbox borrow doesn't overlap with self.note_on / note_off
-            // (which lock self.voices and self.live).
             let drained: Vec<MidiMsg> = {
                 let mut q = self.midi_inbox.borrow_mut();
                 std::mem::take(&mut *q)
@@ -799,167 +262,44 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
             }
         }
 
-        /// Spawn the async SF2 fetch + parse. Caller (`start_audio`)
-        /// only invokes this AFTER `build_audio` succeeded so we know
-        /// `self.sample_rate` is valid. The fetch happens in the
-        /// background — the page is fully interactive while the bytes
-        /// download and rustysynth parses them. Engine selection and
-        /// modelling-voice playback work throughout; only `SfPiano`
-        /// stays silent until the synth lands in `self.synth`.
-        fn start_sf2_load(&self) {
-            if !matches!(
-                *self.synth_status.borrow(),
-                SfStatus::Idle | SfStatus::Failed(_)
-            ) {
-                return;
-            }
-            let synth = self.synth.clone();
-            let status = self.synth_status.clone();
-            let sr = self.sample_rate;
-            *status.borrow_mut() = SfStatus::Loading;
-            wasm_bindgen_futures::spawn_local(async move {
-                let outcome = fetch_and_load_sf2(synth, sr).await;
-                match outcome {
-                    Ok(bytes_len) => {
-                        web_sys::console::log_1(
-                            &format!(
-                                "keysynth-web: SF2 ready ({bytes_len} bytes fetched, sr={sr} Hz)"
-                            )
-                            .into(),
-                        );
-                        *status.borrow_mut() = SfStatus::Ready;
-                    }
-                    Err(e) => {
-                        web_sys::console::warn_1(
-                            &format!("keysynth-web: SF2 load failed: {e}").into(),
-                        );
-                        *status.borrow_mut() = SfStatus::Failed(e);
-                    }
-                }
-            });
-        }
-
-        /// Kick off the Web MIDI handshake. `navigator.requestMIDIAccess()`
-        /// returns a Promise we await via `wasm_bindgen_futures::spawn_local`;
-        /// once it resolves we attach `onmidimessage` handlers to every
-        /// input port and an `onstatechange` handler so devices plugged in
-        /// AFTER the request still get wired up.
-        ///
-        /// The captured `inbox` and `status` are `Rc` clones — they're the
-        /// only state the async block needs from `self`, and they live as
-        /// long as the page does. The resulting `MidiHandles` is leaked
-        /// (`Box::leak`) so the browser-side closures stay valid forever;
-        /// `WebApp` is itself page-lifetime so this isn't a real leak in
-        /// practice and it spares us a channel dance to ship the handles
-        /// back through a `&mut self` boundary.
         fn request_midi(&mut self) {
             if self.midi_requested.get() {
                 return;
             }
             self.midi_requested.set(true);
-            *self.midi_status.borrow_mut() = "requesting...".to_string();
             let inbox = self.midi_inbox.clone();
-            let status = self.midi_status.clone();
             let requested_flag = self.midi_requested.clone();
             let handles_slot = self.midi_handles.clone();
             wasm_bindgen_futures::spawn_local(async move {
-                match request_midi_access(inbox).await {
-                    Ok(handles) => {
-                        let n = handles._closures.borrow().len();
-                        *status.borrow_mut() = format!("{n} input(s) connected");
-                        // Store on `WebApp` so the closures live as long
-                        // as the page does and have a named owner. No
-                        // `Box::leak` — drop happens with `WebApp` on
-                        // page teardown.
-                        *handles_slot.borrow_mut() = Some(handles);
-                        // Leave `requested_flag` true on success so the
-                        // Connect button stays out of the way.
-                    }
-                    Err(e) => {
-                        *status.borrow_mut() = format!("error: {e}");
-                        // Reset on failure so the user can press Connect
-                        // again — permission-denial is recoverable on a
-                        // second click that re-prompts the browser.
-                        requested_flag.set(false);
-                    }
+                if let Ok(handles) = request_midi_access(inbox).await {
+                    *handles_slot.borrow_mut() = Some(handles);
+                } else {
+                    requested_flag.set(false);
                 }
             });
         }
 
         fn note_on(&mut self, note: u8, velocity: u8) {
-            if self.audio.borrow().is_none() || self.sample_rate == 0 {
+            let Some(kira) = self.kira.as_mut() else {
                 return;
-            }
-            let engine = self.live.lock().unwrap().engine;
-            self.push_event(format!("noteOn  ch=0 note={note:>3} vel={velocity:>3}"));
-
-            // SfPiano routes the note straight into the rustysynth
-            // shared synth — the modelling-engine voice pool is bypassed
-            // entirely (the synth holds its own internal voice state and
-            // mixing into the bus happens in render_mono_chunk). For
-            // every other engine we fall through to the modelling path.
-            if engine == Engine::SfPiano {
-                if let Some(s) = self.synth.lock().unwrap().as_mut() {
-                    s.note_on(0, note as i32, velocity as i32);
-                }
-                return;
-            }
-
-            let freq = midi_to_freq(note);
-            let inner = make_voice(engine, self.sample_rate as f32, freq, velocity);
-            let v = Voice {
-                key: (0, note),
-                inner,
             };
-            let mut pool = self.voices.lock().unwrap();
-            if let Some(slot) = pool.iter_mut().find(|x| x.key == (0, note)) {
-                *slot = v;
-            } else {
-                const MAX_VOICES: usize = 24;
-                if pool.len() >= MAX_VOICES {
-                    let evict = pool
-                        .iter()
-                        .position(|x| x.inner.is_done() || x.inner.is_releasing())
-                        .unwrap_or(0);
-                    pool.remove(evict);
-                }
-                pool.push(v);
+            let engine = self.live.lock().unwrap().engine;
+            if engine == Engine::SfPiano {
+                return;
             }
+            kira.note_on(engine, note, velocity);
+            self.notes_held[note as usize] = true;
         }
 
         fn note_off(&mut self, note: u8) {
-            self.push_event(format!("noteOff ch=0 note={note:>3}"));
-            // Always forward note_off to the synth so SF2 keys release
-            // even after the user has switched away from SfPiano while
-            // a note was held — leaving rustysynth's internal envelope
-            // pinned would leak voices for the AudioContext lifetime.
-            if let Some(s) = self.synth.lock().unwrap().as_mut() {
-                s.note_off(0, note as i32);
-            }
-            let mut pool = self.voices.lock().unwrap();
-            if let Some(slot) = pool.iter_mut().find(|x| x.key == (0, note)) {
-                slot.inner.trigger_release();
-            }
+            let Some(kira) = self.kira.as_mut() else {
+                return;
+            };
+            kira.note_off(note);
+            self.notes_held[note as usize] = false;
         }
 
-        /// Force-release every voice the app currently thinks is held.
-        ///
-        /// Called automatically on a focus-lost edge (browsers don't
-        /// always deliver `keyup` when the page loses focus mid-press,
-        /// leaving egui's key state and our `pc_held` bitset stuck on
-        /// phantom notes) and from a manual "Panic" button. Three
-        /// passes:
-        ///
-        ///   1. Iterate the bits set in `pc_held`, fire `note_off` for
-        ///      each → matching pool voices enter their release tail.
-        ///   2. Clear `pc_held` and `mouse_down_note` so subsequent
-        ///      input edges are clean.
-        ///   3. As a belt-and-braces, walk the entire voice pool and
-        ///      `trigger_release` on every voice — even ones we've
-        ///      lost track of (stuck MIDI keys after a cable yank,
-        ///      etc.) get released here.
         fn panic_release(&mut self) {
-            // Pass 1: drain pc_held bits.
             let mut bits = self.pc_held;
             while bits != 0 {
                 let note = bits.trailing_zeros() as u8;
@@ -970,31 +310,14 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
             if let Some(n) = self.mouse_down_note.take() {
                 self.note_off(n);
             }
-            // Pass 3: anything still sounding gets release.
-            let mut pool = self.voices.lock().unwrap();
-            for v in pool.iter_mut() {
-                v.inner.trigger_release();
+            for note in 0..128 {
+                if self.notes_held[note] {
+                    self.note_off(note as u8);
+                }
             }
         }
 
-        /// Process PC keyboard input. Two failure modes to dodge:
-        ///
-        ///   1. Browsers fire OS auto-repeat KeyDown events while a key is
-        ///      held, and `egui::InputState::key_pressed` returns true on
-        ///      each one — a held `z` plays as a fast trill instead of a
-        ///      sustained tone.
-        ///   2. A `keys_down` snapshot misses any tap that begins and ends
-        ///      between two UI frames (low-FPS spike or short stab) — the
-        ///      note never sounds at all.
-        ///
-        /// Stay event-based (`key_pressed` / `key_released`) so transient
-        /// taps survive, but filter via our own `pc_held` set: `note_on`
-        /// only fires when the note isn't already in the held-set, which
-        /// suppresses auto-repeat without dropping any genuine event.
         fn handle_pc_keyboard(&mut self, ctx: &egui::Context) {
-            // Bounded by KEYBOARD_SPAN (=25) so a stack-sized smallvec
-            // would also work, but Vec::new() with no pushes doesn't
-            // allocate, and most frames push 0-1 entries.
             let mut to_on: Vec<u8> = Vec::new();
             let mut to_off: Vec<u8> = Vec::new();
             ctx.input(|i| {
@@ -1005,11 +328,6 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
                         self.pc_held &= !bit;
                         to_off.push(note);
                     }
-                    // `(self.pc_held & bit) == 0` — only fire note_on if
-                    // the bit isn't already set. Browser KeyDown
-                    // auto-repeats while a key is held arrive as
-                    // `key_pressed = true` on every frame, but the bit
-                    // is already set from the first press so we skip.
                     if i.key_pressed(key) && (self.pc_held & bit) == 0 {
                         self.pc_held |= bit;
                         to_on.push(note);
@@ -1024,229 +342,75 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
             }
         }
 
-        /// Push a one-line summary of a MIDI event into the rolling
-        /// `recent_events` ring used by the right side panel. Caps the
-        /// ring at 64 entries (newest at the back) so a sustained MIDI
-        /// stream doesn't grow unbounded across the page lifetime.
-        fn push_event(&self, line: String) {
-            let mut events = self.recent_events.borrow_mut();
-            if events.len() >= 64 {
-                events.pop_front();
-            }
-            events.push_back(line);
-        }
-
-        /// Apply a voice slot click: swap the live engine, set the SF2
-        /// program/bank if the slot points at SfPiano, and push the GM
-        /// Bank Select + Program Change pair into the shared synth so
-        /// the next keypress immediately sounds the new patch (no
-        /// note-driven catch-up). Logs to the MIDI log so the user
-        /// can see the swap reflected.
-        fn apply_voice_slot(&self, idx: usize, slot: &WebVoiceSlot) {
+        fn apply_voice_slot(&mut self, idx: usize, slot: &WebVoiceSlot) {
             {
                 let mut lp = self.live.lock().unwrap();
                 lp.engine = slot.engine;
-                if slot.engine == Engine::SfPiano {
-                    lp.sf_program = slot.sf_program;
-                    lp.sf_bank = slot.sf_bank;
-                }
             }
-            // Modal preset apply: writes the preset's ModalParams
-            // into the global MODAL_PARAMS cell that ModalPianoVoice
-            // reads on every render_add, and toggles MODAL_PHYSICS
-            // for the Physics preset so make_voice routes through
-            // the pure-physics constructor.
             if let Some(preset) = slot.modal_preset {
                 preset.apply();
-            }
-            if slot.engine == Engine::SfPiano {
-                if let Some(s) = self.synth.lock().unwrap().as_mut() {
-                    // Bank Select MSB then Program Change — bank only
-                    // takes effect on the next PC per GM/GS spec, so
-                    // we always emit the pair together.
-                    s.process_midi_message(0, 0xB0, 0, slot.sf_bank as i32);
-                    s.process_midi_message(0, 0xC0, slot.sf_program as i32, 0);
+                if let Some(kira) = self.kira.as_mut() {
+                    kira.set_modal_preset(preset);
                 }
             }
+            if let Some(kira) = self.kira.as_mut() {
+                kira.set_engine(slot.engine);
+            }
             self.current_voice_idx.set(idx);
-            self.push_event(format!("voice → {}", slot.label));
         }
 
-        /// Apply a GM 128 patch pick (separate from voice slots — these
-        /// only switch program/bank within the SfPiano voice that's
-        /// already active; engine stays put). Mirrors the native
-        /// hot-swap path under `if engine == Engine::SfPiano` in
-        /// `src/ui.rs:713`.
-        fn apply_sf_patch(&self, sf_program: u8, sf_bank: u8) {
-            {
-                let mut lp = self.live.lock().unwrap();
-                lp.sf_program = sf_program;
-                lp.sf_bank = sf_bank;
-            }
-            if let Some(s) = self.synth.lock().unwrap().as_mut() {
-                s.process_midi_message(0, 0xB0, 0, sf_bank as i32);
-                s.process_midi_message(0, 0xC0, sf_program as i32, 0);
-            }
-            self.push_event(format!("patch program={sf_program} bank={sf_bank}"));
-        }
-
-        /// Render the voice browser on the left. Mirrors `src/ui.rs:538`
-        /// on the live-hotswap branch: categorised list of voice slots
-        /// (Piano / Synth) where one click swaps engine + (for SF2
-        /// slots) program/bank in one operation. When `Engine::SfPiano`
-        /// is the active voice, a collapsible "GM 128 patches"
-        /// sub-section appears below for live program switching
-        /// (mirrors `src/ui.rs:715`).
-        fn draw_voice_browser(&self, ctx: &egui::Context) {
-            let (engine, sf_program, sf_bank) = {
-                let lp = self.live.lock().unwrap();
-                (lp.engine, lp.sf_program, lp.sf_bank)
-            };
+        fn draw_voice_browser(&mut self, ui: &mut egui::Ui) {
             let mut clicked_slot: Option<usize> = None;
-            let mut clicked_patch: Option<(u8, u8)> = None;
-            egui::SidePanel::left("voice_browser")
-                .default_width(260.0)
-                .min_width(200.0)
-                .show(ctx, |ui| {
-                    ui.heading("Voices");
-                    ui.label(
-                        egui::RichText::new("Click to switch instrument live.")
-                            .small()
-                            .color(egui::Color32::from_rgb(170, 170, 170)),
-                    );
-                    ui.separator();
-                    egui::ScrollArea::vertical()
-                        .auto_shrink([false, false])
-                        .show(ui, |ui| {
-                            for cat in VoiceCategory::ALL {
-                                egui::CollapsingHeader::new(cat.label())
-                                    .default_open(true)
-                                    .show(ui, |ui| {
-                                        let active_idx = self.current_voice_idx.get();
-                                        for (idx, slot) in WEB_VOICE_SLOTS.iter().enumerate() {
-                                            if slot.category != *cat {
-                                                continue;
-                                            }
-                                            // Match by slot index so the
-                                            // four `Modal (…)` variants
-                                            // (which all share
-                                            // `Engine::PianoModal`)
-                                            // don't all light up at
-                                            // once.
-                                            let is_active = idx == active_idx;
-                                            ui.horizontal(|ui| {
-                                                ui.label(if is_active { "●" } else { "○" });
-                                                let rich = if is_active {
-                                                    egui::RichText::new(slot.label)
-                                                        .monospace()
-                                                        .strong()
-                                                        .color(egui::Color32::from_rgb(
-                                                            255, 220, 120,
-                                                        ))
-                                                } else {
-                                                    egui::RichText::new(slot.label).monospace()
-                                                };
-                                                if ui.selectable_label(is_active, rich).clicked() {
-                                                    clicked_slot = Some(idx);
-                                                }
-                                            });
-                                        }
-                                    });
-                            }
-                            // GM 128 patch picker collapsible — only
-                            // surfaced when SfPiano is the active voice
-                            // since program/bank are no-ops for every
-                            // other engine. Same shape as
-                            // `src/ui.rs:715`: drum-kit toggle on top,
-                            // family-collapsing list below, click =
-                            // live patch swap.
-                            if engine == Engine::SfPiano {
-                                ui.add_space(6.0);
-                                ui.separator();
-                                egui::CollapsingHeader::new("GM 128 patches")
-                                    .default_open(false)
-                                    .show(ui, |ui| {
-                                        let drum_on = sf_bank == 128;
-                                        let drum_label = if drum_on {
-                                            "Drum Kit (bank 128) [ON]"
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    for cat in VoiceCategory::ALL {
+                        egui::CollapsingHeader::new(cat.label())
+                            .default_open(true)
+                            .show(ui, |ui| {
+                                let active_idx = self.current_voice_idx.get();
+                                for (idx, slot) in WEB_VOICE_SLOTS.iter().enumerate() {
+                                    if slot.category != *cat {
+                                        continue;
+                                    }
+                                    let is_active = idx == active_idx;
+                                    ui.horizontal(|ui| {
+                                        ui.label(if is_active { "●" } else { "○" });
+                                        let rich = if is_active {
+                                            egui::RichText::new(slot.label)
+                                                .monospace()
+                                                .strong()
+                                                .color(egui::Color32::from_rgb(255, 220, 120))
                                         } else {
-                                            "Drum Kit (bank 128) [off]"
+                                            egui::RichText::new(slot.label).monospace()
                                         };
-                                        if ui.selectable_label(drum_on, drum_label).clicked() {
-                                            let new_bank = if drum_on { 0 } else { 128 };
-                                            clicked_patch = Some((sf_program, new_bank));
-                                        }
-                                        for family in GM_FAMILIES.iter() {
-                                            let default_open = *family == "Pianos";
-                                            egui::CollapsingHeader::new(*family)
-                                                .default_open(default_open)
-                                                .show(ui, |ui| {
-                                                    for (prog, name, fam) in GM_INSTRUMENTS.iter() {
-                                                        if fam != family {
-                                                            continue;
-                                                        }
-                                                        let selected =
-                                                            sf_program == *prog && sf_bank != 128;
-                                                        let label_text =
-                                                            format!("[{:>3}] {}", prog, name);
-                                                        let rich = if selected {
-                                                            egui::RichText::new(label_text)
-                                                                .monospace()
-                                                                .strong()
-                                                                .color(egui::Color32::from_rgb(
-                                                                    255, 220, 120,
-                                                                ))
-                                                        } else {
-                                                            egui::RichText::new(label_text)
-                                                                .monospace()
-                                                        };
-                                                        if ui
-                                                            .selectable_label(selected, rich)
-                                                            .clicked()
-                                                        {
-                                                            // Picking
-                                                            // a melodic
-                                                            // patch
-                                                            // implicitly
-                                                            // leaves
-                                                            // drum mode.
-                                                            clicked_patch = Some((*prog, 0));
-                                                        }
-                                                    }
-                                                });
+                                        if ui.selectable_label(is_active, rich).clicked() {
+                                            clicked_slot = Some(idx);
                                         }
                                     });
-                            }
-                        });
+                                }
+                            });
+                    }
                 });
-
             if let Some(idx) = clicked_slot {
                 self.apply_voice_slot(idx, &WEB_VOICE_SLOTS[idx]);
-            }
-            if let Some((p, b)) = clicked_patch {
-                self.apply_sf_patch(p, b);
             }
         }
 
         fn draw_on_screen_keyboard(&mut self, ui: &mut egui::Ui) {
-            // 2-octave (+1) keyboard. Lay out one wide rect per semitone with
-            // black-key inserts drawn on top so a click selects the right
-            // pitch class. Geometry is rough but legible.
             let span = KEYBOARD_SPAN as i32;
             let total_w = ui.available_width().min(720.0);
             let key_h = 100.0;
-            let white_w = total_w / 15.0; // 15 white keys in a 2-octave span
+            let white_w = total_w / 15.0;
             let black_w = white_w * 0.6;
             let black_h = key_h * 0.6;
 
-            // Allocate the full rect first so child painters share it.
             let (rect, response) = ui.allocate_exact_size(
                 egui::vec2(white_w * 15.0, key_h),
                 egui::Sense::click_and_drag(),
             );
             let painter = ui.painter_at(rect);
 
-            // Pass 1: white keys.
             let mut white_idx = 0usize;
             let mut white_rects: Vec<(u8, egui::Rect)> = Vec::with_capacity(15);
             for semi in 0..span {
@@ -1257,7 +421,7 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
                         egui::vec2(white_w, key_h),
                     );
                     let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
-                    let active = self.is_note_sounding(note);
+                    let active = self.notes_held[note as usize];
                     let fill = if active {
                         egui::Color32::from_rgb(160, 200, 240)
                     } else {
@@ -1270,12 +434,10 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
                 }
             }
 
-            // Pass 2: black keys overlaid on top.
             let mut black_rects: Vec<(u8, egui::Rect)> = Vec::with_capacity(10);
-            let mut white_idx = 0usize;
+            white_idx = 0;
             for semi in 0..span {
                 if is_black(semi as u8) {
-                    // Black key sits at the right edge of the previous white key.
                     let prev_white_x =
                         rect.left() + (white_idx as f32 - 0.5) * white_w + white_w - black_w * 0.5;
                     let r = egui::Rect::from_min_size(
@@ -1283,7 +445,7 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
                         egui::vec2(black_w, black_h),
                     );
                     let note = (self.base_note as i32 + semi).clamp(0, 127) as u8;
-                    let active = self.is_note_sounding(note);
+                    let active = self.notes_held[note as usize];
                     let fill = if active {
                         egui::Color32::from_rgb(80, 100, 140)
                     } else {
@@ -1297,13 +459,9 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
                 }
             }
 
-            // Hit-test pointer against rects: black keys win over white when
-            // overlapping. Mouse drag = sustained note; release = note off.
             let pointer_pos = response.interact_pointer_pos();
             let mouse_down = response.is_pointer_button_down_on() && pointer_pos.is_some();
-
             let hovered_note = pointer_pos.and_then(|p| {
-                // black first
                 for (n, r) in &black_rects {
                     if r.contains(p) {
                         return Some(*n);
@@ -1334,12 +492,6 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
                 _ => {}
             }
         }
-
-        fn is_note_sounding(&self, note: u8) -> bool {
-            let pool = self.voices.lock().unwrap();
-            pool.iter()
-                .any(|v| v.key.1 == note && !v.inner.is_releasing())
-        }
     }
 
     fn is_black(semi: u8) -> bool {
@@ -1348,221 +500,70 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
 
     impl eframe::App for WebApp {
         fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-            // Repaint at 30 fps rather than the implicit 60 fps from a
-            // bare `request_repaint()`. The cpal webaudio backend on
-            // wasm32 polls `setTimeout` for the next AudioBufferSource
-            // schedule on the same JS event loop egui paints from, so
-            // a busy 60 fps repaint loop directly steals scheduling
-            // slack from the audio thread → audible clicks at buffer
-            // boundaries. 30 fps is more than enough for the on-screen
-            // keyboard's "active" highlight while leaving roughly half
-            // the main-thread budget for cpal's polling.
             ctx.request_repaint_after(std::time::Duration::from_millis(33));
-
-            // Focus-loss panic. Browsers don't reliably fire `keyup`
-            // when the page loses focus (Alt+Tab, tab switch, IME
-            // popup, OS-level screensaver, etc.) — so a key the user
-            // released while focus was elsewhere stays "down" in
-            // egui's input state forever and our `pc_held` bitset
-            // holds a phantom bit for it. Detect the focus true→false
-            // edge and force-release everything we think is held.
             let focused_now = ctx.input(|i| i.focused);
             if self.prev_focused && !focused_now {
                 self.panic_release();
             }
             self.prev_focused = focused_now;
 
-            if self.audio.borrow().is_some() {
+            if self.kira.is_some() {
                 self.handle_pc_keyboard(ctx);
             }
-            // Drain the MIDI inbox every frame regardless of audio state.
-            // If audio isn't started yet `note_on` early-returns, so the
-            // queued events get consumed silently — the alternative
-            // (gating drain on audio_started) lets the queue grow
-            // unbounded between page load and the first click on
-            // "Start audio", and on resumption the user hears a stale
-            // burst of every key they pressed during setup.
             self.drain_midi_inbox();
 
-            // Splash gate: until the user has started audio there's
-            // nothing useful to interact with — engine selector,
-            // master gain, keyboard all want a running stream. Show
-            // a single fullscreen overlay with a big centered Start
-            // button so the required first click is impossible to
-            // miss. Once audio is running, fall through to the normal
-            // 3-panel layout below.
-            //
-            // `start_audio()` also fires `request_midi()` in the same
-            // gesture so the same click satisfies both browser
-            // permissions (autoplay → AudioContext, Web MIDI →
-            // requestMIDIAccess). On retry / error the smaller "🎹
-            // Retry MIDI" button lives inside the running UI.
-            if self.audio.borrow().is_none() {
+            if self.kira.is_none() {
                 egui::CentralPanel::default().show(ctx, |ui| {
                     ui.vertical_centered(|ui| {
                         ui.add_space(60.0);
                         ui.heading(egui::RichText::new("keysynth (web)").size(28.0).strong());
                         ui.add_space(12.0);
-                        ui.label(
-                            egui::RichText::new(
-                                "Pure-Rust real-time modelling synth.\n\
-                                 Click below to start audio + connect any USB-MIDI keyboard.",
-                            )
-                            .size(15.0)
-                            .color(egui::Color32::from_gray(190)),
-                        );
+                        ui.label("Pure-Rust real-time modelling synth.");
                         ui.add_space(40.0);
-                        let resp = ui.add(
-                            egui::Button::new(
-                                egui::RichText::new("▶ Start")
-                                    .size(28.0)
-                                    .color(egui::Color32::WHITE)
-                                    .strong(),
+                        if ui
+                            .add(
+                                egui::Button::new(
+                                    egui::RichText::new("▶ Start")
+                                        .size(28.0)
+                                        .color(egui::Color32::WHITE)
+                                        .strong(),
+                                )
+                                .fill(egui::Color32::from_rgb(40, 120, 200))
+                                .min_size(egui::vec2(220.0, 56.0)),
                             )
-                            .fill(egui::Color32::from_rgb(40, 120, 200))
-                            .min_size(egui::vec2(220.0, 56.0)),
-                        );
-                        if resp.clicked() {
+                            .clicked()
+                        {
                             self.start_audio();
                         }
                         if let Some(err) = self.audio_err.borrow().as_ref() {
-                            ui.add_space(20.0);
                             ui.colored_label(
                                 egui::Color32::from_rgb(220, 90, 90),
                                 format!("audio error: {err}"),
                             );
-                            ui.label(
-                                egui::RichText::new("Click again to retry")
-                                    .size(13.0)
-                                    .color(egui::Color32::from_gray(170)),
-                            );
                         }
-                        ui.add_space(40.0);
-                        ui.label(
-                            egui::RichText::new(
-                                "No MIDI keyboard? Use the on-screen piano (mouse) or PC keys\n\
-                                 zsxdcvgbhnjm = lower octave, qwertyui = upper octave",
-                            )
-                            .size(12.0)
-                            .color(egui::Color32::from_gray(150)),
-                        );
                     });
                 });
                 return;
             }
 
-            egui::TopBottomPanel::top("top").show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.heading("keysynth (web)");
+            egui::SidePanel::left("voice_browser")
+                .default_width(220.0)
+                .show(ctx, |ui| {
+                    ui.heading("Voices");
                     ui.separator();
-                    // Audio is already running here (the splash gate
-                    // above early-returns until it is), so we just show
-                    // the sample rate.
-                    ui.label(format!("audio @ {} Hz", self.sample_rate));
-                    ui.separator();
-                    // Status label is always shown so the previous
-                    // outcome (success / error / not requested) stays
-                    // visible even after `midi_requested` resets to
-                    // false on a permission-denied retry path.
-                    let status_owned = self.midi_status.borrow().clone();
-                    let is_error = status_owned.starts_with("error");
-                    if is_error {
-                        ui.colored_label(
-                            egui::Color32::from_rgb(220, 90, 90),
-                            format!("MIDI: {status_owned}"),
-                        );
-                    } else {
-                        ui.label(format!("MIDI: {status_owned}"));
-                    }
-                    if !self.midi_requested.get() {
-                        // Only reachable if Start failed to grant MIDI
-                        // (denied / Web MIDI unsupported). Recover via
-                        // an explicit retry click.
-                        let resp = ui.add(
-                            egui::Button::new(
-                                egui::RichText::new("🎹 Retry MIDI")
-                                    .size(15.0)
-                                    .color(egui::Color32::WHITE)
-                                    .strong(),
-                            )
-                            .fill(egui::Color32::from_rgb(180, 90, 40))
-                            .min_size(egui::vec2(140.0, 24.0)),
-                        );
-                        if resp.clicked() {
-                            self.request_midi();
-                        }
-                    }
+                    self.draw_voice_browser(ui);
                 });
-                // Hint row only shows when the user is in a recoverable
-                // MIDI failure state — once MIDI is connected (or even
-                // mid-handshake) the hint disappears so the chrome
-                // doesn't waste vertical space.
-                if !self.midi_requested.get() {
-                    ui.horizontal(|ui| {
-                        ui.add_space(4.0);
-                        ui.colored_label(
-                            egui::Color32::from_gray(170),
-                            "Click \"🎹 Retry MIDI\" to request USB-MIDI keyboard access again.",
-                        );
-                    });
-                }
-            });
 
-            egui::TopBottomPanel::top("controls").show(ctx, |ui| {
+            egui::CentralPanel::default().show(ctx, |ui| {
                 let mut live = self.live.lock().unwrap();
-                let current_desc = ENGINES_FOR_WEB
-                    .iter()
-                    .find(|(e, _, _)| *e == live.engine)
-                    .map(|(_, _, d)| *d)
-                    .unwrap_or("");
-
-                // Master + reverb sliders share the first row so the
-                // primary continuous controls are immediately reachable
-                // regardless of how long the engine list grows. SF2
-                // status sits next to them so a glance covers
-                // "SF2 loading?" + "where am I in the gain stage".
                 ui.horizontal(|ui| {
-                    ui.label("master:");
+                    ui.label("volume:");
                     ui.add(egui::Slider::new(&mut live.master, 0.0..=4.0).step_by(0.05));
                     ui.separator();
                     ui.label("reverb:");
                     ui.add(egui::Slider::new(&mut live.reverb_wet, 0.0..=1.0).step_by(0.01));
-
-                    // Surface the SF2 fetch lifecycle so SfPiano isn't
-                    // a silent no-op while the bytes are still en
-                    // route. Idle = pre-audio-start (don't draw),
-                    // Ready = quiet OK label, Loading / Failed =
-                    // visible status with colour.
-                    let status = self.synth_status.borrow().clone();
-                    match status {
-                        SfStatus::Idle => {}
-                        SfStatus::Loading => {
-                            ui.separator();
-                            ui.colored_label(
-                                egui::Color32::from_rgb(220, 180, 90),
-                                "SF2: loading…",
-                            );
-                        }
-                        SfStatus::Ready => {
-                            ui.separator();
-                            ui.colored_label(egui::Color32::from_gray(150), "SF2: ready");
-                        }
-                        SfStatus::Failed(msg) => {
-                            ui.separator();
-                            ui.colored_label(
-                                egui::Color32::from_rgb(220, 90, 90),
-                                format!("SF2 failed: {msg}"),
-                            );
-                        }
-                    }
                 });
-
-                // Mix mode as a row of selectable labels, mirroring
-                // `src/ui.rs:130` on the native side. Dropdowns hide
-                // the currently-unselected options behind a click; a
-                // flat row is faster to scan and matches the GM 128
-                // patch picker / engine row idiom below.
-                ui.horizontal_wrapped(|ui| {
+                ui.horizontal(|ui| {
                     ui.label("mix:");
                     for m in MixMode::ALL {
                         let selected = live.mix_mode == *m;
@@ -1571,686 +572,74 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
                         }
                     }
                 });
-
-                // Live SoundFont patch readout when SfPiano is the
-                // active voice. Engine selection lives in the left
-                // voice browser (mirrors live-hotswap `src/ui.rs:538`),
-                // not in this top-bar — duplicating the row would
-                // give the user two places to swap engines and they'd
-                // drift out of sync.
-                if live.engine == Engine::SfPiano {
-                    ui.horizontal(|ui| {
-                        ui.label("patch:");
-                        let prog = live.sf_program;
-                        let bank = live.sf_bank;
-                        let name = GM_INSTRUMENTS
-                            .get(prog as usize)
-                            .map(|(_, n, _)| *n)
-                            .unwrap_or("<unknown>");
-                        let label = if bank == 128 {
-                            format!("[bank128 prog{prog}] (drum kit)")
-                        } else {
-                            format!("[{:>3} {}]", prog, name)
-                        };
-                        ui.label(
-                            egui::RichText::new(label)
-                                .monospace()
-                                .color(egui::Color32::from_rgb(255, 200, 80)),
-                        );
-                    });
-                }
                 drop(live);
-
-                // Manual panic / all-notes-off button. Always-visible
-                // recovery for any input state corruption — focus-loss
-                // missed `keyup` (handled automatically above too), a
-                // MIDI controller cable yank, anything we couldn't
-                // anticipate. One click silences everything currently
-                // held.
-                ui.horizontal(|ui| {
-                    let panic_btn = ui.add(
-                        egui::Button::new(
-                            egui::RichText::new("⏹ Panic / all notes off")
-                                .color(egui::Color32::WHITE)
-                                .strong(),
-                        )
-                        .fill(egui::Color32::from_rgb(170, 60, 60))
-                        .min_size(egui::vec2(180.0, 22.0)),
-                    );
-                    if panic_btn.clicked() {
-                        self.panic_release();
-                    }
-                    ui.add_space(8.0);
-                    ui.label(
-                        egui::RichText::new(
-                            "(Press if keys get stuck. Also fires automatically when the page loses focus.)",
-                        )
-                        .small()
-                        .color(egui::Color32::from_gray(160)),
-                    );
-                });
-
-                // Description of the currently-selected engine,
-                // rendered on its own row as a wrapping `Label` so
-                // long sentences break cleanly on narrow viewports.
-                // The `ENGINES_FOR_WEB` table (kept around purely for
-                // these descriptions; engine selection now happens via
-                // the voice browser) maps each engine to a one-line
-                // explanation of what it actually does.
-                if !current_desc.is_empty() {
-                    ui.add_space(2.0);
-                    ui.add(
-                        egui::Label::new(
-                            egui::RichText::new(current_desc)
-                                .color(egui::Color32::from_gray(160))
-                                .small(),
-                        )
-                        .wrap(),
-                    );
-                }
-
-                ui.horizontal(|ui| {
-                    ui.label("octave:");
-                    if ui.button("◀").clicked() && self.base_note >= 12 {
-                        self.base_note -= 12;
-                    }
-                    // Cast to i32 BEFORE the subtraction. base_note is u8 and
-                    // can step down to 0 (C-1 in MIDI octave numbering),
-                    // where `0u8 / 12 - 1` panics in debug / wraps to 255 in
-                    // release.
-                    ui.label(format!("C{}", self.base_note as i32 / 12 - 1));
-                    if ui.button("▶").clicked() && self.base_note <= 96 {
-                        self.base_note += 12;
-                    }
-                    ui.separator();
-                    ui.label("PC keyboard: zsxdcvgbhnjm = lower octave, qwertyui = upper");
-                });
-            });
-
-            // Left side panel: voice browser. Mirrors the native
-            // (live-hotswap) `voice_browser` SidePanel — categorised
-            // list of voice slots (Piano / Synth) where one click
-            // swaps engine + (for SF2 slots) program/bank in a single
-            // operation. When SfPiano is the active voice, a
-            // collapsible "GM 128 patches" sub-section appears below
-            // for live program switching.
-            self.draw_voice_browser(ctx);
-
-            // Right side panel: rolling MIDI log. `recent_events` is
-            // populated by note_on / note_off (covers both PC keyboard
-            // and Web MIDI sources since both funnel through the same
-            // pair). Mirrors `dash_snapshot.recent` on native.
-            egui::SidePanel::right("log")
-                .default_width(220.0)
-                .show(ctx, |ui| {
-                    ui.heading("MIDI log");
-                    ui.separator();
-                    egui::ScrollArea::vertical()
-                        .stick_to_bottom(true)
-                        .show(ui, |ui| {
-                            for line in self.recent_events.borrow().iter() {
-                                ui.monospace(line);
-                            }
-                        });
-                });
-
-            egui::CentralPanel::default().show(ctx, |ui| {
-                ui.add_space(12.0);
-                self.draw_on_screen_keyboard(ui);
                 ui.add_space(20.0);
-                ui.collapsing("about", |ui| {
-                    ui.label(
-                        "keysynth — pure-Rust real-time modelling synth. The web build \
-                     fetches GeneralUser-GS.sf2 for SfPiano, drops the multi-GB SFZ \
-                     Salamander library; modelling engines (Karplus-Strong, modal \
-                     piano, FM, etc.) run unchanged from the native build.",
-                    );
-                    ui.label("source: https://github.com/YuujiKamura/keysynth");
-                });
+                self.draw_on_screen_keyboard(ui);
             });
         }
     }
-
-    // ===========================================================================
-    // Audio thread setup
-    // ===========================================================================
-
-    /// Synchronous wrapper that kicks off the async worklet handshake.
-    /// Returns the AudioContext sample rate immediately (the worklet
-    /// loads concurrently — no audible difference because `process()`
-    /// only fires after both `addModule` and the first `port` round
-    /// trip have resolved). The handle gets stashed into
-    /// `WebApp::audio` once the async block populates a shared slot.
-    fn build_audio(
-        voices: Arc<Mutex<Vec<Voice>>>,
-        live: Arc<Mutex<LiveParams>>,
-        synth: SharedSynth,
-        slot: Rc<RefCell<Option<AudioHandle>>>,
-        err_slot: Rc<RefCell<Option<String>>>,
-        starting: Rc<std::cell::Cell<bool>>,
-    ) -> Result<u32, String> {
-        // Hint the browser at 48 kHz so the AudioContext matches what
-        // the native cpal default tends to be on the same hardware.
-        // Without this hint Chrome on Linux typically picks 44.1 kHz,
-        // and the OS audio layer then resamples 44.1 → 48 on the way
-        // to the speaker — that resampling step (PulseAudio /
-        // PipeWire / CoreAudio depending on host) is the audible
-        // lo-fi gap users notice vs the native build, NOT the DSP
-        // path itself which is identical Rust code on both sides.
-        // Browsers may ignore the hint (Safari, some Android Chrome)
-        // and pick a different rate; that's fine, `ctx.sample_rate()`
-        // below reflects what we actually got and the rest of the
-        // pipeline (DSP, worklet ring) parameterises off it cleanly.
-        let ctx_opts = web_sys::AudioContextOptions::new();
-        ctx_opts.set_sample_rate(48_000.0);
-        let ctx = web_sys::AudioContext::new_with_context_options(&ctx_opts)
-            .or_else(|_| {
-                // Fall back to the browser default if 48 kHz wasn't
-                // accepted (rare, but Safari / older browsers can
-                // refuse non-native rates).
-                let fallback = web_sys::AudioContextOptions::new();
-                web_sys::AudioContext::new_with_context_options(&fallback)
-            })
-            .map_err(|e| {
-                starting.set(false);
-                format!("AudioContext::new: {e:?}")
-            })?;
-        let sr = ctx.sample_rate() as u32;
-        web_sys::console::log_1(&format!("keysynth-web: AudioContext sampleRate = {sr} Hz").into());
-
-        // Inline the worklet processor source as a Blob URL so we don't
-        // need to ship a separate JS file via Trunk. The browser caches
-        // the URL for the AudioContext's lifetime.
-        let parts = js_sys::Array::new();
-        parts.push(&JsValue::from_str(WORKLET_PROCESSOR_JS));
-        let blob_opts = web_sys::BlobPropertyBag::new();
-        blob_opts.set_type("text/javascript");
-        let blob = web_sys::Blob::new_with_str_sequence_and_options(&parts, &blob_opts)
-            .map_err(|e| format!("Blob::new: {e:?}"))?;
-        let url = web_sys::Url::create_object_url_with_blob(&blob)
-            .map_err(|e| format!("Url::createObjectURL: {e:?}"))?;
-
-        // Per-stream DSP state lives on the heap inside this Rc so the
-        // port `onmessage` closure can hold it without hitting
-        // `&mut self` lifetime issues.
-        let render_state = Rc::new(RefCell::new(RenderState {
-            reverb: Reverb::new(reverb::synthetic_body_ir(sr)),
-            sympathetic: SympatheticBank::new_piano(sr as f32),
-            mono: Vec::new(),
-            mono_compressed: Vec::new(),
-            limiter_gain: 1.0,
-            sf_left: Vec::new(),
-            sf_right: Vec::new(),
-        }));
-
-        let worklet = ctx
-            .audio_worklet()
-            .map_err(|e| format!("audio_worklet(): {e:?}"))?;
-        let module_promise = worklet
-            .add_module(&url)
-            .map_err(|e| format!("addModule: {e:?}"))?;
-
-        let ctx_clone = ctx.clone();
-        let voices_cb = voices.clone();
-        let live_cb = live.clone();
-        let synth_cb = synth.clone();
-        let render_state_cb = render_state.clone();
-        let slot_cb = slot.clone();
-        let err_cb = err_slot.clone();
-        let starting_cb = starting.clone();
-
-        wasm_bindgen_futures::spawn_local(async move {
-            if let Err(e) = wasm_bindgen_futures::JsFuture::from(module_promise).await {
-                *err_cb.borrow_mut() = Some(format!("worklet load failed: {e:?}"));
-                starting_cb.set(false);
-                return;
-            }
-            // Free the blob URL once the module is parsed.
-            let _ = web_sys::Url::revoke_object_url(&url);
-
-            let node_opts = web_sys::AudioWorkletNodeOptions::new();
-            // Stereo output (mirrored from mono inside the worklet so
-            // both ears get the same signal).
-            node_opts.set_output_channel_count(&js_sys::Array::of1(&JsValue::from_f64(2.0)));
-            // Pass a generous ring capacity via processor options so the
-            // worklet can buffer ~370 ms at 44.1 kHz, absorbing main-
-            // thread stalls without underrunning.
-            let proc_opts = js_sys::Object::new();
-            let _ = js_sys::Reflect::set(
-                &proc_opts,
-                &JsValue::from_str("ringCapacity"),
-                &JsValue::from_f64(16384.0),
-            );
-            node_opts.set_processor_options(Some(&proc_opts));
-
-            let node = match web_sys::AudioWorkletNode::new_with_options(
-                &ctx_clone,
-                "keysynth-processor",
-                &node_opts,
-            ) {
-                Ok(n) => n,
-                Err(e) => {
-                    *err_cb.borrow_mut() = Some(format!("AudioWorkletNode::new: {e:?}"));
-                    starting_cb.set(false);
-                    return;
-                }
-            };
-            if let Err(e) = node.connect_with_audio_node(ctx_clone.destination().as_ref()) {
-                *err_cb.borrow_mut() = Some(format!("node.connect: {e:?}"));
-                starting_cb.set(false);
-                return;
-            }
-
-            // Wire the port: every `'need'` request triggers a render
-            // pass on the main thread that produces `want` mono samples
-            // and posts them straight back. The worklet's ring buffer
-            // absorbs the postMessage round-trip latency.
-            let port = match node.port() {
-                Ok(p) => p,
-                Err(e) => {
-                    *err_cb.borrow_mut() = Some(format!("port(): {e:?}"));
-                    starting_cb.set(false);
-                    return;
-                }
-            };
-            let port_for_cb = port.clone();
-            let voices_h = voices_cb;
-            let live_h = live_cb;
-            let synth_h = synth_cb;
-            let render_h = render_state_cb;
-            let on_message = Closure::<dyn FnMut(web_sys::MessageEvent)>::new(
-                move |ev: web_sys::MessageEvent| {
-                    let msg = ev.data();
-                    let kind = js_sys::Reflect::get(&msg, &JsValue::from_str("type"))
-                        .ok()
-                        .and_then(|v| v.as_string());
-                    if kind.as_deref() != Some("need") {
-                        return;
-                    }
-                    let want = js_sys::Reflect::get(&msg, &JsValue::from_str("want"))
-                        .ok()
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(1024.0) as usize;
-                    // Cap one render pass at 4096 frames so a huge
-                    // initial fill request doesn't stall the main
-                    // thread for tens of ms; the worklet will just ask
-                    // again next process() until full.
-                    let chunk = want.min(4096);
-                    let (master, wet, engine, mix_mode) = {
-                        let lp = live_h.lock().unwrap();
-                        (lp.master, lp.reverb_wet, lp.engine, lp.mix_mode)
-                    };
-                    // Render directly into `state.mono` so the per-
-                    // request `Vec<f32>` allocation goes away —
-                    // `state.mono` is reused across requests and only
-                    // resizes when the chunk size changes. The
-                    // Float32Array copy below is the unavoidable
-                    // wasm→JS heap hop.
-                    let arr = {
-                        let mut state = render_h.borrow_mut();
-                        render_mono_chunk(
-                            &voices_h, &synth_h, master, wet, engine, mix_mode, &mut state, chunk,
-                        );
-                        let a = js_sys::Float32Array::new_with_length(chunk as u32);
-                        a.copy_from(&state.mono);
-                        a
-                    };
-                    let out_msg = js_sys::Object::new();
-                    let _ = js_sys::Reflect::set(
-                        &out_msg,
-                        &JsValue::from_str("type"),
-                        &JsValue::from_str("fill"),
-                    );
-                    let _ = js_sys::Reflect::set(&out_msg, &JsValue::from_str("samples"), &arr);
-                    let _ = port_for_cb.post_message(&out_msg);
-                },
-            );
-            port.set_onmessage(Some(on_message.as_ref().unchecked_ref()));
-            // Some browsers leave the AudioContext suspended even after
-            // a user gesture; explicitly resume and treat a rejection
-            // as an audio start failure rather than silently marking
-            // the handle as ready (which would hide the splash gate
-            // and leave the user with a silent app, no recovery path
-            // short of a reload — Codex P1).
-            match ctx_clone.resume() {
-                Ok(p) => {
-                    if let Err(e) = wasm_bindgen_futures::JsFuture::from(p).await {
-                        *err_cb.borrow_mut() = Some(format!("AudioContext.resume rejected: {e:?}"));
-                        starting_cb.set(false);
-                        return;
-                    }
-                }
-                Err(e) => {
-                    *err_cb.borrow_mut() = Some(format!("AudioContext.resume threw: {e:?}"));
-                    starting_cb.set(false);
-                    return;
-                }
-            }
-            *slot_cb.borrow_mut() = Some(AudioHandle {
-                _ctx: ctx_clone,
-                _node: node,
-                _on_message: on_message,
-            });
-            // Clear the in-flight flag after the handle is published.
-            // Subsequent `start_audio()` calls early-return on
-            // `audio.is_some()` so the flag is just for the
-            // not-yet-resolved window.
-            starting_cb.set(false);
-        });
-
-        Ok(sr)
-    }
-
-    /// Per-stream DSP state owned by the audio render closure. Lives
-    /// behind `Rc<RefCell<…>>` so the JS-thread `onmessage` Closure can
-    /// hold it without `&mut self` plumbing.
-    struct RenderState {
-        reverb: Reverb,
-        sympathetic: SympatheticBank,
-        mono: Vec<f32>,
-        mono_compressed: Vec<f32>,
-        limiter_gain: f32,
-        /// Scratch buffers for the rustysynth `render(left, right)` call
-        /// when `Engine::SfPiano` is active. Held in `RenderState` so
-        /// they're reused across audio blocks instead of allocated
-        /// per-callback (the audio thread can't tolerate hidden heap
-        /// traffic). Resized lazily to match the current chunk size.
-        sf_left: Vec<f32>,
-        sf_right: Vec<f32>,
-    }
-
-    /// Render `frames` mono samples directly into `state.mono`. Same
-    /// DSP graph as the prior `audio_render` (voice mix → sym bank →
-    /// denormal flush → reverb → mix-mode tanh) minus the per-channel
-    /// mirroring that the worklet does on the JS side. Caller reads
-    /// the result from `state.mono` after this returns; no per-
-    /// request `Vec` allocation.
-    fn render_mono_chunk(
-        voices: &Arc<Mutex<Vec<Voice>>>,
-        synth: &SharedSynth,
-        master: f32,
-        reverb_wet: f32,
-        engine: Engine,
-        mix_mode: MixMode,
-        state: &mut RenderState,
-        frames: usize,
-    ) {
-        let mono = &mut state.mono;
-        if mono.len() != frames {
-            mono.resize(frames, 0.0);
-        } else {
-            mono.fill(0.0);
-        }
-
-        // Mix the rustysynth SF2 voice into the bus when active. Same
-        // downmix-to-mono shape as native `audio_callback` (sf_left +
-        // sf_right) * 0.5. Always render so the synth's internal voice
-        // envelopes keep advancing even on engine switches; the
-        // contribution is only added when SfPiano is the selected
-        // engine so non-SF voices don't get a phantom piano bus.
-        {
-            let mut guard = synth.lock().unwrap();
-            if let Some(s) = guard.as_mut() {
-                if state.sf_left.len() != frames {
-                    state.sf_left.resize(frames, 0.0);
-                    state.sf_right.resize(frames, 0.0);
-                } else {
-                    state.sf_left.fill(0.0);
-                    state.sf_right.fill(0.0);
-                }
-                s.render(state.sf_left.as_mut_slice(), state.sf_right.as_mut_slice());
-                if engine == Engine::SfPiano {
-                    for i in 0..frames {
-                        mono[i] += (state.sf_left[i] + state.sf_right[i]) * 0.5;
-                    }
-                }
-            }
-        }
-
-        {
-            let mut pool = voices.lock().unwrap();
-            for v in pool.iter_mut() {
-                v.inner.render_add(mono.as_mut_slice());
-            }
-            pool.retain(|v| !v.inner.is_done());
-        }
-
-        if engine.is_piano_family() {
-            const COUPLING: f32 = 0.0002;
-            const MIX: f32 = 0.3;
-            for sample in mono.iter_mut() {
-                let drive = *sample;
-                let sym_out = state.sympathetic.process(drive, COUPLING);
-                *sample += sym_out * MIX;
-            }
-        } else {
-            for _ in 0..mono.len() {
-                let _ = state.sympathetic.process(0.0, 0.0);
-            }
-        }
-
-        // NaN/Inf guard + denormal flush.
-        for s in mono.iter_mut() {
-            if !s.is_finite() {
-                *s = 0.0;
-            } else if s.abs() < 1e-30 {
-                *s = 0.0;
-            }
-        }
-
-        if reverb_wet > 0.0 {
-            state.reverb.process(mono.as_mut_slice(), reverb_wet);
-        }
-
-        match mix_mode {
-            MixMode::Plain => {
-                for sample in mono.iter_mut() {
-                    *sample = (*sample * master).tanh();
-                }
-            }
-            MixMode::Limiter => {
-                const ATTACK: f32 = 0.5;
-                const RELEASE: f32 = 0.0001;
-                for sample in mono.iter_mut() {
-                    let abs_s = sample.abs();
-                    if abs_s > state.limiter_gain {
-                        state.limiter_gain += (abs_s - state.limiter_gain) * ATTACK;
-                    } else {
-                        state.limiter_gain += (abs_s - state.limiter_gain) * RELEASE;
-                    }
-                    let gr = if state.limiter_gain > 1.0 {
-                        1.0 / state.limiter_gain
-                    } else {
-                        1.0
-                    };
-                    *sample = (*sample * gr * master).tanh();
-                }
-            }
-            MixMode::ParallelComp => {
-                const ALPHA: f32 = 0.7;
-                const BETA: f32 = 0.6;
-                const ATTACK: f32 = 0.5;
-                const RELEASE: f32 = 0.0001;
-                let mono_compressed = &mut state.mono_compressed;
-                if mono_compressed.len() != mono.len() {
-                    mono_compressed.resize(mono.len(), 0.0);
-                }
-                for (i, sample) in mono.iter().enumerate() {
-                    let abs_s = sample.abs();
-                    if abs_s > state.limiter_gain {
-                        state.limiter_gain += (abs_s - state.limiter_gain) * ATTACK;
-                    } else {
-                        state.limiter_gain += (abs_s - state.limiter_gain) * RELEASE;
-                    }
-                    let gr = if state.limiter_gain > 1.0 {
-                        1.0 / state.limiter_gain
-                    } else {
-                        1.0
-                    };
-                    mono_compressed[i] = sample * gr;
-                }
-                for (i, sample) in mono.iter_mut().enumerate() {
-                    let combined = (*sample * ALPHA + mono_compressed[i] * BETA) * master;
-                    *sample = combined.tanh();
-                }
-            }
-        }
-        // Caller reads from `state.mono`; no copy back needed since we
-        // rendered in place.
-    }
-
-    // ===========================================================================
-    // wasm-bindgen entry. The outer real `main` (above the `mod imp` wrapper)
-    // dispatches into `imp::start`; we install the panic hook and hand control
-    // to eframe's WebRunner from there.
-    // ===========================================================================
 
     pub fn start() {
         console_error_panic_hook::set_once();
-
         let runner = eframe::WebRunner::new();
         wasm_bindgen_futures::spawn_local(async move {
             let canvas = pick_canvas("keysynth-canvas");
-            let result = runner
+            let _ = runner
                 .start(
                     canvas,
                     eframe::WebOptions::default(),
                     Box::new(|_cc| Ok(Box::new(WebApp::default()))),
                 )
                 .await;
-            if let Err(e) = result {
-                web_sys::console::error_1(&format!("eframe start failed: {e:?}").into());
-            }
         });
     }
 
-    // ---------------------------------------------------------------------
-    // Web MIDI handshake
-    // ---------------------------------------------------------------------
-
-    /// Fetch the SF2 bytes from `SF2_URL` (a static asset trunk copies
-    /// next to the wasm), parse with rustysynth at `sr` Hz, set the
-    /// default GM program, and install the resulting `Synthesizer`
-    /// into the shared `synth` slot. All async + non-blocking, so the
-    /// page remains responsive across the multi-second download.
-    /// Returns the byte length on success so the caller can log a
-    /// confirmation; on failure returns a stringified error.
-    async fn fetch_and_load_sf2(synth: SharedSynth, sr: u32) -> Result<usize, String> {
-        let window = web_sys::window().ok_or_else(|| "no window".to_string())?;
-        let resp_value = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(SF2_URL))
-            .await
-            .map_err(|e| format!("fetch({SF2_URL}): {e:?}"))?;
-        let resp: web_sys::Response = resp_value
-            .dyn_into()
-            .map_err(|_| "fetch result was not a Response".to_string())?;
-        if !resp.ok() {
-            return Err(format!("HTTP {}", resp.status()));
-        }
-        let buffer_promise = resp
-            .array_buffer()
-            .map_err(|e| format!("response.array_buffer: {e:?}"))?;
-        let buffer = wasm_bindgen_futures::JsFuture::from(buffer_promise)
-            .await
-            .map_err(|e| format!("array_buffer await: {e:?}"))?;
-        let array = js_sys::Uint8Array::new(&buffer);
-        let bytes: Vec<u8> = array.to_vec();
-        let n = bytes.len();
-        let sf = SoundFont::new(&mut Cursor::new(&bytes[..]))
-            .map_err(|e| format!("SoundFont parse: {e:?}"))?;
-        let mut settings = SynthesizerSettings::new(sr as i32);
-        settings.maximum_polyphony = 256;
-        let mut s = Synthesizer::new(&Arc::new(sf), &settings)
-            .map_err(|e| format!("Synthesizer::new: {e:?}"))?;
-        // Default to GM program 0 (Acoustic Grand Piano), bank 0. Same
-        // initial state the native `--engine sf-piano` lands in when
-        // `--sf2-program`/`--sf2-bank` are left at their defaults.
-        s.process_midi_message(0, 0xC0, 0, 0);
-        *synth.lock().unwrap() = Some(s);
-        Ok(n)
-    }
-
-    /// Request MIDI access from the browser, attach an `onmidimessage`
-    /// handler to every input port, and set up `onstatechange` on the
-    /// `MidiAccess` so devices plugged in later also start producing
-    /// events. Returns a `MidiHandles` blob the caller must keep alive
-    /// for the lifetime of the page (the browser only stores function
-    /// references; if Rust drops the underlying `Closure`s the
-    /// references go dangling and MIDI silently stops).
     async fn request_midi_access(inbox: MidiInbox) -> Result<MidiHandles, String> {
-        let window = web_sys::window().ok_or_else(|| "no window".to_string())?;
-        let nav: web_sys::Navigator = window.navigator();
-        // `requestMIDIAccess` is technically optional on the Navigator
-        // interface (Firefox without the flag returns undefined). Reach
-        // it via `Reflect::get` so we get a proper error message instead
-        // of a static-link compile dependency on the typed binding.
+        let window = web_sys::window().ok_or("no window")?;
+        let nav = window.navigator();
         let request_fn = js_sys::Reflect::get(&nav, &JsValue::from_str("requestMIDIAccess"))
-            .map_err(|_| "navigator.requestMIDIAccess unavailable".to_string())?;
-        if request_fn.is_undefined() || request_fn.is_null() {
-            return Err("Web MIDI not supported in this browser".to_string());
+            .map_err(|_| "no requestMIDIAccess")?;
+        if request_fn.is_undefined() {
+            return Err("not supported".into());
         }
-        let request_fn: js_sys::Function = request_fn
-            .dyn_into()
-            .map_err(|_| "requestMIDIAccess not callable".to_string())?;
+        let request_fn: js_sys::Function = request_fn.dyn_into().map_err(|_| "not callable")?;
         let promise: js_sys::Promise = request_fn
             .call0(&nav)
-            .map_err(|e| format!("requestMIDIAccess threw: {e:?}"))?
+            .map_err(|_| "threw")?
             .dyn_into()
-            .map_err(|_| "requestMIDIAccess didn't return a Promise".to_string())?;
+            .map_err(|_| "no promise")?;
         let access_jsv = wasm_bindgen_futures::JsFuture::from(promise)
             .await
-            .map_err(|e| format!("MIDI access denied: {e:?}"))?;
-        let access: web_sys::MidiAccess = access_jsv
-            .dyn_into()
-            .map_err(|_| "MIDI access result wasn't a MIDIAccess".to_string())?;
-
-        // Shared registry every onmidimessage closure pushes into —
-        // both the initial walk below and the hot-plug `onstatechange`
-        // closure further down. Keeping one named owner avoids the
-        // per-reconnect leak the original `Box::leak` path produced.
+            .map_err(|_| "denied")?;
+        let access: web_sys::MidiAccess = access_jsv.dyn_into().map_err(|_| "wrong type")?;
         let closures: MessageClosures = Rc::new(RefCell::new(Vec::new()));
-
-        // Walk every current input and attach a message handler. Use
-        // `inputs.values()` rather than `entries()` so we get
-        // `MidiInput` directly without destructuring `[key, value]`.
         let inputs = access.inputs();
         let values: js_sys::Iterator = inputs.values();
         loop {
-            let next = values
-                .next()
-                .map_err(|e| format!("MIDIInputMap.values iter failed: {e:?}"))?;
+            let next = values.next().map_err(|_| "iter failed")?;
             if next.done() {
                 break;
             }
-            let port: web_sys::MidiInput = match next.value().dyn_into() {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
-            attach_midi_handler(&port, inbox.clone(), &closures);
+            if let Ok(port) = next.value().dyn_into::<web_sys::MidiInput>() {
+                attach_midi_handler(&port, inbox.clone(), &closures);
+            }
         }
-
-        // Hot-plug: handle devices that connect after the access grant.
-        // Capture clones of the inbox and the shared closure registry so
-        // a new `Connected` event can attach a handler and store its
-        // closure inside the same `MidiHandles` we hand back below.
         let inbox_state = inbox.clone();
         let closures_state = closures.clone();
         let on_state_change = Closure::<dyn FnMut(web_sys::MidiConnectionEvent)>::new(
             move |ev: web_sys::MidiConnectionEvent| {
-                let Some(port) = ev.port() else { return };
-                if port.type_() != web_sys::MidiPortType::Input {
-                    return;
+                if let Some(port) = ev.port() {
+                    if port.type_() == web_sys::MidiPortType::Input
+                        && port.state() == web_sys::MidiPortDeviceState::Connected
+                    {
+                        if let Ok(input) = port.dyn_into::<web_sys::MidiInput>() {
+                            attach_midi_handler(&input, inbox_state.clone(), &closures_state);
+                        }
+                    }
                 }
-                if port.state() != web_sys::MidiPortDeviceState::Connected {
-                    return;
-                }
-                let Ok(input) = port.dyn_into::<web_sys::MidiInput>() else {
-                    return;
-                };
-                attach_midi_handler(&input, inbox_state.clone(), &closures_state);
             },
         );
         access.set_onstatechange(Some(on_state_change.as_ref().unchecked_ref()));
-
         Ok(MidiHandles {
             _access: access,
             _closures: closures,
@@ -2258,59 +647,28 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
         })
     }
 
-    /// Wire one MIDI input port: set its `onmidimessage` to a closure
-    /// that parses the 3-byte status message and pushes a `MidiMsg` onto
-    /// the inbox. Pushes the created `Closure` into the shared
-    /// `MessageClosures` registry so the caller keeps it alive — letting
-    /// it drop here would dangle the browser's stored function reference.
     fn attach_midi_handler(
         port: &web_sys::MidiInput,
         inbox: MidiInbox,
         closures: &MessageClosures,
     ) {
-        // Diagnostic: log the port name once at attach time so we can
-        // confirm the handler actually got bound to a real input. Cheap
-        // — fires only when a port is added.
-        web_sys::console::log_1(
-            &format!(
-                "keysynth-web: attach_midi_handler port='{}' state={:?}",
-                port.name().unwrap_or_default(),
-                port.state()
-            )
-            .into(),
-        );
         let on_message = Closure::<dyn FnMut(web_sys::MidiMessageEvent)>::new(
             move |ev: web_sys::MidiMessageEvent| {
-                let Ok(data) = ev.data() else { return };
-                if data.len() < 2 {
-                    return;
+                if let Ok(data) = ev.data() {
+                    if data.len() < 2 {
+                        return;
+                    }
+                    let status = data[0];
+                    let kind = status & 0xF0;
+                    let note = data[1];
+                    let velocity = if data.len() >= 3 { data[2] } else { 0 };
+                    let msg = match kind {
+                        0x90 if velocity > 0 => MidiMsg::NoteOn { note, velocity },
+                        0x80 | 0x90 => MidiMsg::NoteOff { note },
+                        _ => return,
+                    };
+                    inbox.borrow_mut().push(msg);
                 }
-                let status = data[0];
-                let kind = status & 0xF0;
-                let note = data[1];
-                // Velocity is data[2] for note_on/off; absent on some
-                // status types but we only branch on 0x80 / 0x90 below.
-                let velocity = if data.len() >= 3 { data[2] } else { 0 };
-                // Diagnostic: log raw bytes ONLY for note_on / note_off.
-                // Logging every inbound message swamps the browser
-                // console with MIDI clock (24 msg/quarter ≈ 48 msg/s
-                // at 120 BPM) and active-sensing chatter from
-                // sequencer-style controllers, jankifying the UI even
-                // though the audio thread is unaffected. Keep the
-                // signal-of-interest visible without spam. Strip once
-                // we've confirmed MIDI is wired end-to-end on the live
-                // demo across enough device models.
-                if matches!(kind, 0x80 | 0x90) {
-                    web_sys::console::log_1(
-                        &format!("keysynth-web: midi raw={:02X?}", data.as_slice()).into(),
-                    );
-                }
-                let msg = match kind {
-                    0x90 if velocity > 0 => MidiMsg::NoteOn { note, velocity },
-                    0x80 | 0x90 => MidiMsg::NoteOff { note },
-                    _ => return,
-                };
-                inbox.borrow_mut().push(msg);
             },
         );
         port.set_onmidimessage(Some(on_message.as_ref().unchecked_ref()));
@@ -2318,14 +676,13 @@ registerProcessor('keysynth-processor', KeysynthProcessor);
     }
 
     fn pick_canvas(id: &str) -> web_sys::HtmlCanvasElement {
-        let document = web_sys::window()
-            .expect("no window")
+        web_sys::window()
+            .unwrap()
             .document()
-            .expect("no document");
-        document
+            .unwrap()
             .get_element_by_id(id)
-            .unwrap_or_else(|| panic!("missing <canvas id=\"{id}\">"))
-            .dyn_into::<web_sys::HtmlCanvasElement>()
-            .expect("element is not a canvas")
+            .unwrap()
+            .dyn_into()
+            .unwrap()
     }
-} // mod imp
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,12 @@ pub mod synth;
 pub mod voice_lib;
 pub mod voices;
 
+// Web-only audio engine using Kira. Gated behind the `web` Cargo
+// feature so the native binary's compile graph isn't pulled into
+// `kira` / cpal-wasm-bindgen / etc.
+#[cfg(feature = "web")]
+pub mod audio_kira;
+
 // Native-only modules: pull in midir / rustysynth / rustfft / hound /
 // game-music-emu / midly / symphonia which are gated out of the
 // wasm32 build via the `web` Cargo feature.


### PR DESCRIPTION
User abandoned the hand-rolled AudioWorkletProcessor + chunk-render path that produced "ゴミ" sound quality. This PR replaces it with [Kira 0.12](https://docs.rs/kira/0.12) — a Rust audio engine that internally uses cpal-wasm-bindgen but abstracts away the worklet plumbing, gives us per-voice \`Sound\` traits and a \`SoundData\` builder, and handles MIDI-event-style scheduling cleanly.

Implementation was split between two parallel agents in different files (no merge conflicts):

| Commit | Agent | File |
|---|---|---|
| \`09387e9\` | Codex (gpt-5.4 xhigh) | \`src/audio_kira.rs\` (new, 510 lines) |
| \`674c892\` | Claude (after Gemini abandoned at 11+ min) | \`src/bin/web.rs\` (rewrite, 1814 → 688 lines) + \`Cargo.toml\` |

## src/audio_kira.rs (Codex)
- \`KiraEngine\` owns \`AudioManager<DefaultBackend>\` + \`HashMap<u8, VoiceSoundHandle>\`.
- \`VoiceSoundData\` / \`VoiceSound\` impl Kira's \`SoundData\` / \`Sound\` traits — wraps a keysynth \`Voice\` and renders into \`&mut [Frame]\` each \`process()\`.
- Per-voice bus chain inline: voice mix → sympathetic bank (piano-family gated) → NaN/denormal flush → body IR reverb → ParallelComp+tanh. Same constants as native \`audio_callback\`. (Caveat: sympathetic is per-voice, not shared. Acceptable approximation; can promote to mixer effect later.)
- \`set_modal_preset\` calls the existing \`ModalPreset::apply()\` so the global \`MODAL_PARAMS\` cell is what new voices read.
- SfPiano / SfzPiano stubbed with explicit "not yet supported" log; no rustysynth integration this PR.

## src/bin/web.rs (Claude takeover)
Per user spec ("音源選択・音量・鍵盤・音設定、それ以外不要") the UI is reduced to:
- Splash gate \`▶ Start\`
- Left side panel: voice browser (Modal/KS/Synth, 16 slots)
- master / reverb sliders + mix mode row (display only — Kira sync deferred)
- On-screen 2-octave keyboard
- PC keyboard input + Web MIDI input

Removed: MIDI log, audio Hz status, MIDI status label, Retry MIDI button, engine description, octave selector, about, panic UI button, record button, SF2 status, GM 128 patches sub-panel, AudioWorkletProcessor JS, chunk-render path, render_mono_chunk, async SF2 fetch, WAV download helpers.

Cargo.toml \`web\` feature: drops \`dep:rustysynth\` (no main-thread synth path), \`Response\` + \`HtmlAnchorElement\` web-sys features (fetch + download paths gone).

## Verification

- \`cargo check --no-default-features --features web --target wasm32-unknown-unknown --bin keysynth-web\` ✓
- \`cargo check --bin keysynth\` (native) ✓
- \`cargo fmt --check\` ✓
- \`trunk serve\` clean build, wasm 7.4 MB

Live verification (browser): \`localhost:8090\` after \`trunk serve web/index.html --port 8090 --no-autoreload\`. Splash gate → Start → click any non-SfPiano voice slot → play via PC keys.

## Deferred

- master / reverb / mix slider → Kira track parameter sync (sliders display only currently)
- SfPiano via Kira (rustysynth doesn't fit Sound trait without a multi-voice wrapper)
- Modal preset propagation to currently-held voices (only new voices pick up new preset)

## Test plan

- [x] cargo check both targets
- [x] cargo fmt
- [ ] CI green
- [ ] Pages: Square + Modal + KS slots all produce sound; sustained tones don't cut out under main-thread egui activity