### PR TITLE
feat(kssong): chord progression DSL CLI for one-line song rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,11 @@ name = "render_midi"
 path = "src/bin/render_midi.rs"
 required-features = ["native"]
 
+[[bin]]
+name = "kssong"
+path = "src/bin/kssong.rs"
+required-features = ["native"]
+
 # render_chiptune binary: parse a chiptune-lab song JSON and render it.
 [[bin]]
 name = "render_chiptune"

--- a/src/bin/kssong.rs
+++ b/src/bin/kssong.rs
@@ -1,0 +1,374 @@
+use std::path::PathBuf;
+
+use midly::num::{u15, u24, u28, u4, u7};
+use midly::{Format, Header, MetaMessage, MidiMessage, Smf, Timing, TrackEvent, TrackEventKind};
+
+use keysynth::song::{parse_progression_with_key, Chord, Key};
+use keysynth::synth::{midi_to_freq, Engine, VoiceImpl};
+use keysynth::voices::guitar::GuitarVoice;
+
+#[allow(dead_code, deprecated)]
+#[path = "render_midi.rs"]
+mod render_midi_impl;
+
+const PPQ: u16 = 480;
+const BEATS_PER_BAR: u32 = 4;
+const DEFAULT_BPM: u32 = 120;
+const DEFAULT_VELOCITY: u8 = 90;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum VoiceChoice {
+    Engine(Engine),
+    Guitar,
+}
+
+impl VoiceChoice {
+    fn parse(input: &str) -> Result<Self, String> {
+        match input {
+            "square" => Ok(Self::Engine(Engine::Square)),
+            "ks" => Ok(Self::Engine(Engine::Ks)),
+            "ks-rich" => Ok(Self::Engine(Engine::KsRich)),
+            "sub" => Ok(Self::Engine(Engine::Sub)),
+            "fm" => Ok(Self::Engine(Engine::Fm)),
+            "piano" => Ok(Self::Engine(Engine::Piano)),
+            "piano-thick" => Ok(Self::Engine(Engine::PianoThick)),
+            "piano-lite" => Ok(Self::Engine(Engine::PianoLite)),
+            "piano-5am" => Ok(Self::Engine(Engine::Piano5AM)),
+            "piano-modal" => Ok(Self::Engine(Engine::PianoModal)),
+            "koto" => Ok(Self::Engine(Engine::Koto)),
+            "sf-piano" => Ok(Self::Engine(Engine::SfPiano)),
+            "sfz-piano" => Ok(Self::Engine(Engine::SfzPiano)),
+            "guitar" => Ok(Self::Guitar),
+            other => Err(format!(
+                "unknown --voice: {other} (piano|piano-modal|piano-thick|piano-lite|piano-5am|guitar|square|ks|ks-rich|fm|sub|koto|sf-piano|sfz-piano)"
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PlayArgs {
+    progression: String,
+    voice: VoiceChoice,
+    bpm: u32,
+    bars: Option<usize>,
+    key: Option<Key>,
+    out_path: PathBuf,
+    sfz_path: Option<PathBuf>,
+    modal_lut_path: Option<PathBuf>,
+}
+
+fn print_help() {
+    eprintln!(
+        "kssong - one-line chord progression renderer\n\n\
+         usage:\n  \
+         kssong play \"C - G - Am - F\" --voice piano --bpm 120 --out out.wav\n\n\
+         play options:\n  \
+         --voice NAME      piano|piano-modal|piano-thick|piano-lite|piano-5am|guitar|square|ks|ks-rich|fm|sub|koto|sf-piano|sfz-piano\n  \
+         --bpm N           tempo in beats per minute (default 120)\n  \
+         --bars N          total bars to render; repeats/truncates progression to fit\n  \
+         --key KEY         base key for roman numerals (example: C, F#, Bb)\n  \
+         --sfz PATH        required when --voice sfz-piano\n  \
+         --modal-lut PATH  optional modal LUT override for piano-modal\n  \
+         --out PATH        output WAV path (required)"
+    );
+}
+
+fn parse_args() -> Result<PlayArgs, String> {
+    let mut iter = std::env::args().skip(1);
+    let Some(subcommand) = iter.next() else {
+        print_help();
+        return Err("missing subcommand".to_string());
+    };
+
+    if matches!(subcommand.as_str(), "--help" | "-h") {
+        print_help();
+        std::process::exit(0);
+    }
+
+    if subcommand != "play" {
+        return Err(format!("unknown subcommand: {subcommand}"));
+    }
+
+    let progression = iter
+        .next()
+        .ok_or_else(|| "play requires a chord progression string".to_string())?;
+    let mut voice = VoiceChoice::Engine(Engine::Piano);
+    let mut bpm = DEFAULT_BPM;
+    let mut bars = None;
+    let mut key = None;
+    let mut out_path: Option<PathBuf> = None;
+    let mut sfz_path = None;
+    let mut modal_lut_path = None;
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--voice" | "--engine" => {
+                let value = iter.next().ok_or("--voice needs a value")?;
+                voice = VoiceChoice::parse(&value)?;
+            }
+            "--bpm" => {
+                bpm = iter
+                    .next()
+                    .ok_or("--bpm needs a value")?
+                    .parse()
+                    .map_err(|e| format!("bad --bpm: {e}"))?;
+                if bpm == 0 {
+                    return Err("--bpm must be > 0".to_string());
+                }
+            }
+            "--bars" => {
+                let value: usize = iter
+                    .next()
+                    .ok_or("--bars needs a value")?
+                    .parse()
+                    .map_err(|e| format!("bad --bars: {e}"))?;
+                if value == 0 {
+                    return Err("--bars must be > 0".to_string());
+                }
+                bars = Some(value);
+            }
+            "--key" => {
+                let value = iter.next().ok_or("--key needs a value")?;
+                key = Some(Key::parse(&value).map_err(|e| format!("bad --key: {e}"))?);
+            }
+            "--out" => {
+                out_path = Some(PathBuf::from(iter.next().ok_or("--out needs a value")?));
+            }
+            "--sfz" => {
+                sfz_path = Some(PathBuf::from(iter.next().ok_or("--sfz needs a value")?));
+            }
+            "--modal-lut" => {
+                modal_lut_path = Some(PathBuf::from(
+                    iter.next().ok_or("--modal-lut needs a value")?,
+                ));
+            }
+            "--help" | "-h" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown arg: {other}")),
+        }
+    }
+
+    Ok(PlayArgs {
+        progression,
+        voice,
+        bpm,
+        bars,
+        key,
+        out_path: out_path.ok_or("--out is required")?,
+        sfz_path,
+        modal_lut_path,
+    })
+}
+
+fn expand_progression(chords: &[Chord], total_bars: usize) -> Vec<Chord> {
+    (0..total_bars)
+        .map(|bar| chords[bar % chords.len()].clone())
+        .collect()
+}
+
+fn build_smf_bytes(chords: &[Chord], bpm: u32) -> Result<Vec<u8>, String> {
+    #[derive(Clone, Copy)]
+    enum MidiKind {
+        NoteOff(u8),
+        NoteOn(u8),
+    }
+
+    let bar_ticks = BEATS_PER_BAR * PPQ as u32;
+    let mut timeline: Vec<(u32, MidiKind)> = Vec::new();
+    for (bar_idx, chord) in chords.iter().enumerate() {
+        let start_tick = bar_idx as u32 * bar_ticks;
+        let end_tick = start_tick + bar_ticks;
+        for note in chord.voice() {
+            timeline.push((end_tick, MidiKind::NoteOff(note)));
+            timeline.push((start_tick, MidiKind::NoteOn(note)));
+        }
+    }
+    timeline.sort_by_key(|(tick, kind)| {
+        let order = match kind {
+            MidiKind::NoteOff(_) => 0_u8,
+            MidiKind::NoteOn(_) => 1_u8,
+        };
+        (*tick, order)
+    });
+
+    let tempo_us_per_quarter = 60_000_000_u32 / bpm;
+    let header = Header {
+        format: Format::Parallel,
+        timing: Timing::Metrical(u15::new(PPQ)),
+    };
+
+    let tempo_track = vec![
+        TrackEvent {
+            delta: u28::new(0),
+            kind: TrackEventKind::Meta(MetaMessage::Tempo(u24::new(tempo_us_per_quarter))),
+        },
+        TrackEvent {
+            delta: u28::new(0),
+            kind: TrackEventKind::Meta(MetaMessage::EndOfTrack),
+        },
+    ];
+
+    let mut note_track: Vec<TrackEvent<'static>> = Vec::with_capacity(timeline.len() + 1);
+    let mut last_tick = 0_u32;
+    for (tick, kind) in timeline {
+        let delta = tick.saturating_sub(last_tick);
+        last_tick = tick;
+        let message = match kind {
+            MidiKind::NoteOn(note) => MidiMessage::NoteOn {
+                key: u7::new(note),
+                vel: u7::new(DEFAULT_VELOCITY),
+            },
+            MidiKind::NoteOff(note) => MidiMessage::NoteOff {
+                key: u7::new(note),
+                vel: u7::new(0),
+            },
+        };
+        note_track.push(TrackEvent {
+            delta: u28::new(delta),
+            kind: TrackEventKind::Midi {
+                channel: u4::new(0),
+                message,
+            },
+        });
+    }
+    note_track.push(TrackEvent {
+        delta: u28::new(0),
+        kind: TrackEventKind::Meta(MetaMessage::EndOfTrack),
+    });
+
+    let smf = Smf {
+        header,
+        tracks: vec![tempo_track, note_track],
+    };
+
+    let mut bytes = Vec::new();
+    smf.write_std(&mut bytes)
+        .map_err(|e| format!("midly write: {e}"))?;
+    Ok(bytes)
+}
+
+fn render_guitar(events: &[render_midi_impl::NoteEvent]) -> (Vec<f32>, Vec<f32>) {
+    let max_end = events
+        .iter()
+        .map(|event| event.start_sec + event.duration_sec)
+        .fold(0.0_f32, f32::max);
+    let total_sec = max_end + render_midi_impl::RELEASE_TAIL_SEC;
+    let total_samples = (total_sec * render_midi_impl::SR as f32) as usize;
+    let mut left = vec![0.0_f32; total_samples];
+    let mut right = vec![0.0_f32; total_samples];
+
+    const RELEASE_BUDGET_SEC: f32 = 1.5;
+    let release_budget_samples = (RELEASE_BUDGET_SEC * render_midi_impl::SR as f32) as usize;
+
+    for event in events {
+        let start_sample = (event.start_sec * render_midi_impl::SR as f32) as usize;
+        let release_sample =
+            ((event.start_sec + event.duration_sec) * render_midi_impl::SR as f32) as usize;
+        if start_sample >= total_samples {
+            continue;
+        }
+        let release_at = release_sample.saturating_sub(start_sample);
+        let voice_total = (release_at + release_budget_samples).min(total_samples - start_sample);
+        let mut voice_buf = vec![0.0_f32; voice_total];
+
+        let freq = midi_to_freq(event.midi_note);
+        let mut voice: Box<dyn VoiceImpl + Send> = Box::new(GuitarVoice::new(
+            render_midi_impl::SR as f32,
+            freq,
+            event.velocity,
+        ));
+        if release_at > 0 {
+            voice.render_add(&mut voice_buf[..release_at.min(voice_total)]);
+        }
+        voice.trigger_release();
+        if release_at < voice_total {
+            voice.render_add(&mut voice_buf[release_at..voice_total]);
+        }
+
+        let (left_gain, right_gain) = constant_power_pan(pan_for_note(event.midi_note));
+        for (idx, sample) in voice_buf.iter().enumerate() {
+            left[start_sample + idx] += *sample * left_gain;
+            right[start_sample + idx] += *sample * right_gain;
+        }
+    }
+
+    (left, right)
+}
+
+fn constant_power_pan(pan: f32) -> (f32, f32) {
+    let p = pan.clamp(-1.0, 1.0);
+    let theta = (p + 1.0) * std::f32::consts::FRAC_PI_4;
+    (theta.cos(), theta.sin())
+}
+
+fn pan_for_note(midi_note: u8) -> f32 {
+    const CENTRE: f32 = 60.0;
+    const SPAN: f32 = 36.0;
+    ((midi_note as f32 - CENTRE) / SPAN).clamp(-1.0, 1.0)
+}
+
+fn render_to_wav(args: &PlayArgs, midi_bytes: &[u8]) -> Result<(), String> {
+    let events = render_midi_impl::parse_smf(midi_bytes, 1.0)?;
+    let (left, right) = match args.voice {
+        VoiceChoice::Engine(Engine::SfzPiano) => {
+            let sfz_path = args
+                .sfz_path
+                .as_deref()
+                .ok_or("--sfz PATH is required when --voice sfz-piano")?;
+            render_midi_impl::render_sfz(sfz_path, &events)?
+        }
+        VoiceChoice::Engine(Engine::SfPiano) => {
+            return Err(
+                "sf-piano is live-only in keysynth; use sfz-piano or a synthesized engine"
+                    .to_string(),
+            );
+        }
+        VoiceChoice::Engine(engine) => {
+            render_midi_impl::render_keysynth(engine, &events, args.modal_lut_path.as_deref())
+        }
+        VoiceChoice::Guitar => render_guitar(&events),
+    };
+    render_midi_impl::write_wav_stereo(&args.out_path, &left, &right)
+}
+
+fn run_play(args: PlayArgs) -> Result<(), String> {
+    let chords = parse_progression_with_key(&args.progression, args.key)
+        .map_err(|e| format!("progression parse: {e}"))?;
+    let total_bars = args.bars.unwrap_or(chords.len());
+    let expanded = expand_progression(&chords, total_bars);
+    let midi_bytes = build_smf_bytes(&expanded, args.bpm)?;
+    render_to_wav(&args, &midi_bytes)?;
+    eprintln!(
+        "kssong: wrote {} (bars={} bpm={})",
+        args.out_path.display(),
+        total_bars,
+        args.bpm
+    );
+    Ok(())
+}
+
+fn main() {
+    #[cfg(target_arch = "x86_64")]
+    #[allow(deprecated)]
+    unsafe {
+        use std::arch::x86_64::{_mm_getcsr, _mm_setcsr};
+        let csr = _mm_getcsr();
+        _mm_setcsr(csr | 0x8040);
+    }
+
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("kssong: {err}");
+            std::process::exit(2);
+        }
+    };
+
+    if let Err(err) = run_play(args) {
+        eprintln!("kssong: {err}");
+        std::process::exit(2);
+    }
+}

--- a/src/bin/render_midi.rs
+++ b/src/bin/render_midi.rs
@@ -18,15 +18,15 @@ use midly::{MetaMessage, MidiMessage, Smf, Timing, TrackEventKind};
 use keysynth::sfz::SfzPlayer;
 use keysynth::synth::{make_voice, midi_to_freq, Engine, ModalLut, MODAL_LUT};
 
-const SR: u32 = 44100;
-const RELEASE_TAIL_SEC: f32 = 2.5;
+pub const SR: u32 = 44100;
+pub const RELEASE_TAIL_SEC: f32 = 2.5;
 
 #[derive(Clone, Copy, Debug)]
-struct NoteEvent {
-    start_sec: f32,
-    midi_note: u8,
-    duration_sec: f32,
-    velocity: u8,
+pub struct NoteEvent {
+    pub start_sec: f32,
+    pub midi_note: u8,
+    pub duration_sec: f32,
+    pub velocity: u8,
 }
 
 struct Args {
@@ -100,7 +100,7 @@ fn parse_args() -> Result<Args, String> {
 /// (note_on/note_off pairs collapsed into start_sec + duration_sec).
 /// Handles format-0 (single track) and format-1 (multi-track merged by
 /// absolute tick); tempo changes mid-piece are honoured.
-fn parse_smf(bytes: &[u8], tempo_scale: f32) -> Result<Vec<NoteEvent>, String> {
+pub fn parse_smf(bytes: &[u8], tempo_scale: f32) -> Result<Vec<NoteEvent>, String> {
     let smf = Smf::parse(bytes).map_err(|e| format!("midly parse: {e}"))?;
     let ppq: u32 = match smf.header.timing {
         Timing::Metrical(t) => t.as_int() as u32,
@@ -212,7 +212,7 @@ fn pan_for_note(midi_note: u8) -> f32 {
     ((midi_note as f32 - CENTRE) / SPAN).clamp(-1.0, 1.0)
 }
 
-fn render_keysynth(
+pub fn render_keysynth(
     engine: Engine,
     events: &[NoteEvent],
     modal_lut_path: Option<&std::path::Path>,
@@ -277,7 +277,7 @@ fn render_keysynth(
     (left, right)
 }
 
-fn render_sfz(
+pub fn render_sfz(
     sfz_path: &std::path::Path,
     events: &[NoteEvent],
 ) -> Result<(Vec<f32>, Vec<f32>), String> {
@@ -322,7 +322,7 @@ fn render_sfz(
     Ok((left, right))
 }
 
-fn write_wav_stereo(path: &std::path::Path, left: &[f32], right: &[f32]) -> Result<(), String> {
+pub fn write_wav_stereo(path: &std::path::Path, left: &[f32], right: &[f32]) -> Result<(), String> {
     if let Some(p) = path.parent() {
         std::fs::create_dir_all(p).map_err(|e| format!("create_dir_all: {e}"))?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod gm;
 pub mod live_abi;
 pub mod resample;
 pub mod reverb;
+pub mod song;
 pub mod soundboard;
 pub mod sympathetic;
 pub mod synth;

--- a/src/song/mod.rs
+++ b/src/song/mod.rs
@@ -1,0 +1,373 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct PitchClass(u8);
+
+impl PitchClass {
+    pub const C: Self = Self(0);
+    pub const C_SHARP: Self = Self(1);
+    pub const D: Self = Self(2);
+    pub const D_SHARP: Self = Self(3);
+    pub const E: Self = Self(4);
+    pub const F: Self = Self(5);
+    pub const F_SHARP: Self = Self(6);
+    pub const G: Self = Self(7);
+    pub const G_SHARP: Self = Self(8);
+    pub const A: Self = Self(9);
+    pub const A_SHARP: Self = Self(10);
+    pub const B: Self = Self(11);
+
+    pub fn new(value: u8) -> Self {
+        Self(value % 12)
+    }
+
+    pub fn as_u8(self) -> u8 {
+        self.0
+    }
+
+    pub fn canonical_name(self) -> &'static str {
+        match self.0 {
+            0 => "C",
+            1 => "C#",
+            2 => "D",
+            3 => "D#",
+            4 => "E",
+            5 => "F",
+            6 => "F#",
+            7 => "G",
+            8 => "G#",
+            9 => "A",
+            10 => "A#",
+            11 => "B",
+            _ => unreachable!("pitch class must be 0..12"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Key(PitchClass);
+
+impl Key {
+    pub const C: Self = Self(PitchClass::C);
+
+    pub fn new(tonic: PitchClass) -> Self {
+        Self(tonic)
+    }
+
+    pub fn tonic(self) -> PitchClass {
+        self.0
+    }
+
+    pub fn parse(input: &str) -> Result<Self, ParseError> {
+        let (pitch_class, rest) = parse_note_root(input.trim())?;
+        if !rest.is_empty() {
+            return Err(ParseError::new(format!(
+                "unexpected trailing characters in key '{}'",
+                input
+            )));
+        }
+        Ok(Self::new(pitch_class))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Quality {
+    Major,
+    Minor,
+    Major7,
+    Minor7,
+    Dominant7,
+    Diminished,
+    Augmented,
+    Sus2,
+    Sus4,
+}
+
+impl Quality {
+    pub fn suffix(self) -> &'static str {
+        match self {
+            Self::Major => "maj",
+            Self::Minor => "min",
+            Self::Major7 => "maj7",
+            Self::Minor7 => "min7",
+            Self::Dominant7 => "7",
+            Self::Diminished => "dim",
+            Self::Augmented => "aug",
+            Self::Sus2 => "sus2",
+            Self::Sus4 => "sus4",
+        }
+    }
+
+    pub fn intervals(self) -> &'static [u8] {
+        match self {
+            Self::Major => &[0, 4, 7, 12],
+            Self::Minor => &[0, 3, 7, 12],
+            Self::Major7 => &[0, 4, 7, 11, 12],
+            Self::Minor7 => &[0, 3, 7, 10, 12],
+            Self::Dominant7 => &[0, 4, 7, 10, 12],
+            Self::Diminished => &[0, 3, 6, 12],
+            Self::Augmented => &[0, 4, 8, 12],
+            Self::Sus2 => &[0, 2, 7, 12],
+            Self::Sus4 => &[0, 5, 7, 12],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Chord {
+    pub root: PitchClass,
+    pub quality: Quality,
+}
+
+impl Chord {
+    pub fn voice(&self) -> Vec<u8> {
+        let root_midi = centered_root_midi(self.root);
+        self.quality
+            .intervals()
+            .iter()
+            .map(|interval| root_midi + interval)
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParseError {
+    message: String,
+}
+
+impl ParseError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for ParseError {}
+
+pub fn parse_chord(input: &str) -> Result<Chord, ParseError> {
+    let token = input.trim();
+    if token.is_empty() {
+        return Err(ParseError::new("chord token is empty"));
+    }
+    if looks_like_roman_token(token) {
+        return Err(ParseError::new(format!(
+            "roman numeral '{}' requires parse_roman() or parse_progression_with_key()",
+            token
+        )));
+    }
+    let (root, rest) = parse_note_root(token)?;
+    let quality = parse_named_quality(rest)?;
+    Ok(Chord { root, quality })
+}
+
+pub fn parse_roman(input: &str, key: Key) -> Result<Chord, ParseError> {
+    let token = input.trim();
+    if token.is_empty() {
+        return Err(ParseError::new("roman numeral token is empty"));
+    }
+
+    let roman_len = token
+        .char_indices()
+        .take_while(|(_, ch)| matches!(*ch, 'I' | 'V' | 'i' | 'v'))
+        .last()
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .ok_or_else(|| ParseError::new(format!("invalid roman numeral '{}'", token)))?;
+
+    let roman_part = &token[..roman_len];
+    let degree = match roman_part.to_ascii_lowercase().as_str() {
+        "i" => 0,
+        "ii" => 2,
+        "iii" => 4,
+        "iv" => 5,
+        "v" => 7,
+        "vi" => 9,
+        "vii" => 11,
+        _ => {
+            return Err(ParseError::new(format!(
+                "unsupported roman numeral '{}'",
+                roman_part
+            )));
+        }
+    };
+
+    let mut rest = &token[roman_len..];
+    let mut default_quality = if roman_part.chars().all(|ch| ch.is_ascii_uppercase()) {
+        Quality::Major
+    } else if roman_part.chars().all(|ch| ch.is_ascii_lowercase()) {
+        Quality::Minor
+    } else {
+        return Err(ParseError::new(format!(
+            "roman numeral '{}' must use consistent case",
+            roman_part
+        )));
+    };
+
+    if let Some(stripped) = rest.strip_prefix('\u{00B0}') {
+        default_quality = Quality::Diminished;
+        rest = stripped;
+    }
+
+    let quality = parse_roman_quality(rest, default_quality)?;
+    Ok(Chord {
+        root: PitchClass::new(key.tonic().as_u8() + degree),
+        quality,
+    })
+}
+
+pub fn parse_progression(input: &str) -> Result<Vec<Chord>, ParseError> {
+    parse_progression_with_key(input, None)
+}
+
+pub fn parse_progression_with_key(input: &str, key: Option<Key>) -> Result<Vec<Chord>, ParseError> {
+    let tokens = split_progression_tokens(input);
+    if tokens.is_empty() {
+        return Err(ParseError::new("progression is empty"));
+    }
+
+    let mut chords = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        if looks_like_roman_token(token) {
+            let Some(key) = key else {
+                return Err(ParseError::new(format!(
+                    "roman numeral '{}' requires --key",
+                    token
+                )));
+            };
+            chords.push(parse_roman(token, key)?);
+        } else {
+            chords.push(parse_chord(token)?);
+        }
+    }
+    Ok(chords)
+}
+
+fn split_progression_tokens(input: &str) -> Vec<&str> {
+    let mut tokens = Vec::new();
+    let mut start: Option<usize> = None;
+
+    for (idx, ch) in input.char_indices() {
+        let is_separator = ch == '-' || ch == '|' || ch.is_whitespace();
+        if is_separator {
+            if let Some(token_start) = start.take() {
+                if token_start < idx {
+                    let token = input[token_start..idx].trim();
+                    if !token.is_empty() {
+                        tokens.push(token);
+                    }
+                }
+            }
+        } else if start.is_none() {
+            start = Some(idx);
+        }
+    }
+
+    if let Some(token_start) = start {
+        let token = input[token_start..].trim();
+        if !token.is_empty() {
+            tokens.push(token);
+        }
+    }
+
+    tokens
+}
+
+fn parse_note_root(input: &str) -> Result<(PitchClass, &str), ParseError> {
+    let mut chars = input.char_indices();
+    let (_, first) = chars
+        .next()
+        .ok_or_else(|| ParseError::new("note token is empty"))?;
+
+    let base = match first.to_ascii_uppercase() {
+        'A' => 9_i16,
+        'B' => 11,
+        'C' => 0,
+        'D' => 2,
+        'E' => 4,
+        'F' => 5,
+        'G' => 7,
+        other => {
+            return Err(ParseError::new(format!("invalid note root '{}'", other)));
+        }
+    };
+
+    let mut semitone = base;
+    let mut consumed = first.len_utf8();
+    if let Some((idx, accidental)) = chars.next() {
+        match accidental {
+            '#' => {
+                semitone += 1;
+                consumed = idx + accidental.len_utf8();
+            }
+            'b' => {
+                semitone -= 1;
+                consumed = idx + accidental.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    let remainder = &input[consumed..];
+    let normalized = semitone.rem_euclid(12) as u8;
+    Ok((PitchClass::new(normalized), remainder))
+}
+
+fn parse_named_quality(input: &str) -> Result<Quality, ParseError> {
+    match input {
+        "" | "maj" => Ok(Quality::Major),
+        "m" | "min" => Ok(Quality::Minor),
+        "maj7" => Ok(Quality::Major7),
+        "m7" | "min7" => Ok(Quality::Minor7),
+        "7" => Ok(Quality::Dominant7),
+        "dim" => Ok(Quality::Diminished),
+        "aug" => Ok(Quality::Augmented),
+        "sus2" => Ok(Quality::Sus2),
+        "sus4" => Ok(Quality::Sus4),
+        other => Err(ParseError::new(format!(
+            "unsupported chord quality '{}'",
+            other
+        ))),
+    }
+}
+
+fn parse_roman_quality(input: &str, default_quality: Quality) -> Result<Quality, ParseError> {
+    if input.is_empty() {
+        return Ok(default_quality);
+    }
+
+    match input {
+        "7" => match default_quality {
+            Quality::Major => Ok(Quality::Dominant7),
+            Quality::Minor => Ok(Quality::Minor7),
+            Quality::Diminished => Err(ParseError::new(
+                "v1 roman numerals do not support diminished seventh shorthand",
+            )),
+            _ => parse_named_quality(input),
+        },
+        other => parse_named_quality(other),
+    }
+}
+
+fn looks_like_roman_token(token: &str) -> bool {
+    token
+        .chars()
+        .next()
+        .map(|ch| matches!(ch, 'I' | 'V' | 'i' | 'v'))
+        .unwrap_or(false)
+}
+
+fn centered_root_midi(root: PitchClass) -> u8 {
+    let pc = root.as_u8();
+    if pc <= 5 {
+        60 + pc
+    } else {
+        48 + pc
+    }
+}

--- a/tests/kssong_e2e.rs
+++ b/tests/kssong_e2e.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "native")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use keysynth::song::{parse_chord, parse_progression, parse_roman, Key, PitchClass, Quality};
+
+fn unique_wav_path(stem: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!("kssong-{stem}-{nanos}.wav"))
+}
+
+fn read_wav_peak_and_frames(path: &std::path::Path) -> (f32, usize) {
+    let mut reader = hound::WavReader::open(path).expect("wav should open");
+    let spec = reader.spec();
+    let channels = spec.channels.max(1) as usize;
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Float => reader.samples::<f32>().filter_map(Result::ok).collect(),
+        hound::SampleFormat::Int => {
+            let max = (1_i64 << (spec.bits_per_sample.saturating_sub(1))) as f32;
+            reader
+                .samples::<i32>()
+                .filter_map(Result::ok)
+                .map(|sample| sample as f32 / max)
+                .collect()
+        }
+    };
+    let frames = samples.len() / channels;
+    let peak = samples
+        .iter()
+        .fold(0.0_f32, |acc, sample| acc.max(sample.abs()));
+    (peak, frames)
+}
+
+#[test]
+fn gate_1_parse_c_major_close_voicing() {
+    let chord = parse_chord("C").expect("C should parse");
+    assert_eq!(chord.root, PitchClass::C);
+    assert_eq!(chord.quality, Quality::Major);
+    assert_eq!(chord.voice(), vec![60, 64, 67, 72]);
+}
+
+#[test]
+fn gate_2_parse_a_minor_close_voicing() {
+    let chord = parse_chord("Am").expect("Am should parse");
+    assert_eq!(chord.root, PitchClass::A);
+    assert_eq!(chord.quality, Quality::Minor);
+    assert_eq!(chord.voice(), vec![57, 60, 64, 69]);
+}
+
+#[test]
+fn gate_3_parse_major_seventh_with_five_notes() {
+    let chord = parse_chord("Cmaj7").expect("Cmaj7 should parse");
+    assert_eq!(chord.quality, Quality::Major7);
+    assert_eq!(chord.voice(), vec![60, 64, 67, 71, 72]);
+}
+
+#[test]
+fn gate_4_parse_progression_four_chords() {
+    let progression = parse_progression("C - G - Am - F").expect("progression should parse");
+    assert_eq!(progression.len(), 4);
+}
+
+#[test]
+fn gate_5_parse_roman_vi_in_c_major() {
+    let chord = parse_roman("vi", Key::C).expect("roman vi should parse");
+    assert_eq!(chord.root, PitchClass::A);
+    assert_eq!(chord.quality, Quality::Minor);
+}
+
+#[test]
+fn gate_6_and_7_cli_renders_nonempty_audible_wav_with_expected_length() {
+    let out_path = unique_wav_path("cli");
+    let status = Command::new(env!("CARGO_BIN_EXE_kssong"))
+        .args([
+            "play",
+            "C - G",
+            "--voice",
+            "piano",
+            "--bpm",
+            "120",
+            "--out",
+            out_path.to_str().expect("temp path must be utf-8"),
+        ])
+        .status()
+        .expect("kssong binary should launch");
+
+    assert!(status.success(), "kssong CLI exited with {status}");
+    assert!(out_path.exists(), "output wav should exist");
+
+    let (peak, frames) = read_wav_peak_and_frames(&out_path);
+    let expected_sec = 2.0_f32 * 4.0 * 60.0 / 120.0 + 2.5;
+    let expected_frames = (expected_sec * 44_100.0) as f32;
+    let frame_error = (frames as f32 - expected_frames).abs() / expected_frames.max(1.0);
+    assert!(
+        frame_error <= 0.10,
+        "wav length should be within 10%: got {frames} frames, expected about {expected_frames}"
+    );
+    assert!(peak > 0.1, "wav should be audible, got peak {peak}");
+
+    let _ = std::fs::remove_file(out_path);
+}


### PR DESCRIPTION
## Summary
- add `kssong` native CLI for one-line chord progression rendering to WAV
- add `keysynth::song` parser module for named chords, roman numerals, simple close voicings, and progression expansion
- reuse existing `render_midi` parsing/render/write path by importing its functions from `src/bin/render_midi.rs`; only visibility changed there

## Accepted notation
```bnf
progression  := chord (sep chord)*
sep          := '-' | '|' | whitespace+
chord        := note_chord | roman_chord
note_chord   := ROOT QUALITY?
ROOT         := [A-G] ['#' | 'b']?
QUALITY      := '' | 'maj' | 'm' | 'min' | 'maj7' | 'm7' | 'min7' | '7' | 'dim' | 'aug' | 'sus2' | 'sus4'
roman_chord  := ROMAN DEGREE_MARK? ROMAN_QUALITY?
ROMAN        := 'I' | 'ii' | 'iii' | 'IV' | 'V' | 'vi' | 'vii'
DEGREE_MARK  := '°'
ROMAN_QUALITY:= '7' | 'maj' | 'm' | 'min' | 'maj7' | 'm7' | 'min7' | 'dim' | 'aug' | 'sus2' | 'sus4'
```

Examples:
- `C - G - Am - F`
- `Cmaj7 - Dm7 - G7 - Cmaj7`
- `I - V - vi - IV --key C`

## Roman numerals
- uppercase roman numerals default to major triads
- lowercase roman numerals default to minor triads
- `°` marks diminished (for example `vii°` in key C -> B diminished)
- `--key` supplies the tonic used to transpose roman numerals into concrete pitch classes

## render_midi relationship
- `kssong` builds an SMF format-1 byte stream with `midly`
- it then reuses `render_midi` internals by importing `parse_smf`, `render_keysynth`, `render_sfz`, and `write_wav_stereo` from `src/bin/render_midi.rs`
- `render_midi.rs` logic is unchanged; only the minimum visibility needed for reuse was added
- `guitar` stays outside `Engine` as required: `kssong` reuses the same SMF parse + WAV write flow and renders events through `GuitarVoice` directly without touching the enum

## Validation
### 7 numerical / functional gate
```text
$ cargo test --test kssong_e2e
running 6 tests
- gate_1_parse_c_major_close_voicing ... ok
- gate_2_parse_a_minor_close_voicing ... ok
- gate_3_parse_major_seventh_with_five_notes ... ok
- gate_4_parse_progression_four_chords ... ok
- gate_5_parse_roman_vi_in_c_major ... ok
- gate_6_and_7_cli_renders_nonempty_audible_wav_with_expected_length ... ok

test result: ok. 6 passed; 0 failed
```

### Required checks
```text
cargo fmt --check                                           OK
cargo check --bin keysynth                                  OK
cargo check --bin kssong                                    OK
cargo check --no-default-features --features web \
  --target wasm32-unknown-unknown --bin keysynth-web        OK
```

### Sample WAVs
- `kssong-a.wav` (`C - G - Am - F`, piano, 120 BPM): `004825f0015a0ca0372a70bcb25397ee163a478ec528fb61ee84c30e8efee082`
- `kssong-b.wav` (`I - V - vi - IV`, key C, piano-modal, 100 BPM): `5f5e91b1dab9e45882b57c3529577379d65f6693e2306cee980098399ba3b4d5`
- `kssong-c.wav` (`Cmaj7 - Dm7 - G7 - C`, guitar, 90 BPM): `db3fb693661e9f2d1e61344fa02ff6f9036b5d63164b08df14b6384c187395f5`
