### PR TITLE
feat(keysynth): MIDI-optional + CP E2E verification (#41 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,13 @@ reference/*.wav
 !bench-out/REF/README.md
 !bench-out/REF/sfz_salamander_multi/
 !bench-out/REF/sfz_salamander_multi/**
+# CP E2E demo log: tests/cp_e2e_demo.sh writes the captured PR evidence
+# here. Whitelist the directory so run.log is checkable, but keep the
+# rendered WAVs and keysynth's verbose stderr tail local-only.
+!bench-out/cp-e2e/
+!bench-out/cp-e2e/run.log
+bench-out/cp-e2e/*.wav
+bench-out/cp-e2e/keysynth.stderr.log
 **/*.flac
 **/*.aif
 **/*.aiff

--- a/bench-out/cp-e2e/run.log
+++ b/bench-out/cp-e2e/run.log
@@ -1,0 +1,40 @@
+spawning keysynth --engine live --cp ...
+keysynth pid=63221
+waiting for CP server on 127.0.0.1:5577 ...
+CP server ready after 0s
+active = default
+slots  = 1
+sr_hz  = 48000
+status = loaded in 297 ms
+
+=== slot A: build + render ===
+slot A: built + loaded in 64 ms
+dll: C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337969886486800.dll
+slot A: ok
+rendered 384000 frames (8.00 s) → bench-out/cp-e2e/cp_demo_a.wav
+active slot:  A
+fingerprint:  fnv1a64:50709f704312a319
+set A -> first sample of A: 80 ms
+
+=== mutating voices_live (gain 0.6 -> 0.3) for slot B ===
+
+=== slot B: build + render ===
+slot B: built + loaded in 275 ms
+dll: C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337970401878400.dll
+slot B: ok
+rendered 384000 frames (8.00 s) → bench-out/cp-e2e/cp_demo_b.wav
+active slot:  B
+fingerprint:  fnv1a64:e68573da57ecb049
+slot       active dll
+A                 C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337969886486800.dll
+B          *      C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337970401878400.dll
+default           C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337970403443900.dll
+
+=== assertions ===
+sha256 A = 6dc56287908713270d56aa2aaebc80ced27291c6a09f1341ef7bad9df55ced83  (bench-out/cp-e2e/cp_demo_a.wav)
+sha256 B = 9244a48394d27436b658ae4ffd9f6e150d25dbd362448c3b24451d4046c30594  (bench-out/cp-e2e/cp_demo_b.wav)
+size   A = 768044 bytes
+size   B = 768044 bytes
+
+reload latency (set A -> first sample of A): 80 ms
+CP E2E DEMO: PASS — see bench-out/cp-e2e/cp_demo_a.wav and bench-out/cp-e2e/cp_demo_b.wav

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,8 +157,9 @@ fn parse_args() -> Result<Args, String> {
                     "piano-lite" => Engine::PianoLite,
                     "piano-5am" => Engine::Piano5AM,
                     "piano-modal" => Engine::PianoModal,
+                    "live" => Engine::Live,
                     other => return Err(format!(
-                        "unknown engine: {other} (square|ks|ks-rich|sub|fm|piano|koto|sf-piano|sfz-piano|piano-thick|piano-lite|piano-5am|piano-modal)"
+                        "unknown engine: {other} (square|ks|ks-rich|sub|fm|piano|koto|sf-piano|sfz-piano|piano-thick|piano-lite|piano-5am|piano-modal|live)"
                     )),
                 };
             }
@@ -419,42 +420,63 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    if ports.is_empty() {
-        return Err("no MIDI input ports found - keyboard plugged in?".into());
-    }
-
+    // MIDI is optional — `keysynth --cp` is a valid headless config on
+    // machines with no MIDI hardware (CI, Docker, or just a desktop
+    // without a keyboard plugged in). When `--port NAME` is explicitly
+    // requested but the device isn't there, that's still a hard error;
+    // silently falling back would mask a typo. With no `--port` flag,
+    // an empty port list logs a one-line note and continues to audio +
+    // CP setup so the egui PC keyboard and the CP server are both
+    // reachable. The MIDI callback connection (`_conn`) and the chosen
+    // port handle therefore become `Option`s; the audio + CP paths
+    // never read them anyway.
     let chosen_port = if let Some(want) = &args.port {
-        ports
-            .iter()
-            .find(|p| midi_in.port_name(p).map(|n| n == *want).unwrap_or(false))
-            .ok_or_else(|| {
-                let available: Vec<String> = ports
-                    .iter()
-                    .filter_map(|p| midi_in.port_name(p).ok())
-                    .collect();
-                format!("port {want:?} not found. Available: {available:?}")
-            })?
-            .clone()
+        if ports.is_empty() {
+            return Err(format!("port {want:?} not found. Available: []").into());
+        }
+        Some(
+            ports
+                .iter()
+                .find(|p| midi_in.port_name(p).map(|n| n == *want).unwrap_or(false))
+                .ok_or_else(|| {
+                    let available: Vec<String> = ports
+                        .iter()
+                        .filter_map(|p| midi_in.port_name(p).ok())
+                        .collect();
+                    format!("port {want:?} not found. Available: {available:?}")
+                })?
+                .clone(),
+        )
+    } else if ports.is_empty() {
+        None
     } else {
         // Prefer an AKAI device when no --port was given. Live workflow
         // is "boot the keysynth GUI with the AKAI MPK plugged in", and
         // the OS may enumerate IAC / loopback / virtual ports ahead of
         // the physical keyboard depending on driver load order.
-        ports
-            .iter()
-            .find(|p| {
-                midi_in
-                    .port_name(p)
-                    .map(|n| {
-                        n.to_ascii_uppercase().contains("AKAI")
-                            || n.to_ascii_uppercase().contains("MPK")
-                    })
-                    .unwrap_or(false)
-            })
-            .cloned()
-            .unwrap_or_else(|| ports[0].clone())
+        Some(
+            ports
+                .iter()
+                .find(|p| {
+                    midi_in
+                        .port_name(p)
+                        .map(|n| {
+                            n.to_ascii_uppercase().contains("AKAI")
+                                || n.to_ascii_uppercase().contains("MPK")
+                        })
+                        .unwrap_or(false)
+                })
+                .cloned()
+                .unwrap_or_else(|| ports[0].clone()),
+        )
     };
-    let port_name = midi_in.port_name(&chosen_port)?;
+    let port_name = match &chosen_port {
+        Some(p) => midi_in.port_name(p)?,
+        None => {
+            eprintln!("keysynth: no MIDI input — running CP / PC keyboard only");
+            "(no MIDI)".to_string()
+        }
+    };
 
     // -- Audio output --
     let host = cpal::default_host();
@@ -576,199 +598,202 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // != 0 was already applied at SF2 load time -- still cheap).
     let mut last_applied_program: u16 = u16::MAX;
     let mut last_applied_bank: u16 = u16::MAX;
-    let _conn = midi_in.connect(
-        &chosen_port,
-        "keysynth-in",
-        move |_stamp, raw, _| {
-            if raw.is_empty() {
+    // Build the MIDI callback closure regardless of whether a port is
+    // available — when `chosen_port` is None we just don't connect it,
+    // and the `_conn: Option<...>` stays `None` (no callback runs).
+    let midi_callback = move |_stamp: u64, raw: &[u8], _: &mut ()| {
+        if raw.is_empty() {
+            return;
+        }
+        let status = raw[0];
+        let msg_type = status & 0xF0;
+        let channel = status & 0x0F;
+
+        // Program Change is a 2-byte message: status + program.
+        // Handle BEFORE the >=3 guard below, otherwise it gets dropped.
+        if msg_type == 0xC0 {
+            if raw.len() < 2 {
                 return;
             }
-            let status = raw[0];
-            let msg_type = status & 0xF0;
-            let channel = status & 0x0F;
+            let program = raw[1].min(127);
+            {
+                let mut lp = live_for_midi.lock().unwrap();
+                lp.sf_program = program;
+            }
+            {
+                let mut d = dash_for_midi.lock().unwrap();
+                d.push_event(format!("PC ch{channel} prog={program}"));
+            }
+            return;
+        }
 
-            // Program Change is a 2-byte message: status + program.
-            // Handle BEFORE the >=3 guard below, otherwise it gets dropped.
-            if msg_type == 0xC0 {
-                if raw.len() < 2 {
-                    return;
-                }
-                let program = raw[1].min(127);
-                {
-                    let mut lp = live_for_midi.lock().unwrap();
-                    lp.sf_program = program;
-                }
+        if raw.len() < 3 {
+            return;
+        }
+        let note = raw[1];
+        let velocity = raw[2];
+
+        match msg_type {
+            0x90 if velocity > 0 => {
                 {
                     let mut d = dash_for_midi.lock().unwrap();
-                    d.push_event(format!("PC ch{channel} prog={program}"));
+                    d.active_notes.insert((channel, note));
+                    d.push_event(format!("note_on  ch{channel} n{note} v{velocity}"));
                 }
-                return;
-            }
+                let freq = midi_to_freq(note);
+                // Read currently-selected engine + GM patch fresh each
+                // note so GUI changes apply immediately to subsequent
+                // keypresses.
+                let (engine, want_program, want_bank) = {
+                    let lp = live_for_midi.lock().unwrap();
+                    (lp.engine, lp.sf_program, lp.sf_bank)
+                };
 
-            if raw.len() < 3 {
-                return;
-            }
-            let note = raw[1];
-            let velocity = raw[2];
-
-            match msg_type {
-                0x90 if velocity > 0 => {
-                    {
-                        let mut d = dash_for_midi.lock().unwrap();
-                        d.active_notes.insert((channel, note));
-                        d.push_event(format!("note_on  ch{channel} n{note} v{velocity}"));
-                    }
-                    let freq = midi_to_freq(note);
-                    // Read currently-selected engine + GM patch fresh each
-                    // note so GUI changes apply immediately to subsequent
-                    // keypresses.
-                    let (engine, want_program, want_bank) = {
-                        let lp = live_for_midi.lock().unwrap();
-                        (lp.engine, lp.sf_program, lp.sf_bank)
-                    };
-
-                    // Drive the shared SoundFont synth too if we're in
-                    // sf-piano (or whenever a synth is loaded -- harmless
-                    // for other engines because the placeholder is what
-                    // routes audio for them, not the synth).
-                    if engine == Engine::SfzPiano {
-                        if let Some(player) = sfz_for_midi.lock().unwrap().as_mut() {
-                            player.note_on(channel, note, velocity);
-                        }
-                    } else if engine == Engine::SfPiano {
-                        if let Some(synth) = synth_for_midi.lock().unwrap().as_mut() {
-                            // Push Bank Select + Program Change ONLY when
-                            // the desired pair has actually changed since
-                            // last note. Order: Bank Select (CC 0 MSB)
-                            // first, then Program Change -- bank select
-                            // takes effect on the next PC per GM/GS spec.
-                            if (want_bank as u16) != last_applied_bank
-                                || (want_program as u16) != last_applied_program
-                            {
-                                synth.process_midi_message(
-                                    channel as i32,
-                                    0xB0,
-                                    0,
-                                    want_bank as i32,
-                                );
-                                synth.process_midi_message(
-                                    channel as i32,
-                                    0xC0,
-                                    want_program as i32,
-                                    0,
-                                );
-                                last_applied_bank = want_bank as u16;
-                                last_applied_program = want_program as u16;
-                            }
-                            synth.note_on(channel as i32, note as i32, velocity as i32);
-                        }
-                    }
-
-                    let inner: Box<dyn VoiceImpl> =
-                        make_voice(engine, sr_for_voices, freq, velocity);
-                    let v = Voice {
-                        key: (channel, note),
-                        inner,
-                    };
-                    let mut pool = voices_for_midi.lock().unwrap();
-                    if let Some(slot) = pool.iter_mut().find(|x| x.key == (channel, note)) {
-                        *slot = v;
-                    } else {
-                        // Hard cap voice pool to bound CPU/memory growth under
-                        // sustained MIDI input. When at cap, prefer evicting an
-                        // already-released voice; fall back to the oldest entry.
-                        //
-                        // Pre-2026-04-25: most VoiceImpls forgot to override
-                        // `is_releasing` (only SfPianoPlaceholder did). The
-                        // released-voice scan therefore returned None on
-                        // every Piano/Ks/etc. voice and `unwrap_or(0)`
-                        // killed slot 0 — often a still-sustained note,
-                        // perceived as "no sound after pressing many keys".
-                        // ReleaseEnvelope-based VoiceImpl trait now provides
-                        // is_releasing() by default, so the scan finds a
-                        // real candidate as long as ANY voice in the pool
-                        // has been released.
-                        const MAX_VOICES: usize = 32;
-                        if pool.len() >= MAX_VOICES {
-                            let evict_idx = pool
-                                .iter()
-                                .position(|x| x.inner.is_done() || x.inner.is_releasing())
-                                .unwrap_or(0);
-                            pool.remove(evict_idx);
-                        }
-                        pool.push(v);
-                    }
-                }
-                0x80 | 0x90 => {
-                    // Note off, or note_on with velocity 0 (running-status note off)
-                    {
-                        let mut d = dash_for_midi.lock().unwrap();
-                        d.active_notes.remove(&(channel, note));
-                        d.push_event(format!("note_off ch{channel} n{note}"));
-                    }
-                    // Forward note-off to the shared synth too so its envelope
-                    // moves into release. We can't tell from here whether this
-                    // particular note was an sf-piano voice without scanning
-                    // the pool, but rustysynth ignores note_off for inactive
-                    // notes, so the call is safe and cheap.
-                    if let Some(synth) = synth_for_midi.lock().unwrap().as_mut() {
-                        synth.note_off(channel as i32, note as i32);
-                    }
-                    // Forward to SFZ player too. Like rustysynth above, this
-                    // is safe whether or not sfz-piano is the active engine —
-                    // an inactive note_off is a no-op inside the player.
+                // Drive the shared SoundFont synth too if we're in
+                // sf-piano (or whenever a synth is loaded -- harmless
+                // for other engines because the placeholder is what
+                // routes audio for them, not the synth).
+                if engine == Engine::SfzPiano {
                     if let Some(player) = sfz_for_midi.lock().unwrap().as_mut() {
-                        player.note_off(channel, note);
+                        player.note_on(channel, note, velocity);
                     }
-                    let mut pool = voices_for_midi.lock().unwrap();
-                    if let Some(slot) = pool.iter_mut().find(|x| x.key == (channel, note)) {
-                        slot.inner.trigger_release();
+                } else if engine == Engine::SfPiano {
+                    if let Some(synth) = synth_for_midi.lock().unwrap().as_mut() {
+                        // Push Bank Select + Program Change ONLY when
+                        // the desired pair has actually changed since
+                        // last note. Order: Bank Select (CC 0 MSB)
+                        // first, then Program Change -- bank select
+                        // takes effect on the next PC per GM/GS spec.
+                        if (want_bank as u16) != last_applied_bank
+                            || (want_program as u16) != last_applied_program
+                        {
+                            synth.process_midi_message(channel as i32, 0xB0, 0, want_bank as i32);
+                            synth.process_midi_message(
+                                channel as i32,
+                                0xC0,
+                                want_program as i32,
+                                0,
+                            );
+                            last_applied_bank = want_bank as u16;
+                            last_applied_program = want_program as u16;
+                        }
+                        synth.note_on(channel as i32, note as i32, velocity as i32);
                     }
                 }
-                0xB0 => {
-                    // Control Change. raw[1] = CC number, raw[2] = value (0..127).
-                    let cc_num = note; // (raw[1])
-                    let cc_val = velocity; // (raw[2])
-                    {
-                        let mut d = dash_for_midi.lock().unwrap();
-                        d.cc_raw.insert(cc_num, cc_val);
-                        *d.cc_count.entry(cc_num).or_insert(0) += 1;
-                        d.push_event(format!("CC{cc_num}={cc_val} ch{channel}"));
-                    }
 
-                    // MPK mini 3 K1-K8 are ROTARY ENCODERS in relative mode:
-                    //   1..63   = +N step(s) clockwise
-                    //   65..127 = -N step(s) counter-clockwise (encoded as 128-N)
-                    // Standard MIDI Volume (CC 7) is absolute (a "real" pot).
-                    let delta_ticks: i32 = match cc_val {
-                        0 | 64 => 0,
-                        1..=63 => cc_val as i32,
-                        65..=127 => -(128 - cc_val as i32),
-                        _ => 0, // MIDI CC values are 0..127 in spec; defensive
-                    };
-
-                    match cc_num {
-                        // CC 7 = absolute MIDI Volume (rare on MPK).
-                        // Top out at 10.0 to match the GUI slider + CC70 range.
-                        // tanh soft-clip handles saturation past ~3.
-                        7 => {
-                            let new_master = (cc_val as f32 / 127.0) * 10.0;
-                            live_for_midi.lock().unwrap().master = new_master;
-                        }
-                        // CC 70 = MPK K1 (relative encoder by default).
-                        // 1 tick = +/- 0.1 master gain, clamped 0..10.0.
-                        70 => {
-                            let mut p = live_for_midi.lock().unwrap();
-                            p.master = (p.master + delta_ticks as f32 * 0.1).clamp(0.0, 10.0);
-                        }
-                        _ => {}
+                let inner: Box<dyn VoiceImpl> = make_voice(engine, sr_for_voices, freq, velocity);
+                let v = Voice {
+                    key: (channel, note),
+                    inner,
+                };
+                let mut pool = voices_for_midi.lock().unwrap();
+                if let Some(slot) = pool.iter_mut().find(|x| x.key == (channel, note)) {
+                    *slot = v;
+                } else {
+                    // Hard cap voice pool to bound CPU/memory growth under
+                    // sustained MIDI input. When at cap, prefer evicting an
+                    // already-released voice; fall back to the oldest entry.
+                    //
+                    // Pre-2026-04-25: most VoiceImpls forgot to override
+                    // `is_releasing` (only SfPianoPlaceholder did). The
+                    // released-voice scan therefore returned None on
+                    // every Piano/Ks/etc. voice and `unwrap_or(0)`
+                    // killed slot 0 — often a still-sustained note,
+                    // perceived as "no sound after pressing many keys".
+                    // ReleaseEnvelope-based VoiceImpl trait now provides
+                    // is_releasing() by default, so the scan finds a
+                    // real candidate as long as ANY voice in the pool
+                    // has been released.
+                    const MAX_VOICES: usize = 32;
+                    if pool.len() >= MAX_VOICES {
+                        let evict_idx = pool
+                            .iter()
+                            .position(|x| x.inner.is_done() || x.inner.is_releasing())
+                            .unwrap_or(0);
+                        pool.remove(evict_idx);
                     }
+                    pool.push(v);
                 }
-                _ => {}
             }
-        },
-        (),
-    )?;
+            0x80 | 0x90 => {
+                // Note off, or note_on with velocity 0 (running-status note off)
+                {
+                    let mut d = dash_for_midi.lock().unwrap();
+                    d.active_notes.remove(&(channel, note));
+                    d.push_event(format!("note_off ch{channel} n{note}"));
+                }
+                // Forward note-off to the shared synth too so its envelope
+                // moves into release. We can't tell from here whether this
+                // particular note was an sf-piano voice without scanning
+                // the pool, but rustysynth ignores note_off for inactive
+                // notes, so the call is safe and cheap.
+                if let Some(synth) = synth_for_midi.lock().unwrap().as_mut() {
+                    synth.note_off(channel as i32, note as i32);
+                }
+                // Forward to SFZ player too. Like rustysynth above, this
+                // is safe whether or not sfz-piano is the active engine —
+                // an inactive note_off is a no-op inside the player.
+                if let Some(player) = sfz_for_midi.lock().unwrap().as_mut() {
+                    player.note_off(channel, note);
+                }
+                let mut pool = voices_for_midi.lock().unwrap();
+                if let Some(slot) = pool.iter_mut().find(|x| x.key == (channel, note)) {
+                    slot.inner.trigger_release();
+                }
+            }
+            0xB0 => {
+                // Control Change. raw[1] = CC number, raw[2] = value (0..127).
+                let cc_num = note; // (raw[1])
+                let cc_val = velocity; // (raw[2])
+                {
+                    let mut d = dash_for_midi.lock().unwrap();
+                    d.cc_raw.insert(cc_num, cc_val);
+                    *d.cc_count.entry(cc_num).or_insert(0) += 1;
+                    d.push_event(format!("CC{cc_num}={cc_val} ch{channel}"));
+                }
+
+                // MPK mini 3 K1-K8 are ROTARY ENCODERS in relative mode:
+                //   1..63   = +N step(s) clockwise
+                //   65..127 = -N step(s) counter-clockwise (encoded as 128-N)
+                // Standard MIDI Volume (CC 7) is absolute (a "real" pot).
+                let delta_ticks: i32 = match cc_val {
+                    0 | 64 => 0,
+                    1..=63 => cc_val as i32,
+                    65..=127 => -(128 - cc_val as i32),
+                    _ => 0, // MIDI CC values are 0..127 in spec; defensive
+                };
+
+                match cc_num {
+                    // CC 7 = absolute MIDI Volume (rare on MPK).
+                    // Top out at 10.0 to match the GUI slider + CC70 range.
+                    // tanh soft-clip handles saturation past ~3.
+                    7 => {
+                        let new_master = (cc_val as f32 / 127.0) * 10.0;
+                        live_for_midi.lock().unwrap().master = new_master;
+                    }
+                    // CC 70 = MPK K1 (relative encoder by default).
+                    // 1 tick = +/- 0.1 master gain, clamped 0..10.0.
+                    70 => {
+                        let mut p = live_for_midi.lock().unwrap();
+                        p.master = (p.master + delta_ticks as f32 * 0.1).clamp(0.0, 10.0);
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    };
+    let _conn = match &chosen_port {
+        Some(p) => Some(midi_in.connect(p, "keysynth-in", midi_callback, ())?),
+        None => {
+            // Drop midi_in without connecting; the GUI's PC keyboard
+            // path uses egui input, not the MIDI callback, so silence
+            // here is intentional.
+            drop(midi_in);
+            drop(midi_callback);
+            None
+        }
+    };
 
     let voices_for_audio = voices.clone();
     let live_for_audio = live.clone();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -37,7 +37,11 @@ use crate::voice_lib::{Category, VoiceLibrary, VoiceSlot};
 /// MIDI handles so they aren't dropped while the GUI is open.
 pub struct AppContext {
     pub stream: Stream,
-    pub midi_conn: MidiInputConnection<()>,
+    /// MIDI input connection. `None` when no MIDI input was found (or
+    /// `--port`-less startup on a machine with no devices); the egui PC
+    /// keyboard path still works without it. Stored so the connection
+    /// (and its callback closures) live as long as the GUI window.
+    pub midi_conn: Option<MidiInputConnection<()>>,
     pub live: Arc<Mutex<LiveParams>>,
     pub dash: Arc<Mutex<DashState>>,
     pub voices: Arc<Mutex<Vec<Voice>>>,

--- a/tests/cp_e2e_demo.sh
+++ b/tests/cp_e2e_demo.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# CP E2E live demonstration.
+#
+# Spawns a real keysynth process, drives it via the ksctl client, builds
+# two voice slots from the same voices_live crate (mutating one constant
+# in between), renders both to WAV, and asserts the audio is observably
+# different between slot A and slot B. PASS gate is the literal
+# "CP E2E DEMO: PASS" line at the bottom — the parent CI/PR workflow
+# greps for it.
+#
+# Hardcoded MIDI ports are NOT required: keysynth tolerates an empty
+# port list (post #41 follow-up) so this works on CI / containers /
+# desktops without a keyboard plugged in.
+#
+# Run from the worktree root:
+#   bash tests/cp_e2e_demo.sh
+
+set -u
+# Don't `set -e` globally — we want to detect failure ourselves and
+# always fall through to the cleanup trap so a stray keysynth process
+# never lingers. Exit codes are checked manually with `|| { ... }`.
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || { echo "FATAL: cannot cd to repo root"; exit 1; }
+
+OUT_DIR="bench-out/cp-e2e"
+mkdir -p "$OUT_DIR"
+WAV_A="$OUT_DIR/cp_demo_a.wav"
+WAV_B="$OUT_DIR/cp_demo_b.wav"
+KS_LOG="$OUT_DIR/keysynth.stderr.log"
+PORT=5577
+ENDPOINT="127.0.0.1:$PORT"
+LIVE_SRC="voices_live/src/lib.rs"
+LIVE_SRC_BACKUP="$OUT_DIR/lib.rs.orig"
+
+rm -f "$WAV_A" "$WAV_B" "$KS_LOG"
+
+# Locate the built keysynth + ksctl binaries via cargo metadata so we
+# tolerate a custom target-dir (e.g. the F:\rust-targets override on
+# this dev machine).
+TARGET_DIR=$(cargo metadata --no-deps --format-version 1 2>/dev/null \
+  | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p' | head -n1)
+if [ -z "$TARGET_DIR" ]; then
+    TARGET_DIR="$ROOT/target"
+fi
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) EXE_SUFFIX=".exe" ;;
+    *) EXE_SUFFIX="" ;;
+esac
+KEYSYNTH_BIN="$TARGET_DIR/release/keysynth$EXE_SUFFIX"
+KSCTL_BIN="$TARGET_DIR/release/ksctl$EXE_SUFFIX"
+
+if [ ! -x "$KEYSYNTH_BIN" ] && [ ! -f "$KEYSYNTH_BIN" ]; then
+    echo "FATAL: keysynth binary not found at $KEYSYNTH_BIN"
+    echo "       run: cargo build --release --bin keysynth --bin ksctl"
+    exit 1
+fi
+if [ ! -x "$KSCTL_BIN" ] && [ ! -f "$KSCTL_BIN" ]; then
+    echo "FATAL: ksctl binary not found at $KSCTL_BIN"
+    exit 1
+fi
+
+KS_PID=""
+
+# Restore voices_live source + kill keysynth on any exit path so a
+# panic during the test never leaves the user's tree dirty or the
+# audio device locked by an orphan process.
+cleanup() {
+    local rc=$?
+    if [ -f "$LIVE_SRC_BACKUP" ]; then
+        cp "$LIVE_SRC_BACKUP" "$LIVE_SRC"
+        rm -f "$LIVE_SRC_BACKUP"
+    fi
+    if [ -n "$KS_PID" ]; then
+        kill "$KS_PID" 2>/dev/null
+        sleep 1
+        kill -KILL "$KS_PID" 2>/dev/null
+        if command -v taskkill >/dev/null 2>&1; then
+            taskkill //F //PID "$KS_PID" >/dev/null 2>&1 || true
+        fi
+        wait "$KS_PID" 2>/dev/null || true
+    fi
+    return $rc
+}
+trap cleanup EXIT INT TERM
+
+# --- spawn keysynth ---------------------------------------------------
+echo "spawning keysynth --engine live --cp ..."
+KEYSYNTH_CP="$ENDPOINT" "$KEYSYNTH_BIN" --engine live --cp \
+    --cp-endpoint "$ENDPOINT" >"$KS_LOG" 2>&1 &
+KS_PID=$!
+echo "keysynth pid=$KS_PID"
+
+# --- wait for CP server -----------------------------------------------
+echo "waiting for CP server on $ENDPOINT ..."
+WAITED=0
+DEADLINE=30
+READY=0
+while [ "$WAITED" -lt "$DEADLINE" ]; do
+    if "$KSCTL_BIN" --endpoint "$ENDPOINT" status >/dev/null 2>&1; then
+        READY=1
+        break
+    fi
+    if ! kill -0 "$KS_PID" 2>/dev/null; then
+        echo "FATAL: keysynth died during startup; tail of $KS_LOG:"
+        tail -n 40 "$KS_LOG" || true
+        exit 1
+    fi
+    sleep 1
+    WAITED=$((WAITED + 1))
+done
+if [ "$READY" -ne 1 ]; then
+    echo "FATAL: CP server did not come up within ${DEADLINE}s"
+    tail -n 40 "$KS_LOG" || true
+    exit 1
+fi
+echo "CP server ready after ${WAITED}s"
+"$KSCTL_BIN" --endpoint "$ENDPOINT" status
+
+# --- slot A: build + render ------------------------------------------
+echo
+echo "=== slot A: build + render ==="
+"$KSCTL_BIN" --endpoint "$ENDPOINT" build --slot A --src voices_live \
+    || { echo "FATAL: build A failed"; exit 1; }
+
+# Reload latency = time between issuing `set A` and the first
+# successful render coming back. cp-core's `set` is a constant-time
+# active-slot swap, so this also captures the call+JSON-RPC overhead
+# end-to-end.
+SET_START_NS=$(date +%s%N)
+"$KSCTL_BIN" --endpoint "$ENDPOINT" set A \
+    || { echo "FATAL: set A failed"; exit 1; }
+"$KSCTL_BIN" --endpoint "$ENDPOINT" render \
+    --notes 60,64,67,72 --duration 6.0 --out "$WAV_A" \
+    || { echo "FATAL: render A failed"; exit 1; }
+RENDER_END_NS=$(date +%s%N)
+RELOAD_LATENCY_MS=$(( (RENDER_END_NS - SET_START_NS) / 1000000 ))
+echo "set A -> first sample of A: ${RELOAD_LATENCY_MS} ms"
+
+# --- mutate voices_live for slot B -----------------------------------
+echo
+echo "=== mutating voices_live (gain 0.6 -> 0.3) for slot B ==="
+cp "$LIVE_SRC" "$LIVE_SRC_BACKUP"
+# Halve the gain. Single, targeted, reversible mutation. The whole
+# point is that B *sounds* different from A, and a 6 dB gain swing
+# is well outside any FNV-1a fingerprint collision risk.
+sed -i 's/\* 0\.6;/* 0.3;/' "$LIVE_SRC"
+if ! grep -q '\* 0\.3;' "$LIVE_SRC"; then
+    echo "FATAL: voices_live mutation did not apply (gain pattern not matched)"
+    diff "$LIVE_SRC_BACKUP" "$LIVE_SRC" || true
+    exit 1
+fi
+
+# --- slot B: build + render ------------------------------------------
+echo
+echo "=== slot B: build + render ==="
+"$KSCTL_BIN" --endpoint "$ENDPOINT" build --slot B --src voices_live \
+    || { echo "FATAL: build B failed"; exit 1; }
+"$KSCTL_BIN" --endpoint "$ENDPOINT" set B \
+    || { echo "FATAL: set B failed"; exit 1; }
+"$KSCTL_BIN" --endpoint "$ENDPOINT" render \
+    --notes 60,64,67,72 --duration 6.0 --out "$WAV_B" \
+    || { echo "FATAL: render B failed"; exit 1; }
+
+# Restore source NOW so even if the assertion phase fails the tree
+# is clean — cleanup trap also does this, but doing it eagerly keeps
+# the diff out of "git status" the moment the test passes.
+cp "$LIVE_SRC_BACKUP" "$LIVE_SRC"
+rm -f "$LIVE_SRC_BACKUP"
+
+"$KSCTL_BIN" --endpoint "$ENDPOINT" list
+
+# --- assertions -------------------------------------------------------
+echo
+echo "=== assertions ==="
+[ -s "$WAV_A" ] || { echo "FATAL: $WAV_A missing/empty"; exit 1; }
+[ -s "$WAV_B" ] || { echo "FATAL: $WAV_B missing/empty"; exit 1; }
+
+if command -v sha256sum >/dev/null 2>&1; then
+    SHA_A=$(sha256sum "$WAV_A" | awk '{print $1}')
+    SHA_B=$(sha256sum "$WAV_B" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    SHA_A=$(shasum -a 256 "$WAV_A" | awk '{print $1}')
+    SHA_B=$(shasum -a 256 "$WAV_B" | awk '{print $1}')
+else
+    echo "WARN: no sha256 binary, skipping hash check"
+    SHA_A="(no sha256)"
+    SHA_B="(no sha256)"
+fi
+echo "sha256 A = $SHA_A  ($WAV_A)"
+echo "sha256 B = $SHA_B  ($WAV_B)"
+if [ "$SHA_A" != "(no sha256)" ] && [ "$SHA_A" = "$SHA_B" ]; then
+    echo "FATAL: WAV A and WAV B sha256 are identical — slot swap had no audible effect"
+    exit 1
+fi
+
+SIZE_A=$(wc -c < "$WAV_A")
+SIZE_B=$(wc -c < "$WAV_B")
+echo "size   A = $SIZE_A bytes"
+echo "size   B = $SIZE_B bytes"
+
+echo
+echo "reload latency (set A -> first sample of A): ${RELOAD_LATENCY_MS} ms"
+echo "CP E2E DEMO: PASS — see $WAV_A and $WAV_B"


### PR DESCRIPTION
## What

Follow-up to #41 (cp-core substrate). Lands the **two blockers** that prevented `keysynth --cp` from being verified end-to-end on a machine with no MIDI hardware, plus a captured live demonstration of the slot-swap behaviour the substrate was built for.

## The fixes

1. **`--engine live` was missing from the CLI parser.** The `Engine::Live` variant existed (#40 voice hot-reload) but was unreachable from the command line. Added `"live" => Engine::Live` to `parse_args` and surfaced it in `--help`.
2. **MIDI was mandatory.** `keysynth` hard-errored on `ports.is_empty()`, which killed every container / CI / no-keyboard-attached invocation — including the test environment for #41. Now: empty port list logs `keysynth: no MIDI input — running CP / PC keyboard only` and continues to audio + CP setup. `chosen_port` is `Option<MidiInputPort>`, `_conn` is `Option<MidiInputConnection<()>>`, `ui::AppContext.midi_conn` is `Option<...>` to match. An explicit `--port "Name"` mismatch still hard-errors so typos cannot silently fall back.

## E2E demonstration

`tests/cp_e2e_demo.sh` is a POSIX bash script (runs in MSYS / git-bash on Windows) that:

1. spawns `keysynth --engine live --cp` in the background,
2. polls `ksctl status` until the CP server is up (30 s timeout),
3. `ksctl build --slot A --src voices_live` → `ksctl set A` → `ksctl render`,
4. mutates `voices_live/src/lib.rs` (gain `0.6` → `0.3`),
5. `ksctl build --slot B --src voices_live` → `ksctl set B` → `ksctl render`,
6. asserts both WAVs exist and their sha256 differ,
7. restores the source, kills keysynth, prints `CP E2E DEMO: PASS`.

The hard rule from the brief is "live PASS line on the contributor's machine before the PR opens, no exceptions." Captured below.

## Captured run

WAV sha256 hashes (slot A vs slot B — different, as the gain mutation requires):

- A: `6dc56287908713270d56aa2aaebc80ced27291c6a09f1341ef7bad9df55ced83`
- B: `9244a48394d27436b658ae4ffd9f6e150d25dbd362448c3b24451d4046c30594`

Reload latency (`set A` → first rendered sample of A): **80 ms** (full `ksctl set` + `ksctl render` round trip including JSON-RPC, voice construction, 4-note arpeggio render, and FNV-1a fingerprint hashing).

`bench-out/cp-e2e/run.log` checked in:

```
spawning keysynth --engine live --cp ...
keysynth pid=63221
waiting for CP server on 127.0.0.1:5577 ...
CP server ready after 0s
active = default
slots  = 1
sr_hz  = 48000
status = loaded in 297 ms

=== slot A: build + render ===
slot A: built + loaded in 64 ms
dll: C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337969886486800.dll
slot A: ok
rendered 384000 frames (8.00 s) → bench-out/cp-e2e/cp_demo_a.wav
active slot:  A
fingerprint:  fnv1a64:50709f704312a319
set A -> first sample of A: 80 ms

=== mutating voices_live (gain 0.6 -> 0.3) for slot B ===

=== slot B: build + render ===
slot B: built + loaded in 275 ms
dll: C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337970401878400.dll
slot B: ok
rendered 384000 frames (8.00 s) → bench-out/cp-e2e/cp_demo_b.wav
active slot:  B
fingerprint:  fnv1a64:e68573da57ecb049
slot       active dll
A                 C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337969886486800.dll
B          *      C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337970401878400.dll
default           C:\Users\yuuji\AppData\Local\Temp\ks-cp-e2e\voices_live\target\debug\keysynth_voices_live-live-1777337970403443900.dll

=== assertions ===
sha256 A = 6dc56287908713270d56aa2aaebc80ced27291c6a09f1341ef7bad9df55ced83  (bench-out/cp-e2e/cp_demo_a.wav)
sha256 B = 9244a48394d27436b658ae4ffd9f6e150d25dbd362448c3b24451d4046c30594  (bench-out/cp-e2e/cp_demo_b.wav)
size   A = 768044 bytes
size   B = 768044 bytes

reload latency (set A -> first sample of A): 80 ms
CP E2E DEMO: PASS — see bench-out/cp-e2e/cp_demo_a.wav and bench-out/cp-e2e/cp_demo_b.wav
```

## Build sanity

- `cargo fmt --check` clean
- `cargo build --release --bin keysynth --bin ksctl` clean
- `cargo check --no-default-features --features web --target wasm32-unknown-unknown --bin keysynth-web` clean (MIDI-optional change does not regress the wasm32 path)

## Out of scope

- voices_live DSL improvements (per #40)
- web parity / Kira backend hot-reload
- CP authentication / network exposure (still local-pipe only)

## Citations

Substrate landed in #41. Voice hot-reload landed in #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)