### PR TITLE
feat(kssong): --voicing flag (close/piano/guitar/open) for musically usable output (#53 follow-up)

### DIFF
--- a/src/bin/kssong.rs
+++ b/src/bin/kssong.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use midly::num::{u15, u24, u28, u4, u7};
 use midly::{Format, Header, MetaMessage, MidiMessage, Smf, Timing, TrackEvent, TrackEventKind};
 
-use keysynth::song::{parse_progression_with_key, Chord, Key};
+use keysynth::song::{parse_progression_with_key, Chord, Key, Voicing};
 use keysynth::synth::{midi_to_freq, Engine, VoiceImpl};
 use keysynth::voices::guitar::GuitarVoice;
 
@@ -50,6 +50,7 @@ impl VoiceChoice {
 struct PlayArgs {
     progression: String,
     voice: VoiceChoice,
+    voicing: Voicing,
     bpm: u32,
     bars: Option<usize>,
     key: Option<Key>,
@@ -65,6 +66,7 @@ fn print_help() {
          kssong play \"C - G - Am - F\" --voice piano --bpm 120 --out out.wav\n\n\
          play options:\n  \
          --voice NAME      piano|piano-modal|piano-thick|piano-lite|piano-5am|guitar|square|ks|ks-rich|fm|sub|koto|sf-piano|sfz-piano\n  \
+         --voicing MODE    close|piano|guitar|open (default close)\n  \
          --bpm N           tempo in beats per minute (default 120)\n  \
          --bars N          total bars to render; repeats/truncates progression to fit\n  \
          --key KEY         base key for roman numerals (example: C, F#, Bb)\n  \
@@ -94,6 +96,7 @@ fn parse_args() -> Result<PlayArgs, String> {
         .next()
         .ok_or_else(|| "play requires a chord progression string".to_string())?;
     let mut voice = VoiceChoice::Engine(Engine::Piano);
+    let mut voicing = Voicing::Close;
     let mut bpm = DEFAULT_BPM;
     let mut bars = None;
     let mut key = None;
@@ -106,6 +109,10 @@ fn parse_args() -> Result<PlayArgs, String> {
             "--voice" | "--engine" => {
                 let value = iter.next().ok_or("--voice needs a value")?;
                 voice = VoiceChoice::parse(&value)?;
+            }
+            "--voicing" => {
+                let value = iter.next().ok_or("--voicing needs a value")?;
+                voicing = Voicing::parse(&value).map_err(|e| format!("bad --voicing: {e}"))?;
             }
             "--bpm" => {
                 bpm = iter
@@ -154,6 +161,7 @@ fn parse_args() -> Result<PlayArgs, String> {
     Ok(PlayArgs {
         progression,
         voice,
+        voicing,
         bpm,
         bars,
         key,
@@ -169,7 +177,7 @@ fn expand_progression(chords: &[Chord], total_bars: usize) -> Vec<Chord> {
         .collect()
 }
 
-fn build_smf_bytes(chords: &[Chord], bpm: u32) -> Result<Vec<u8>, String> {
+fn build_smf_bytes(chords: &[Chord], bpm: u32, voicing: Voicing) -> Result<Vec<u8>, String> {
     #[derive(Clone, Copy)]
     enum MidiKind {
         NoteOff(u8),
@@ -181,7 +189,7 @@ fn build_smf_bytes(chords: &[Chord], bpm: u32) -> Result<Vec<u8>, String> {
     for (bar_idx, chord) in chords.iter().enumerate() {
         let start_tick = bar_idx as u32 * bar_ticks;
         let end_tick = start_tick + bar_ticks;
-        for note in chord.voice() {
+        for note in chord.voice(voicing) {
             timeline.push((end_tick, MidiKind::NoteOff(note)));
             timeline.push((start_tick, MidiKind::NoteOn(note)));
         }
@@ -339,13 +347,14 @@ fn run_play(args: PlayArgs) -> Result<(), String> {
         .map_err(|e| format!("progression parse: {e}"))?;
     let total_bars = args.bars.unwrap_or(chords.len());
     let expanded = expand_progression(&chords, total_bars);
-    let midi_bytes = build_smf_bytes(&expanded, args.bpm)?;
+    let midi_bytes = build_smf_bytes(&expanded, args.bpm, args.voicing)?;
     render_to_wav(&args, &midi_bytes)?;
     eprintln!(
-        "kssong: wrote {} (bars={} bpm={})",
+        "kssong: wrote {} (bars={} bpm={} voicing={})",
         args.out_path.display(),
         total_bars,
-        args.bpm
+        args.bpm,
+        args.voicing.as_str()
     );
     Ok(())
 }

--- a/src/song/mod.rs
+++ b/src/song/mod.rs
@@ -114,6 +114,35 @@ impl Quality {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Voicing {
+    Close,
+    Piano,
+    Guitar,
+    Open,
+}
+
+impl Voicing {
+    pub fn parse(input: &str) -> Result<Self, ParseError> {
+        match input {
+            "close" => Ok(Self::Close),
+            "piano" => Ok(Self::Piano),
+            "guitar" => Ok(Self::Guitar),
+            "open" => Ok(Self::Open),
+            other => Err(ParseError::new(format!("unsupported voicing '{}'", other))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Close => "close",
+            Self::Piano => "piano",
+            Self::Guitar => "guitar",
+            Self::Open => "open",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Chord {
     pub root: PitchClass,
@@ -121,13 +150,89 @@ pub struct Chord {
 }
 
 impl Chord {
-    pub fn voice(&self) -> Vec<u8> {
+    pub fn voice(&self, voicing: Voicing) -> Vec<u8> {
+        match voicing {
+            Voicing::Close => self.close_voice(),
+            Voicing::Piano => self.piano_voice(),
+            Voicing::Guitar => self.guitar_voice(),
+            Voicing::Open => self.open_voice(),
+        }
+    }
+
+    fn close_voice(&self) -> Vec<u8> {
         let root_midi = centered_root_midi(self.root);
         self.quality
             .intervals()
             .iter()
             .map(|interval| root_midi + interval)
             .collect()
+    }
+
+    fn piano_voice(&self) -> Vec<u8> {
+        let mut notes = Vec::with_capacity(self.quality.intervals().len() + 1);
+        notes.push(bass_root_midi(self.root));
+        notes.extend(self.close_voice());
+        notes
+    }
+
+    fn guitar_voice(&self) -> Vec<u8> {
+        const OPEN_STRINGS: [u8; 6] = [40, 45, 50, 55, 59, 64];
+
+        OPEN_STRINGS
+            .iter()
+            .map(|open_string| self.lowest_chord_tone_at_or_above(*open_string))
+            .collect()
+    }
+
+    fn open_voice(&self) -> Vec<u8> {
+        let bass_root = bass_root_midi(self.root);
+        let (third, fifth, seventh) = self.structure_intervals();
+        let mut notes = vec![
+            bass_root,
+            bass_root + fifth,
+            bass_root + third + 12,
+            bass_root + fifth + 12,
+        ];
+        if let Some(seventh) = seventh {
+            notes.push(bass_root + seventh + 12);
+        }
+        notes.push(bass_root + 24);
+        notes.push(bass_root + third + 24);
+        notes
+    }
+
+    fn structure_intervals(&self) -> (u8, u8, Option<u8>) {
+        let intervals = self.quality.intervals();
+        let third = intervals.get(1).copied().unwrap_or(4);
+        let fifth = intervals.get(2).copied().unwrap_or(7);
+        let seventh = if intervals.len() >= 5 {
+            intervals.get(3).copied()
+        } else {
+            None
+        };
+        (third, fifth, seventh)
+    }
+
+    fn chord_tone_intervals(&self) -> Vec<u8> {
+        let mut intervals = Vec::new();
+        for interval in self.quality.intervals() {
+            let normalized = interval % 12;
+            if !intervals.contains(&normalized) {
+                intervals.push(normalized);
+            }
+        }
+        intervals
+    }
+
+    fn lowest_chord_tone_at_or_above(&self, floor: u8) -> u8 {
+        let chord_tones = self.chord_tone_intervals();
+        for note in floor..=127 {
+            let relative_pc = (12 + note % 12 - self.root.as_u8()) % 12;
+            if chord_tones.contains(&relative_pc) {
+                return note;
+            }
+        }
+        unreachable!("a chord tone must exist within one octave above any guitar string");
     }
 }
 
@@ -370,4 +475,8 @@ fn centered_root_midi(root: PitchClass) -> u8 {
     } else {
         48 + pc
     }
+}
+
+fn bass_root_midi(root: PitchClass) -> u8 {
+    36 + root.as_u8()
 }

--- a/tests/kssong_e2e.rs
+++ b/tests/kssong_e2e.rs
@@ -1,9 +1,15 @@
 #![cfg(feature = "native")]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use keysynth::song::{parse_chord, parse_progression, parse_roman, Key, PitchClass, Quality};
+use keysynth::song::{
+    parse_chord, parse_progression, parse_roman, Chord, Key, PitchClass, Quality, Voicing,
+};
+use rustfft::num_complex::Complex32;
+use rustfft::FftPlanner;
+
+const STANDARD_GUITAR_OPEN_STRINGS: [u8; 6] = [40, 45, 50, 55, 59, 64];
 
 fn unique_wav_path(stem: &str) -> PathBuf {
     let nanos = std::time::SystemTime::now()
@@ -13,11 +19,19 @@ fn unique_wav_path(stem: &str) -> PathBuf {
     std::env::temp_dir().join(format!("kssong-{stem}-{nanos}.wav"))
 }
 
-fn read_wav_peak_and_frames(path: &std::path::Path) -> (f32, usize) {
+fn read_wav_peak_and_frames(path: &Path) -> (f32, usize) {
+    let (samples, _sr) = read_wav_mono(path);
+    let peak = samples
+        .iter()
+        .fold(0.0_f32, |acc, sample| acc.max(sample.abs()));
+    (peak, samples.len())
+}
+
+fn read_wav_mono(path: &Path) -> (Vec<f32>, u32) {
     let mut reader = hound::WavReader::open(path).expect("wav should open");
     let spec = reader.spec();
     let channels = spec.channels.max(1) as usize;
-    let samples: Vec<f32> = match spec.sample_format {
+    let interleaved: Vec<f32> = match spec.sample_format {
         hound::SampleFormat::Float => reader.samples::<f32>().filter_map(Result::ok).collect(),
         hound::SampleFormat::Int => {
             let max = (1_i64 << (spec.bits_per_sample.saturating_sub(1))) as f32;
@@ -28,51 +42,236 @@ fn read_wav_peak_and_frames(path: &std::path::Path) -> (f32, usize) {
                 .collect()
         }
     };
-    let frames = samples.len() / channels;
-    let peak = samples
-        .iter()
-        .fold(0.0_f32, |acc, sample| acc.max(sample.abs()));
-    (peak, frames)
+
+    if channels == 1 {
+        (interleaved, spec.sample_rate)
+    } else {
+        let mut mono = Vec::with_capacity(interleaved.len() / channels);
+        for frame in interleaved.chunks_exact(channels) {
+            let sum: f32 = frame.iter().sum();
+            mono.push(sum / channels as f32);
+        }
+        (mono, spec.sample_rate)
+    }
+}
+
+fn band_peak_relative_db(
+    samples: &[f32],
+    sr_hz: u32,
+    band_low_hz: f32,
+    band_high_hz: f32,
+) -> (f32, f32) {
+    let n = samples.len().min(131_072);
+    assert!(n >= 1024, "need at least 1024 samples for FFT gate");
+
+    let fft_len = n.next_power_of_two();
+    let mean = samples[..n].iter().sum::<f32>() / n as f32;
+    let mut fft_buf = vec![Complex32::new(0.0, 0.0); fft_len];
+    for (idx, sample) in samples[..n].iter().enumerate() {
+        let window = if n > 1 {
+            let phase = 2.0 * std::f32::consts::PI * idx as f32 / (n as f32 - 1.0);
+            0.5 - 0.5 * phase.cos()
+        } else {
+            1.0
+        };
+        fft_buf[idx].re = (*sample - mean) * window;
+    }
+
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(fft_len);
+    fft.process(&mut fft_buf);
+
+    let bin_hz = sr_hz as f32 / fft_len as f32;
+    let mut global_max = 0.0_f32;
+    let mut band_max = 0.0_f32;
+    let mut band_peak_hz = 0.0_f32;
+    for (idx, bin) in fft_buf.iter().take(fft_len / 2).enumerate().skip(1) {
+        let hz = idx as f32 * bin_hz;
+        let mag = bin.norm();
+        if hz >= 20.0 && mag > global_max {
+            global_max = mag;
+        }
+        if hz >= band_low_hz && hz <= band_high_hz && mag > band_max {
+            band_max = mag;
+            band_peak_hz = hz;
+        }
+    }
+
+    let rel_db = 20.0 * (band_max / global_max.max(1e-12)).log10();
+    (band_peak_hz, rel_db)
+}
+
+fn chord_tone_intervals(chord: &Chord) -> Vec<u8> {
+    let mut out = Vec::new();
+    for interval in chord.quality.intervals() {
+        let normalized = interval % 12;
+        if !out.contains(&normalized) {
+            out.push(normalized);
+        }
+    }
+    out
+}
+
+fn is_chord_tone(chord: &Chord, midi_note: u8) -> bool {
+    let relative_pc = (12 + midi_note % 12 - chord.root.as_u8()) % 12;
+    chord_tone_intervals(chord).contains(&relative_pc)
+}
+
+fn assert_strictly_ascending(notes: &[u8]) {
+    assert!(
+        notes.windows(2).all(|pair| pair[0] < pair[1]),
+        "notes must be strictly ascending: {notes:?}"
+    );
 }
 
 #[test]
-fn gate_1_parse_c_major_close_voicing() {
+fn gate_1_close_voicing_keeps_legacy_c_major() {
     let chord = parse_chord("C").expect("C should parse");
     assert_eq!(chord.root, PitchClass::C);
     assert_eq!(chord.quality, Quality::Major);
-    assert_eq!(chord.voice(), vec![60, 64, 67, 72]);
+    assert_eq!(chord.voice(Voicing::Close), vec![60, 64, 67, 72]);
 }
 
 #[test]
-fn gate_2_parse_a_minor_close_voicing() {
+fn gate_2_piano_voicing_adds_c2_bass_root() {
+    let chord = parse_chord("C").expect("C should parse");
+    assert_eq!(chord.voice(Voicing::Piano), vec![36, 60, 64, 67, 72]);
+    assert_eq!(chord.voice(Voicing::Piano)[0], 36);
+}
+
+#[test]
+fn gate_3_guitar_voicing_uses_six_string_spread_for_c_major() {
+    let chord = parse_chord("C").expect("C should parse");
+    assert_eq!(chord.voice(Voicing::Guitar), vec![40, 48, 52, 55, 60, 64]);
+    assert_eq!(chord.voice(Voicing::Guitar).len(), 6);
+    assert_eq!(chord.voice(Voicing::Guitar)[0], 40);
+}
+
+#[test]
+fn gate_4_open_voicing_spreads_c_major_over_28_semitones() {
+    let chord = parse_chord("C").expect("C should parse");
+    let notes = chord.voice(Voicing::Open);
+    assert_eq!(notes, vec![36, 43, 52, 55, 60, 64]);
+    assert_eq!(notes[0], 36);
+    assert_eq!(notes[notes.len() - 1], 64);
+    assert_eq!(notes[notes.len() - 1] - notes[0], 28);
+}
+
+#[test]
+fn gate_5_voicing_rules_hold_for_c_g_am_f() {
+    for symbol in ["C", "G", "Am", "F"] {
+        let chord = parse_chord(symbol).expect("progression chord should parse");
+
+        let close = chord.voice(Voicing::Close);
+        assert_strictly_ascending(&close);
+
+        let piano = chord.voice(Voicing::Piano);
+        assert_eq!(
+            piano[0],
+            36 + chord.root.as_u8(),
+            "{symbol}: piano bass root"
+        );
+        assert_eq!(&piano[1..], &close, "{symbol}: piano upper close voicing");
+
+        let guitar = chord.voice(Voicing::Guitar);
+        assert_eq!(guitar.len(), 6, "{symbol}: guitar mode should emit 6 notes");
+        for (note, open_string) in guitar.iter().zip(STANDARD_GUITAR_OPEN_STRINGS) {
+            assert!(
+                *note >= open_string,
+                "{symbol}: guitar note {note} must not sit below open string {open_string}"
+            );
+            assert!(
+                is_chord_tone(&chord, *note),
+                "{symbol}: guitar note {note} must be a chord tone"
+            );
+        }
+        assert_strictly_ascending(&guitar);
+
+        let open = chord.voice(Voicing::Open);
+        assert_eq!(open[0], 36 + chord.root.as_u8(), "{symbol}: open bass root");
+        assert!(open.len() >= 6, "{symbol}: open voicing should be wide");
+        assert_strictly_ascending(&open);
+    }
+}
+
+#[test]
+fn gate_6_existing_close_voicing_parse_gates_still_hold() {
     let chord = parse_chord("Am").expect("Am should parse");
     assert_eq!(chord.root, PitchClass::A);
     assert_eq!(chord.quality, Quality::Minor);
-    assert_eq!(chord.voice(), vec![57, 60, 64, 69]);
+    assert_eq!(chord.voice(Voicing::Close), vec![57, 60, 64, 69]);
+
+    let maj7 = parse_chord("Cmaj7").expect("Cmaj7 should parse");
+    assert_eq!(maj7.quality, Quality::Major7);
+    assert_eq!(maj7.voice(Voicing::Close), vec![60, 64, 67, 71, 72]);
 }
 
 #[test]
-fn gate_3_parse_major_seventh_with_five_notes() {
-    let chord = parse_chord("Cmaj7").expect("Cmaj7 should parse");
-    assert_eq!(chord.quality, Quality::Major7);
-    assert_eq!(chord.voice(), vec![60, 64, 67, 71, 72]);
-}
-
-#[test]
-fn gate_4_parse_progression_four_chords() {
+fn gate_7_progression_and_roman_parsing_still_hold() {
     let progression = parse_progression("C - G - Am - F").expect("progression should parse");
     assert_eq!(progression.len(), 4);
-}
 
-#[test]
-fn gate_5_parse_roman_vi_in_c_major() {
     let chord = parse_roman("vi", Key::C).expect("roman vi should parse");
     assert_eq!(chord.root, PitchClass::A);
     assert_eq!(chord.quality, Quality::Minor);
 }
 
 #[test]
-fn gate_6_and_7_cli_renders_nonempty_audible_wav_with_expected_length() {
+fn gate_8_default_close_cli_is_bit_identical_to_explicit_close() {
+    let default_out = unique_wav_path("default-close");
+    let explicit_out = unique_wav_path("explicit-close");
+
+    let default_status = Command::new(env!("CARGO_BIN_EXE_kssong"))
+        .args([
+            "play",
+            "C - G",
+            "--voice",
+            "piano",
+            "--bpm",
+            "120",
+            "--out",
+            default_out.to_str().expect("temp path must be utf-8"),
+        ])
+        .status()
+        .expect("kssong default close should launch");
+    assert!(
+        default_status.success(),
+        "default close exited with {default_status}"
+    );
+
+    let explicit_status = Command::new(env!("CARGO_BIN_EXE_kssong"))
+        .args([
+            "play",
+            "C - G",
+            "--voicing",
+            "close",
+            "--voice",
+            "piano",
+            "--bpm",
+            "120",
+            "--out",
+            explicit_out.to_str().expect("temp path must be utf-8"),
+        ])
+        .status()
+        .expect("kssong explicit close should launch");
+    assert!(
+        explicit_status.success(),
+        "explicit close exited with {explicit_status}"
+    );
+
+    let default_bytes = std::fs::read(&default_out).expect("default wav should exist");
+    let explicit_bytes = std::fs::read(&explicit_out).expect("explicit wav should exist");
+    assert_eq!(
+        default_bytes, explicit_bytes,
+        "default close must stay bit-identical"
+    );
+
+    let _ = std::fs::remove_file(default_out);
+    let _ = std::fs::remove_file(explicit_out);
+}
+
+#[test]
+fn gate_9_cli_default_close_render_keeps_length_and_audibility() {
     let out_path = unique_wav_path("cli");
     let status = Command::new(env!("CARGO_BIN_EXE_kssong"))
         .args([
@@ -100,6 +299,43 @@ fn gate_6_and_7_cli_renders_nonempty_audible_wav_with_expected_length() {
         "wav length should be within 10%: got {frames} frames, expected about {expected_frames}"
     );
     assert!(peak > 0.1, "wav should be audible, got peak {peak}");
+
+    let _ = std::fs::remove_file(out_path);
+}
+
+#[test]
+fn gate_10_cli_piano_voicing_has_c2_band_energy() {
+    let out_path = unique_wav_path("piano-voicing");
+    let status = Command::new(env!("CARGO_BIN_EXE_kssong"))
+        .args([
+            "play",
+            "C",
+            "--voicing",
+            "piano",
+            "--voice",
+            "piano",
+            "--bpm",
+            "120",
+            "--out",
+            out_path.to_str().expect("temp path must be utf-8"),
+        ])
+        .status()
+        .expect("kssong piano voicing should launch");
+
+    assert!(
+        status.success(),
+        "kssong piano voicing exited with {status}"
+    );
+    let (samples, sr_hz) = read_wav_mono(&out_path);
+    let (peak_hz, rel_db) = band_peak_relative_db(&samples, sr_hz, 60.0, 70.0);
+    assert!(
+        (60.0..=70.0).contains(&peak_hz),
+        "expected a bass-band peak near C2, got {peak_hz:.2} Hz"
+    );
+    assert!(
+        rel_db >= -40.0,
+        "expected bass-band energy to sit within -40 dB of spectral max, got {rel_db:.2} dB"
+    );
 
     let _ = std::fs::remove_file(out_path);
 }


### PR DESCRIPTION
## Summary
- add `--voicing close|piano|guitar|open` to `kssong play`
- keep `close` as the default so existing CLI behavior stays bit-identical
- move voicing rules into `keysynth::song::Voicing` and expand the e2e gate with 4-chord coverage plus a bass-band FFT check

## Why this follow-up exists
`kssong` in PR #53 always emitted a close voicing clustered around the middle register. That made one-line progression playback easy to use, but it left no dedicated bass register in the common case.

Examples of the old close-only shape:
- `C` -> `C4 E4 G4 C5`
- `G` -> `G3 B3 D4 G4`
- `Am` -> `A3 C4 E4 A4`
- `F` -> `F4 A4 C5 F5`

That is still useful as a compact default, but it is not enough on its own for practical piano/guitar-style progression auditioning.

## Voicing modes
- `close` (default): preserve the original compact voicing around C4.
  Example `C` -> `C4 E4 G4 C5`
- `piano`: add a bass root in the C2-B2 range under the original close voicing.
  Example `C` -> `C2 + C4 E4 G4 C5`
- `guitar`: standard-tuning approximation. For each string `E2 A2 D3 G3 B3 E4`, pick the lowest chord tone at or above the open-string pitch.
  Example `C` -> `E2 C3 E3 G3 C4 E4`
- `open`: wide root-position spread using bass root, bass fifth, upper 10th, upper 12th, and repeated upper root/third.
  Example `C` -> `C2 G2 E3 G3 C4 E4`

## Numerical / functional gate
```text
$ cargo test --test kssong_e2e
running 10 tests
- gate_1_close_voicing_keeps_legacy_c_major ... ok
- gate_2_piano_voicing_adds_c2_bass_root ... ok
- gate_3_guitar_voicing_uses_six_string_spread_for_c_major ... ok
- gate_4_open_voicing_spreads_c_major_over_28_semitones ... ok
- gate_5_voicing_rules_hold_for_c_g_am_f ... ok
- gate_6_existing_close_voicing_parse_gates_still_hold ... ok
- gate_7_progression_and_roman_parsing_still_hold ... ok
- gate_8_default_close_cli_is_bit_identical_to_explicit_close ... ok
- gate_9_cli_default_close_render_keeps_length_and_audibility ... ok
- gate_10_cli_piano_voicing_has_c2_band_energy ... ok

test result: ok. 10 passed; 0 failed
```

### Bass FFT gate
- `kssong play "C" --voicing piano --voice piano --bpm 120 --out X.wav`
- FFT band check passes with a detected spectral peak in the `60..70 Hz` band and bass-band magnitude within `-40 dB` of the overall spectral maximum

### Required checks
```text
cargo fmt --check                                                                OK
cargo check --bin keysynth --bin kssong                                          OK
cargo check --no-default-features --features web --target wasm32-unknown-unknown \
  --bin keysynth-web                                                             OK
```

## A/B sample WAVs
Same progression in all cases: `C - G - Am - F`, rendered via `--voice piano --bpm 120`.

- `close`: sha256 `004825f0015a0ca0372a70bcb25397ee163a478ec528fb61ee84c30e8efee082`, size `1852244` bytes
- `piano`: sha256 `2d48939a7a27e01542cb6fbbe9cc559b81334244f00f6bf5b1a7cfc14c4afd94`, size `1852244` bytes
- `guitar`: sha256 `2722cb9b81c138e330146bce2ae81665a390ecd83c93801b67b64de5d874a1db`, size `1852244` bytes
- `open`: sha256 `5fbd66cfb5ec043fd6e5508c65a8cc4c77709781f846d2d1311defa316605c02`, size `1852244` bytes
