### PR TITLE
feat(ui): expose CP slots in voice browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,13 @@ bench-out/cp-e2e/keysynth.stderr.log
 bench-out/voice-unify/*.wav
 bench-out/voice-unify/keysynth.stderr.log
 bench-out/voice-unify/reload_latency.tsv
+# CP-GUI bridge E2E demo log: tests/cp_gui_integration_e2e.sh writes
+# the captured PR evidence here. Whitelist the log; rendered WAVs and
+# verbose keysynth stderr stay local-only.
+!bench-out/cp-gui/
+!bench-out/cp-gui/run.log
+bench-out/cp-gui/*.wav
+bench-out/cp-gui/keysynth.stderr.log
 **/*.flac
 **/*.aif
 **/*.aiff

--- a/bench-out/cp-gui/run.log
+++ b/bench-out/cp-gui/run.log
@@ -1,0 +1,48 @@
+=== cp_gui_integration_e2e.sh starting at 2026-04-28T02:11:20Z ===
+TARGET_DIR    = F:\\rust-targets
+KEYSYNTH_BIN  = F:\\rust-targets/release/keysynth.exe
+KSCTL_BIN     = F:\\rust-targets/release/ksctl.exe
+
+=== spawn keysynth --engine live --cp (GUI process) ===
+keysynth pid=26442
+
+=== wait for CP server on 127.0.0.1:5597 ===
+CP server ready after 0s
+
+=== baseline ksctl list ===
+slot       active dll
+default    *      C:\Users\yuuji\AppData\Local\Temp\ks-voice-unify\voices_live\target\debug\keysynth_voices_live-live-1777342281620530300.dll
+
+=== step 1: ksctl build piano slot ===
+slot piano: built + loaded in 2147 ms
+dll: C:\Users\yuuji\AppData\Local\Temp\ks-voice-unify\voices_live/piano\target\debug\keysynth_voice_piano-live-1777342284376633000.dll
+
+=== step 2: ksctl list after build ===
+slot       active dll
+default    *      C:\Users\yuuji\AppData\Local\Temp\ks-voice-unify\voices_live\target\debug\keysynth_voices_live-live-1777342281620530300.dll
+piano             C:\Users\yuuji\AppData\Local\Temp\ks-voice-unify\voices_live/piano\target\debug\keysynth_voice_piano-live-1777342284376633000.dll
+OK: piano slot visible to GUI library refresh
+
+=== step 3: ksctl set piano + render ===
+slot piano: ok
+rendered 326400 frames (6.80 s) → bench-out/cp-gui/cpgui_piano.wav
+active slot:  piano
+fingerprint:  fnv1a64:28bd89f2dfb8272e
+
+=== step 4: ksctl set default + render ===
+slot default: ok
+rendered 336000 frames (7.00 s) → bench-out/cp-gui/cpgui_default.wav
+active slot:  default
+fingerprint:  fnv1a64:80731065b5d07f53
+
+=== step 5: ksctl unload piano ===
+slot piano: ok
+slot       active dll
+default    *      C:\Users\yuuji\AppData\Local\Temp\ks-voice-unify\voices_live\target\debug\keysynth_voices_live-live-1777342281620530300.dll
+OK: piano slot gone after ksctl unload
+
+=== assertions ===
+piano    sha256=4dca7eee69accb9698b1dc2a9c046df7174740c89a5a5bbc2db87f9e22feb479   size=652844   path=bench-out/cp-gui/cpgui_piano.wav
+default  sha256=59635265fc8559a95c6635a30d496b042ecd223fb9383dea1337f4dc571e3ba9 size=672044 path=bench-out/cp-gui/cpgui_default.wav
+
+CP-GUI BRIDGE PASS — see bench-out/cp-gui/

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -206,6 +206,23 @@ impl KeysynthApp {
         };
         self.library.active = idx;
 
+        // 0. CP-managed slot: route through the Reloader's active-slot
+        //    pointer so the next note_on resolves to the named cdylib.
+        //    Errors here are user-visible (slot was unloaded between
+        //    refresh and click) but non-fatal — we still flip the
+        //    engine to Live and let the silent fallback play out.
+        if slot.category == Category::CpSlot {
+            if let Some(reloader) = self.ctx.live_reloader.as_ref() {
+                if let Err(e) = reloader.set_active(&slot.label) {
+                    self.set_msg_err(format!("CP slot '{}' activate failed: {e}", slot.label));
+                } else {
+                    self.set_msg_ok(format!("CP slot '{}' active", slot.label));
+                }
+            } else {
+                self.set_msg_err("CP slot click ignored: live_reloader unavailable".to_string());
+            }
+        }
+
         // 1. Engine swap (cheap, just a write to LiveParams).
         {
             let mut lp = self.ctx.live.lock().unwrap();
@@ -353,6 +370,16 @@ const QWERTY_VELOCITY: u8 = 100;
 impl eframe::App for KeysynthApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         ctx.request_repaint_after(Duration::from_millis(16));
+
+        // Sync CP-managed slots into the voice browser. Cheap: one
+        // Mutex acquire on the slot map + a HashSet diff. The browser
+        // is rendered later in this frame, so the user sees a
+        // freshly-loaded `ksctl build --slot X` entry within one
+        // repaint tick (~16 ms) of CP server confirming the build.
+        if let Some(reloader) = self.ctx.live_reloader.as_ref() {
+            let names: Vec<String> = reloader.list_slots().into_iter().map(|s| s.name).collect();
+            self.library.refresh_cp_slots(&names);
+        }
 
         // QWERTY → voice pool injection.
         let (engine, sr_hz) = {
@@ -630,6 +657,19 @@ impl eframe::App for KeysynthApp {
                                             }
                                         }
                                         Category::Synth => {}
+                                        // CP-managed slots: no per-category
+                                        // action button. Add / remove is
+                                        // ksctl's job; the GUI only renders
+                                        // what the Reloader pool advertises.
+                                        Category::CpSlot => {
+                                            ui.label(
+                                                egui::RichText::new(
+                                                    "Add via: ksctl build --slot <name> --src <crate>",
+                                                )
+                                                .small()
+                                                .color(egui::Color32::from_rgb(140, 140, 150)),
+                                            );
+                                        }
                                     }
                                 });
                         }

--- a/src/voice_lib.rs
+++ b/src/voice_lib.rs
@@ -24,6 +24,15 @@ pub enum Category {
     Piano,
     Synth,
     Custom,
+    /// CP-managed slot: a `voices_live/<name>/` cdylib that ksctl
+    /// (or any other CP client) has loaded into the running
+    /// `Reloader`'s slot pool. Entries in this category are
+    /// **dynamic** — `VoiceLibrary::refresh_cp_slots` syncs them
+    /// from `Reloader::list_slots()` on every frame, so adding
+    /// (`ksctl build`) or removing (`ksctl unload`) a slot
+    /// pops up / disappears from the browser without a GUI
+    /// restart.
+    CpSlot,
 }
 
 impl Category {
@@ -32,10 +41,16 @@ impl Category {
             Category::Piano => "Piano",
             Category::Synth => "Other (synth)",
             Category::Custom => "Custom",
+            Category::CpSlot => "CP Slot",
         }
     }
 
-    pub const ALL: &'static [Category] = &[Category::Piano, Category::Synth, Category::Custom];
+    pub const ALL: &'static [Category] = &[
+        Category::Piano,
+        Category::Synth,
+        Category::Custom,
+        Category::CpSlot,
+    ];
 }
 
 /// One selectable voice in the browser.
@@ -143,6 +158,26 @@ impl VoiceSlot {
             // Custom category so it sits next to user-saved presets and
             // doesn't clutter the Piano family with a synth-style entry.
             category: Category::Custom,
+            engine: Engine::Live,
+            params: None,
+            asset_path: None,
+            sf_program: None,
+            sf_bank: None,
+            modal_physics: false,
+            builtin: true,
+        }
+    }
+
+    /// Construct a slot that targets a CP-managed `Reloader` slot
+    /// by name. `apply_slot` for these flips the engine to
+    /// `Engine::Live` and calls `reloader.set_active(name)` so
+    /// the next note_on routes through the named cdylib in the
+    /// pool. Always built-in (the user can't rename / remove a CP
+    /// slot through the GUI; that's `ksctl unload`'s job).
+    pub fn cp_slot(name: &str) -> Self {
+        Self {
+            label: name.to_string(),
+            category: Category::CpSlot,
             engine: Engine::Live,
             params: None,
             asset_path: None,
@@ -329,6 +364,92 @@ impl VoiceLibrary {
 
     pub fn active_slot(&self) -> Option<&VoiceSlot> {
         self.slots.get(self.active)
+    }
+
+    /// Sync `Category::CpSlot` browser entries against the live
+    /// `Reloader` slot pool surfaced by ksctl / CP clients.
+    ///
+    /// Native-only: the wasm32 / GitHub Pages build doesn't have a
+    /// `live_reload` module compiled in, so the CP browser category
+    /// is entirely a native concern.
+    #[cfg(feature = "native")]
+    ///
+    /// `cp_slot_names` should be the names returned by
+    /// `Reloader::list_slots()` (just the `name` fields). The watcher
+    /// "default" slot is ignored — that one already has a dedicated
+    /// "Live (hot edit)" Custom-category entry seeded by `builtins()`,
+    /// and shadowing it as a CP slot would let the user click two
+    /// different browser entries that ultimately do the same thing.
+    ///
+    /// Sync rules (idempotent — safe to call every frame):
+    ///   - For each name in `cp_slot_names` not already in the
+    ///     library as a `Category::CpSlot`: append a new
+    ///     `VoiceSlot::cp_slot(name)`. Order: alphabetical by name,
+    ///     so `ksctl build` order doesn't influence the browser.
+    ///   - For each existing `Category::CpSlot` whose label is no
+    ///     longer in `cp_slot_names`: remove it. If the removed
+    ///     entry was active, the active index falls back to the
+    ///     last library slot — the GUI will then click any builtin
+    ///     to recover.
+    ///
+    /// Returns `(added, removed)` counts so the caller can log a
+    /// one-line "popped up: piano, gone: piano_modal" status.
+    pub fn refresh_cp_slots(&mut self, cp_slot_names: &[String]) -> (usize, usize) {
+        // Active-slot label, captured before mutation so we can
+        // re-derive the index after add/remove churn (indices shift).
+        let active_label = self.slots.get(self.active).map(|s| s.label.clone());
+
+        // Names to display, sorted, dedup, default filtered.
+        let mut wanted: Vec<String> = cp_slot_names
+            .iter()
+            .filter(|n| n.as_str() != crate::live_reload::DEFAULT_SLOT)
+            .cloned()
+            .collect();
+        wanted.sort();
+        wanted.dedup();
+
+        // What's currently on display.
+        let existing: std::collections::HashSet<String> = self
+            .slots
+            .iter()
+            .filter(|s| s.category == Category::CpSlot)
+            .map(|s| s.label.clone())
+            .collect();
+        let wanted_set: std::collections::HashSet<String> = wanted.iter().cloned().collect();
+
+        // Drop stale CP entries.
+        let before = self.slots.len();
+        self.slots
+            .retain(|s| s.category != Category::CpSlot || wanted_set.contains(&s.label));
+        let removed = before - self.slots.len();
+
+        // Append fresh CP entries (sorted) at the end so they cluster
+        // under the CpSlot collapsing header. The browser already
+        // groups by category at render time, so positional order
+        // inside `slots` only matters for stable hashing/test asserts.
+        let mut added = 0;
+        for name in &wanted {
+            if !existing.contains(name) {
+                self.slots.push(VoiceSlot::cp_slot(name));
+                added += 1;
+            }
+        }
+
+        // Restore the active index by label match. If the previously
+        // active slot was removed (CP unload of the active slot),
+        // clamp to a valid index.
+        if let Some(label) = active_label {
+            self.active = self
+                .slots
+                .iter()
+                .position(|s| s.label == label)
+                .unwrap_or(0);
+        }
+        if self.active >= self.slots.len() {
+            self.active = self.slots.len().saturating_sub(1);
+        }
+
+        (added, removed)
     }
 }
 

--- a/tests/cp_gui_integration_e2e.sh
+++ b/tests/cp_gui_integration_e2e.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# CP <-> GUI voice browser bridge E2E.
+#
+# Proves that a CP-managed slot added via ksctl is reachable through
+# the same audio path the GUI's voice-browser click would use:
+#
+#   1. Spawn `keysynth --engine live --cp` (the GUI process; a window
+#      opens but we never click anything — the app's update() loop
+#      runs `library.refresh_cp_slots(&reloader.list_slots())` every
+#      frame, which is the in-process state the tests/cp_gui_voice_lib
+#      Rust test asserts on).
+#   2. ksctl build --slot piano --src voices_live/piano    → loads
+#      the cdylib into the Reloader pool.
+#   3. ksctl list                                          → ksctl
+#      surfaces the same `Reloader::list_slots()` the GUI's library
+#      refresh reads from.
+#   4. ksctl set piano + render                            → audio
+#      path: render → make_voice(Engine::Live) → reloader.make_voice
+#      → active slot (piano cdylib) → Tier 1 PianoVoice. This is the
+#      exact path the GUI's apply_slot for a Category::CpSlot triggers
+#      (engine = Live + reloader.set_active(name)).
+#   5. ksctl set default + render                          → swap to
+#      the watcher's toy-sine slot, render again, expect different
+#      sha256.
+#   6. ksctl unload piano                                  → CP slot
+#      gone; ksctl list confirms. The GUI's next frame would also
+#      drop the browser entry via refresh_cp_slots.
+#
+# PASS gate is the literal "CP-GUI BRIDGE PASS" line at the bottom.
+#
+# Run from worktree root:
+#   bash tests/cp_gui_integration_e2e.sh
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || { echo "FATAL: cannot cd to repo root"; exit 1; }
+
+OUT_DIR="bench-out/cp-gui"
+mkdir -p "$OUT_DIR"
+RUN_LOG="$OUT_DIR/run.log"
+WAV_PIANO="$OUT_DIR/cpgui_piano.wav"
+WAV_DEFAULT="$OUT_DIR/cpgui_default.wav"
+KS_LOG="$OUT_DIR/keysynth.stderr.log"
+PORT=5597  # distinct from cp_e2e (5577) and voice_unify (5587)
+ENDPOINT="127.0.0.1:$PORT"
+
+rm -f "$WAV_PIANO" "$WAV_DEFAULT" "$KS_LOG" "$RUN_LOG"
+
+exec > >(tee -a "$RUN_LOG") 2>&1
+
+echo "=== cp_gui_integration_e2e.sh starting at $(date -u +%FT%TZ) ==="
+
+TARGET_DIR=$(cargo metadata --no-deps --format-version 1 2>/dev/null \
+  | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p' | head -n1)
+if [ -z "$TARGET_DIR" ]; then
+    TARGET_DIR="$ROOT/target"
+fi
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) EXE_SUFFIX=".exe" ;;
+    *) EXE_SUFFIX="" ;;
+esac
+KEYSYNTH_BIN="$TARGET_DIR/release/keysynth$EXE_SUFFIX"
+KSCTL_BIN="$TARGET_DIR/release/ksctl$EXE_SUFFIX"
+
+echo "TARGET_DIR    = $TARGET_DIR"
+echo "KEYSYNTH_BIN  = $KEYSYNTH_BIN"
+echo "KSCTL_BIN     = $KSCTL_BIN"
+
+if [ ! -f "$KEYSYNTH_BIN" ] || [ ! -f "$KSCTL_BIN" ]; then
+    echo "FATAL: keysynth/ksctl binaries missing — run: cargo build --release --bin keysynth --bin ksctl"
+    exit 1
+fi
+
+KS_PID=""
+cleanup() {
+    local rc=$?
+    if [ -n "$KS_PID" ]; then
+        kill "$KS_PID" 2>/dev/null
+        sleep 1
+        kill -KILL "$KS_PID" 2>/dev/null
+        if command -v taskkill >/dev/null 2>&1; then
+            taskkill //F //PID "$KS_PID" >/dev/null 2>&1 || true
+        fi
+        wait "$KS_PID" 2>/dev/null || true
+    fi
+    return $rc
+}
+trap cleanup EXIT INT TERM
+
+echo
+echo "=== spawn keysynth --engine live --cp (GUI process) ==="
+KEYSYNTH_CP="$ENDPOINT" "$KEYSYNTH_BIN" --engine live --cp \
+    --cp-endpoint "$ENDPOINT" >"$KS_LOG" 2>&1 &
+KS_PID=$!
+echo "keysynth pid=$KS_PID"
+
+echo
+echo "=== wait for CP server on $ENDPOINT ==="
+WAITED=0
+DEADLINE=30
+READY=0
+while [ "$WAITED" -lt "$DEADLINE" ]; do
+    if "$KSCTL_BIN" --endpoint "$ENDPOINT" status >/dev/null 2>&1; then
+        READY=1
+        break
+    fi
+    if ! kill -0 "$KS_PID" 2>/dev/null; then
+        echo "FATAL: keysynth died during startup; tail of $KS_LOG:"
+        tail -n 40 "$KS_LOG" || true
+        exit 1
+    fi
+    sleep 1
+    WAITED=$((WAITED + 1))
+done
+if [ "$READY" -ne 1 ]; then
+    echo "FATAL: CP server did not come up within ${DEADLINE}s"
+    exit 1
+fi
+echo "CP server ready after ${WAITED}s"
+
+# --- baseline list ----------------------------------------------------
+echo
+echo "=== baseline ksctl list ==="
+"$KSCTL_BIN" --endpoint "$ENDPOINT" list
+
+# --- step 1: ksctl build piano slot ----------------------------------
+echo
+echo "=== step 1: ksctl build piano slot ==="
+"$KSCTL_BIN" --endpoint "$ENDPOINT" build --slot piano --src voices_live/piano \
+    || { echo "FATAL: build piano failed"; exit 1; }
+
+# --- step 2: assert piano shows in list ------------------------------
+#
+# The same `Reloader::list_slots()` that this RPC reads is what
+# `KeysynthApp::update()` calls every frame to refresh the browser's
+# Category::CpSlot section. So if `ksctl list` sees piano, the GUI
+# library would too on its next repaint tick.
+echo
+echo "=== step 2: ksctl list after build ==="
+LIST_OUT=$("$KSCTL_BIN" --endpoint "$ENDPOINT" list)
+echo "$LIST_OUT"
+if ! echo "$LIST_OUT" | grep -qE '(^|[[:space:]])piano([[:space:]]|$)'; then
+    echo "FATAL: piano slot did not appear in ksctl list — CP-GUI bridge broken at the data source"
+    exit 1
+fi
+echo "OK: piano slot visible to GUI library refresh"
+
+# --- step 3: render through CP slot ----------------------------------
+#
+# `ksctl set piano` flips the Reloader's active-slot pointer — the
+# exact same call the GUI's apply_slot for Category::CpSlot makes:
+#
+#     reloader.set_active(&slot.label)
+#
+# So a render right after `set` exercises the CP-slot audio path the
+# GUI click would have triggered.
+echo
+echo "=== step 3: ksctl set piano + render ==="
+"$KSCTL_BIN" --endpoint "$ENDPOINT" set piano \
+    || { echo "FATAL: set piano failed"; exit 1; }
+"$KSCTL_BIN" --endpoint "$ENDPOINT" render \
+    --notes 60,64,67,72 --duration 5.0 --out "$WAV_PIANO" \
+    || { echo "FATAL: render piano failed"; exit 1; }
+
+# --- step 4: swap to default + render --------------------------------
+echo
+echo "=== step 4: ksctl set default + render ==="
+"$KSCTL_BIN" --endpoint "$ENDPOINT" set default \
+    || { echo "FATAL: set default failed"; exit 1; }
+"$KSCTL_BIN" --endpoint "$ENDPOINT" render \
+    --notes 60,64,67,72 --duration 5.0 --out "$WAV_DEFAULT" \
+    || { echo "FATAL: render default failed"; exit 1; }
+
+# --- step 5: ksctl unload + assert it's gone -------------------------
+echo
+echo "=== step 5: ksctl unload piano ==="
+"$KSCTL_BIN" --endpoint "$ENDPOINT" unload --slot piano \
+    || { echo "FATAL: unload piano failed"; exit 1; }
+LIST_AFTER_UNLOAD=$("$KSCTL_BIN" --endpoint "$ENDPOINT" list)
+echo "$LIST_AFTER_UNLOAD"
+if echo "$LIST_AFTER_UNLOAD" | grep -qE '(^|[[:space:]])piano([[:space:]]|$)'; then
+    echo "FATAL: piano slot still visible after unload"
+    exit 1
+fi
+echo "OK: piano slot gone after ksctl unload"
+
+# --- assertions -------------------------------------------------------
+echo
+echo "=== assertions ==="
+sha_for() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        echo "(no-sha256-binary)"
+    fi
+}
+
+[ -s "$WAV_PIANO" ]   || { echo "FATAL: $WAV_PIANO missing/empty"; exit 1; }
+[ -s "$WAV_DEFAULT" ] || { echo "FATAL: $WAV_DEFAULT missing/empty"; exit 1; }
+
+SHA_PIANO=$(sha_for "$WAV_PIANO")
+SHA_DEFAULT=$(sha_for "$WAV_DEFAULT")
+SIZE_PIANO=$(wc -c < "$WAV_PIANO")
+SIZE_DEFAULT=$(wc -c < "$WAV_DEFAULT")
+echo "piano    sha256=$SHA_PIANO   size=$SIZE_PIANO   path=$WAV_PIANO"
+echo "default  sha256=$SHA_DEFAULT size=$SIZE_DEFAULT path=$WAV_DEFAULT"
+
+if [ "$SHA_PIANO" = "$SHA_DEFAULT" ]; then
+    echo "FATAL: piano and default WAV sha256 are identical — slot swap had no audible effect"
+    exit 1
+fi
+
+echo
+echo "CP-GUI BRIDGE PASS — see $OUT_DIR/"

--- a/tests/cp_gui_voice_lib.rs
+++ b/tests/cp_gui_voice_lib.rs
@@ -1,0 +1,137 @@
+//! Voice browser <-> CP slot pool synchronisation regression.
+//!
+//! Asserts that `VoiceLibrary::refresh_cp_slots` produces the
+//! browser state the CP-GUI bridge promises:
+//!
+//!   1. ksctl build piano  → browser gets a "piano" entry under
+//!      `Category::CpSlot`, no other entries change.
+//!   2. ksctl unload piano → "piano" entry disappears.
+//!   3. The `default` watcher slot is filtered out (the browser
+//!      already has a "Live (hot edit)" Custom-category entry for
+//!      that one).
+//!   4. Calling refresh repeatedly with the same input is
+//!      idempotent — slot count stays stable, active index doesn't
+//!      drift.
+//!   5. If the active slot is unloaded, the active index falls
+//!      back gracefully without panicking.
+//!
+//! GUI rendering itself isn't testable here (eframe needs a
+//! windowing context), but every state change the browser would
+//! display flows through `VoiceLibrary::slots`, which IS testable.
+//! That's the boundary the brief calls out: "library.slots の中身
+//! を assert で確認すれば足りる".
+
+#![cfg(feature = "native")]
+
+use keysynth::synth::Engine;
+use keysynth::voice_lib::{Category, VoiceLibrary, VoiceSlot};
+
+fn names_in_category(lib: &VoiceLibrary, cat: Category) -> Vec<String> {
+    lib.slots
+        .iter()
+        .filter(|s| s.category == cat)
+        .map(|s| s.label.clone())
+        .collect()
+}
+
+fn fresh_library() -> VoiceLibrary {
+    // Builtins only; no persisted user entries (HOME-relative load
+    // would pull in dev-machine state we don't want in a regression).
+    VoiceLibrary {
+        slots: VoiceLibrary::load(None, None, Engine::Square).slots,
+        active: 0,
+    }
+}
+
+#[test]
+fn cp_slot_appears_when_reloader_reports_one() {
+    let mut lib = fresh_library();
+    let before = lib.slots.len();
+    assert!(
+        names_in_category(&lib, Category::CpSlot).is_empty(),
+        "fresh library should have zero CP slots"
+    );
+
+    let names = vec!["piano".to_string()];
+    let (added, removed) = lib.refresh_cp_slots(&names);
+    assert_eq!((added, removed), (1, 0));
+    let cp = names_in_category(&lib, Category::CpSlot);
+    assert_eq!(cp, vec!["piano".to_string()]);
+    // Builtins must be preserved.
+    assert_eq!(lib.slots.len(), before + 1);
+}
+
+#[test]
+fn cp_slot_disappears_when_unloaded() {
+    let mut lib = fresh_library();
+    let _ = lib.refresh_cp_slots(&["piano".to_string()]);
+    assert_eq!(names_in_category(&lib, Category::CpSlot).len(), 1);
+
+    let (added, removed) = lib.refresh_cp_slots(&[]);
+    assert_eq!((added, removed), (0, 1));
+    assert!(names_in_category(&lib, Category::CpSlot).is_empty());
+}
+
+#[test]
+fn default_watcher_slot_is_filtered() {
+    // The watcher's own DEFAULT_SLOT shows up in Reloader::list_slots()
+    // alongside CP-loaded slots, but the browser already has a "Live
+    // (hot edit)" Custom entry for it. refresh_cp_slots must not
+    // duplicate it.
+    let mut lib = fresh_library();
+    let names = vec!["default".to_string(), "piano".to_string()];
+    let (added, _) = lib.refresh_cp_slots(&names);
+    assert_eq!(added, 1, "only piano should be added; default is filtered");
+    let cp = names_in_category(&lib, Category::CpSlot);
+    assert_eq!(cp, vec!["piano".to_string()]);
+}
+
+#[test]
+fn refresh_is_idempotent() {
+    let mut lib = fresh_library();
+    let names = vec!["piano".to_string(), "piano_modal".to_string()];
+    lib.refresh_cp_slots(&names);
+    let snapshot: Vec<String> = lib.slots.iter().map(|s| s.label.clone()).collect();
+    let active = lib.active;
+
+    // Repeating with the same input must not change anything.
+    let (added, removed) = lib.refresh_cp_slots(&names);
+    assert_eq!((added, removed), (0, 0));
+    let after: Vec<String> = lib.slots.iter().map(|s| s.label.clone()).collect();
+    assert_eq!(snapshot, after);
+    assert_eq!(active, lib.active);
+}
+
+#[test]
+fn unloading_active_cp_slot_clamps_active_index() {
+    let mut lib = fresh_library();
+    lib.refresh_cp_slots(&["piano".to_string(), "piano_modal".to_string()]);
+    let piano_idx = lib
+        .slots
+        .iter()
+        .position(|s| s.category == Category::CpSlot && s.label == "piano")
+        .unwrap();
+    lib.active = piano_idx;
+
+    // Unload piano. Active was pointing at it; expect a graceful
+    // fallback without panic.
+    lib.refresh_cp_slots(&["piano_modal".to_string()]);
+    assert!(lib.active < lib.slots.len(), "active index out of bounds");
+    let names: Vec<String> = lib.slots.iter().map(|s| s.label.clone()).collect();
+    assert!(
+        !names.iter().any(|n| n == "piano"),
+        "stale piano entry survived unload: {names:?}"
+    );
+}
+
+#[test]
+fn cp_slot_constructor_targets_engine_live() {
+    let s = VoiceSlot::cp_slot("piano_thick");
+    assert_eq!(s.category, Category::CpSlot);
+    assert_eq!(s.engine, Engine::Live);
+    assert_eq!(s.label, "piano_thick");
+    assert!(
+        s.builtin,
+        "CP slots must be marked builtin (no rename / remove via GUI)"
+    );
+}


### PR DESCRIPTION
## Summary

CP-managed slots (added via `ksctl build --slot <name> --src <crate>`) now appear live in the GUI's voice browser under a new **CP Slot** category, clickable to swap timbres without restart, and disappear when `ksctl unload`'d. Closes the loop the brief calls out: outside-driven slot edits → in-GUI visible voice → click → audible.

> Stacks on #46 (`claude/voice-plugin-migration`). Base = that branch so the diff shows only the bridge work; merge order = #46 first, then this PR.

## Why

PR #46 made it possible to ksctl-build a Tier 1 piano cdylib from outside, but the GUI's voice browser was static — the user had to know which `Engine::Live` slot was active and trust the audio. After this PR:

```
keysynth --engine live --cp        # GUI window opens
# (separate terminal)
ksctl build --slot piano --src voices_live/piano
# → next GUI repaint tick (~16 ms): "piano" pops up in left browser under "CP Slot"
# → click "piano" → that timbre plays
ksctl unload --slot piano
# → next repaint: "piano" disappears
```

## Design

- **`Category::CpSlot`** — new fourth voice-browser category (Piano / Synth / Custom / **CP Slot**). `Category::ALL` extended; existing builtin slots untouched.
- **`VoiceSlot::cp_slot(name)`** — constructor for a CP-managed slot. Always `builtin = true` (the user can't rename / remove via the GUI; that's `ksctl unload`'s job). Engine = `Engine::Live`.
- **`VoiceLibrary::refresh_cp_slots(&[String])`** — sync method called every frame from `KeysynthApp::update`. Idempotent. Filters the watcher's `default` slot (already represented by the existing "Live (hot edit)" Custom entry, would otherwise duplicate). Clamps the active index gracefully if the active CP slot is unloaded out from under the user.
- **`apply_slot` for `Category::CpSlot`** — flips `Engine::Live` and calls `reloader.set_active(name)`. The `live_reload` / `cp-core` / `voices_live` / `src/cp.rs` surfaces are untouched; this PR only consumes existing public APIs (`Reloader::list_slots`, `Reloader::set_active`).

## Hard gate (PR-blocking tests)

### 1. Library sync regression — `tests/cp_gui_voice_lib.rs`

Pure-Rust integration test. GUI rendering itself isn't testable without an eframe context, but every state change the browser would display flows through `VoiceLibrary::slots`, which is. Per the brief: "library.slots の中身を assert で確認すれば足りる".

```
$ cargo test --test cp_gui_voice_lib

running 6 tests
test cp_slot_constructor_targets_engine_live ... ok
test cp_slot_appears_when_reloader_reports_one ... ok
test default_watcher_slot_is_filtered ... ok
test cp_slot_disappears_when_unloaded ... ok
test unloading_active_cp_slot_clamps_active_index ... ok
test refresh_is_idempotent ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Covers: appears on build / disappears on unload / `default` filtered / idempotent on re-call / active-index clamps when active slot is unloaded / constructor targets `Engine::Live`.

### 2. End-to-end audio swap — `tests/cp_gui_integration_e2e.sh`

PASS gate is the literal `CP-GUI BRIDGE PASS` line. Captured run committed at `bench-out/cp-gui/run.log`:

```
=== spawn keysynth --engine live --cp (GUI process) ===
keysynth pid=26442
=== wait for CP server on 127.0.0.1:5597 ===
CP server ready after 0s

=== baseline ksctl list ===
slot       active dll
default    *      ...keysynth_voices_live-live-1777342281620530300.dll

=== step 1: ksctl build piano slot ===
slot piano: built + loaded in 2147 ms

=== step 2: ksctl list after build ===
slot       active dll
default    *      ...keysynth_voices_live-live-1777342281620530300.dll
piano             ...keysynth_voice_piano-live-1777342284376633000.dll
OK: piano slot visible to GUI library refresh

=== step 3: ksctl set piano + render ===
slot piano: ok
rendered 326400 frames (6.80 s) → bench-out/cp-gui/cpgui_piano.wav
active slot:  piano

=== step 4: ksctl set default + render ===
slot default: ok
rendered 336000 frames (7.00 s) → bench-out/cp-gui/cpgui_default.wav
active slot:  default

=== step 5: ksctl unload piano ===
slot piano: ok
slot       active dll
default    *      ...keysynth_voices_live-live-1777342281620530300.dll
OK: piano slot gone after ksctl unload

=== assertions ===
piano    sha256=4dca7eee69accb9698b1dc2a9c046df7174740c89a5a5bbc2db87f9e22feb479   size=652844
default  sha256=59635265fc8559a95c6635a30d496b042ecd223fb9383dea1337f4dc571e3ba9   size=672044

CP-GUI BRIDGE PASS — see bench-out/cp-gui/
```

The shell script drives the same RPC surface (`Reloader::list_slots`, `Reloader::set_active`) that the GUI's per-frame `library.refresh_cp_slots` and click-driven `apply_slot` consume. So the audio swap proven here is the same path a GUI user would hit by clicking the CP Slot entry.

## Hard rules verified

- [x] `cargo fmt --check` clean
- [x] `cargo check --bin keysynth --bin ksctl` clean
- [x] `cargo check --no-default-features --features web --target wasm32-unknown-unknown --bin keysynth-web` clean (`refresh_cp_slots` gated on `feature = "native"`)
- [x] `cargo test --test cp_gui_voice_lib` (6/6 PASS)
- [x] `bash tests/cp_gui_integration_e2e.sh` (CP-GUI BRIDGE PASS line emitted; log committed)

## Untouched (per brief)

- `cp-core/`
- `src/live_reload.rs`
- `voices_live/<name>/` cdylib sources
- `src/cp.rs`
- `audio_kira.rs`
- Tier 1 voice DSP sources (`hammer_stulov.rs`, `string_inharmonicity.rs`, `longitudinal.rs`, `piano.rs`, `piano_modal.rs`, `piano_5am.rs`)
- Existing builtin voice browser entries (Piano family, Synth, Custom) — additive only

## Files

| Path | Purpose |
|---|---|
| `src/voice_lib.rs` | `Category::CpSlot`, `VoiceSlot::cp_slot`, `VoiceLibrary::refresh_cp_slots` |
| `src/ui.rs` | Per-frame refresh in `update`; `apply_slot` Category::CpSlot routing; CP Slot collapsing-header hint string |
| `tests/cp_gui_voice_lib.rs` | 6 Rust regression tests for the sync semantics |
| `tests/cp_gui_integration_e2e.sh` | End-to-end CP build → list → set → render → unload demo |
| `bench-out/cp-gui/run.log` | Captured local E2E run for PR evidence |
| `.gitignore` | Whitelist `bench-out/cp-gui/run.log` |

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --bin keysynth --bin ksctl`
- [x] `cargo check --no-default-features --features web --target wasm32-unknown-unknown --bin keysynth-web`
- [x] `cargo test --test cp_gui_voice_lib` (6/6)
- [x] `bash tests/cp_gui_integration_e2e.sh` (PASS line emitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
