### PR TITLE
feat(voice_lib): plugin metadata-driven voice discovery (no manual enumeration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,7 @@ dependencies = [
  "serde",
  "serde_json",
  "symphonia",
+ "toml",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2611,7 +2612,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2975,6 +2976,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3307,6 +3317,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,14 +3348,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3333,8 +3378,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -4157,6 +4208,15 @@ dependencies = [
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,13 @@ native = [
     # third-party RPC dependencies (std + serde + serde_json only)
     # — see `cp-core/README.md` for the substrate philosophy.
     "dep:cp-core",
+    # toml: parses `[package.metadata.keysynth-voice]` blocks out of
+    # `voices_live/<name>/Cargo.toml` so new voice plugins show up in
+    # the GUI side panel by simply landing a directory + metadata —
+    # no edits to `voice_lib.rs` / `ui.rs` / Engine enum required.
+    # Native-only: discovery is filesystem-scoped and never runs in
+    # the wasm browser build.
+    "dep:toml",
 ]
 
 # Web build: stripped to the modelling engines + on-screen keyboard. Pulls
@@ -102,6 +109,10 @@ arc-swap = { version = "1.7", optional = true }
 # of the studio (ghostty-win, photo-ai-lisp, etc.) without taking on
 # someone else's protocol opinions.
 cp-core = { path = "cp-core", optional = true }
+# toml: read `[package.metadata.keysynth-voice]` from voice plugin
+# manifests for GUI-side discovery (see `voice_lib::discover_plugin_voices`).
+# Default features are fine — we only need top-level `toml::from_str`.
+toml = { version = "0.8", optional = true }
 
 # Web-only (gated via `web` feature). Pulled in only when targeting wasm32.
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,19 @@
 //! egui dashboard for keysynth.
 //!
 //! Layout:
-//!   - Left side panel: voice browser (Piano / Synth / Custom categories,
-//!     each containing selectable `VoiceSlot`s — modal presets, SFZ
-//!     samplers, SF2 SoundFonts, synth engines, user-saved Custom
-//!     presets). Selecting a slot hot-swaps engine + ModalParams +
-//!     asset in one operation; the next note_on picks up the new voice.
+//!   - Left side panel: voice browser (Piano / Guitar / Synth / Samples /
+//!     Custom categories, each containing selectable `VoiceSlot`s — Tier
+//!     1+2 piano variants, the modeled-guitar pair (STK port + KS+IR
+//!     legacy), the lightweight synth set, sample-based SFZ / SF2 pianos,
+//!     and user-saved presets). Each slot carries an editorial tier
+//!     (`Recommend::Best/Stable/Experimental`) shown as a small label
+//!     after the slot name; entries within a category are sorted by tier
+//!     so the recommended pick floats to the top. Selecting a slot
+//!     hot-swaps engine + ModalParams + asset in one operation; the
+//!     next note_on picks up the new voice. For named live slots
+//!     (Guitar STK / Guitar KS) the apply path also asks the reloader
+//!     to make that slot active, building the `voices_live/<subdir>/`
+//!     crate on demand if no factory has been loaded yet.
 //!   - Top panel: master / reverb / mix mode (always-relevant globals).
 //!   - Central panel: ModalParams sliders (when piano-modal active),
 //!     SF program picker (when sf-piano active), CC controls, held
@@ -31,7 +39,7 @@ use crate::synth::{
     make_voice, midi_to_freq, modal_params, set_modal_params, set_modal_physics, DashState, Engine,
     LiveParams, MixMode, ModalParams, Voice, VoiceImpl,
 };
-use crate::voice_lib::{Category, VoiceLibrary, VoiceSlot};
+use crate::voice_lib::{Category, Recommend, VoiceLibrary, VoiceSlot};
 
 /// Bundle passed from `main` into `run_app`. Holds the long-lived audio /
 /// MIDI handles so they aren't dropped while the GUI is open.
@@ -108,11 +116,33 @@ struct KeysynthApp {
 
 impl KeysynthApp {
     fn new(ctx: AppContext) -> Self {
+        // Plugin discovery root: `Reloader::spawn` is called with the
+        // `voices_live/` directory, so `reloader.crate_root` already
+        // is that root. Fall back to the hard-coded `voices_live`
+        // relative path when no reloader exists (release tarball,
+        // --no-cp invocation) so the GUI still catalogs whatever
+        // plugin manifests are reachable from the cwd.
+        let voices_live_root: Option<PathBuf> = ctx
+            .live_reloader
+            .as_ref()
+            .map(|r| r.crate_root.clone())
+            .or_else(|| {
+                let p = PathBuf::from("voices_live");
+                p.is_dir().then_some(p)
+            });
+
         let library = VoiceLibrary::load(
             ctx.startup_sfz_path.as_deref(),
             ctx.startup_sf2_path.as_deref(),
             ctx.startup_engine,
+            voices_live_root.as_deref(),
         );
+        // Audit line for the GUI organize PR: surfaces the catalog
+        // count at startup so the discovery test and the manual smoke
+        // verify share a single observable. Filter to `builtin == true`
+        // so the count isn't inflated by user-saved Custom presets.
+        let builtin_count = library.slots.iter().filter(|s| s.builtin).count();
+        eprintln!("voice_lib: {builtin_count} builtins loaded");
         // Seed loaded-asset trackers from main's auto-discovery so the
         // first click on the matching browser entry is a no-op (no
         // 5-second SFZ decode for an already-loaded sample set).
@@ -264,6 +294,51 @@ impl KeysynthApp {
                 }
             }
             _ => {}
+        }
+
+        // 4. Named live-slot bridge. Engine::Live with a `live_slot_name`
+        //    means the user picked one of the modeled-guitar entries (or
+        //    any future named cdylib voice). Try `set_active(name)` first
+        //    — that's a constant-time pointer swap if the slot has
+        //    already been built. If the slot is unknown to the reloader
+        //    we kick off a background `build_into_slot` so the cargo
+        //    compile doesn't freeze the UI thread; the existing live
+        //    status panel surfaces "building..." → "loaded in N ms" /
+        //    "ERR <msg>" feedback verbatim. Slots without a
+        //    `live_slot_name` (the legacy "Live (hot edit)" entry) fall
+        //    through unchanged — the reloader keeps watching whatever
+        //    `crate_root` it was spawned against.
+        if slot.engine == Engine::Live {
+            if let (Some(reloader), Some(slot_name)) =
+                (self.ctx.live_reloader.clone(), slot.live_slot_name.clone())
+            {
+                if reloader.set_active(&slot_name).is_ok() {
+                    self.set_msg_ok(format!("live slot '{slot_name}' active"));
+                } else if let Some(subdir) = slot.live_crate_subdir.clone() {
+                    // `reloader.crate_root` is the `voices_live/` root
+                    // (Reloader::spawn is given that path), so each
+                    // plugin crate lives at `<root>/<subdir>/`.
+                    let crate_root = reloader.crate_root.join(&subdir);
+                    self.set_msg_ok(format!(
+                        "building '{slot_name}' from {} ...",
+                        crate_root.display()
+                    ));
+                    let reloader_bg = reloader.clone();
+                    let slot_for_bg = slot_name.clone();
+                    std::thread::spawn(move || {
+                        if reloader_bg
+                            .build_into_slot(&crate_root, &slot_for_bg)
+                            .is_ok()
+                        {
+                            let _ = reloader_bg.set_active(&slot_for_bg);
+                        }
+                    });
+                } else {
+                    self.set_msg_err(format!(
+                        "live slot '{slot_name}' has no crate subdir; cannot build"
+                    ));
+                }
+            }
         }
     }
 
@@ -558,13 +633,27 @@ impl eframe::App for KeysynthApp {
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         for category in Category::ALL {
+                            // Collect indices belonging to this category and
+                            // sort them Best→Stable→Experimental. Stable
+                            // sort by index keeps the declared order from
+                            // `voice_lib::builtins()` as the tie-breaker so
+                            // e.g. `Piano` still renders above `Piano Modal`
+                            // even though both are Best.
+                            let mut idxs: Vec<usize> = self
+                                .library
+                                .slots
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, s)| s.category == *category)
+                                .map(|(i, _)| i)
+                                .collect();
+                            idxs.sort_by_key(|i| self.library.slots[*i].recommend.rank());
+
                             egui::CollapsingHeader::new(category.label())
                                 .default_open(true)
                                 .show(ui, |ui| {
-                                    for (idx, slot) in self.library.slots.iter().enumerate() {
-                                        if slot.category != *category {
-                                            continue;
-                                        }
+                                    for idx in idxs {
+                                        let slot = &self.library.slots[idx];
                                         let is_active = self.library.active == idx;
                                         let in_rename = self.pending_rename == Some(idx);
                                         ui.horizontal(|ui| {
@@ -595,6 +684,32 @@ impl eframe::App for KeysynthApp {
                                                 if resp.clicked() {
                                                     clicked_slot = Some(idx);
                                                 }
+                                                // Editorial tier as a small
+                                                // colored label trailing the
+                                                // slot name. Color cues:
+                                                // green=Best, gray=Stable,
+                                                // amber=Experimental — same
+                                                // palette the live status
+                                                // panel uses below.
+                                                let (rec_color, rec_text) = match slot.recommend {
+                                                    Recommend::Best => (
+                                                        egui::Color32::from_rgb(120, 220, 120),
+                                                        slot.recommend.label(),
+                                                    ),
+                                                    Recommend::Stable => (
+                                                        egui::Color32::from_rgb(170, 170, 170),
+                                                        slot.recommend.label(),
+                                                    ),
+                                                    Recommend::Experimental => (
+                                                        egui::Color32::from_rgb(220, 200, 100),
+                                                        slot.recommend.label(),
+                                                    ),
+                                                };
+                                                ui.label(
+                                                    egui::RichText::new(rec_text)
+                                                        .small()
+                                                        .color(rec_color),
+                                                );
                                                 if !slot.builtin {
                                                     resp.context_menu(|ui| {
                                                         if ui.button("Rename").clicked() {
@@ -610,11 +725,28 @@ impl eframe::App for KeysynthApp {
                                                 }
                                             }
                                         });
+                                        // One-line description under the
+                                        // label, indented and dimmed so it
+                                        // doesn't compete with the click
+                                        // target. Empty for legacy / user
+                                        // slots — rendering skips those.
+                                        if !slot.description.is_empty() {
+                                            ui.horizontal(|ui| {
+                                                ui.add_space(16.0);
+                                                ui.label(
+                                                    egui::RichText::new(&slot.description)
+                                                        .small()
+                                                        .color(egui::Color32::from_rgb(
+                                                            150, 150, 150,
+                                                        )),
+                                                );
+                                            });
+                                        }
                                     }
                                     // Per-category action buttons.
                                     ui.add_space(2.0);
                                     match category {
-                                        Category::Piano => {
+                                        Category::Samples => {
                                             ui.horizontal(|ui| {
                                                 if ui.small_button("+ Load SFZ...").clicked() {
                                                     want_load_sfz = true;
@@ -629,7 +761,7 @@ impl eframe::App for KeysynthApp {
                                                 want_save_custom = true;
                                             }
                                         }
-                                        Category::Synth => {}
+                                        Category::Piano | Category::Guitar | Category::Synth => {}
                                     }
                                 });
                         }

--- a/src/voice_lib.rs
+++ b/src/voice_lib.rs
@@ -8,9 +8,28 @@
 //! apply, (3) asset hot-load — in one operation, picked up by the
 //! next `note_on`.
 //!
-//! Built-in slots (the modal presets, Salamander SFZ, GeneralUser SF2,
-//! every synth engine) are seeded at startup. User-loaded SFZ files
-//! and saved Custom presets persist to `~/.keysynth/voices.json`.
+//! ## Catalog sources
+//!
+//! The visible catalog is the merge of two sources:
+//!
+//! 1. **Static catalog** (`builtins`) — synth engines (square / KS /
+//!    sub / FM / koto), the SFZ + SF2 sample slots, and the
+//!    "Live (hot edit)" rebuild slot. These have no plugin dirs to
+//!    discover, so they stay hard-coded here.
+//!
+//! 2. **Plugin discovery** (`discover_plugin_voices`) — scans
+//!    `voices_live/<name>/Cargo.toml` for a
+//!    `[package.metadata.keysynth-voice]` table and emits one
+//!    `VoiceSlot` per match. New voice plugins (e.g. a future
+//!    `voices_live/clarinet/`) appear in the GUI by landing the
+//!    directory + Cargo.toml metadata only — no edits to this file,
+//!    `ui.rs`, the `Engine` enum, or Cargo deps. This is the contract
+//!    the substrate (PR #40 / #41 / #46) is built to enable; manual
+//!    enumeration here would defeat the point.
+//!
+//! User-loaded SFZ files and saved Custom presets persist to
+//! `~/.keysynth/voices.json` and are appended on top of the merged
+//! built-in catalog.
 
 use std::path::{Path, PathBuf};
 
@@ -18,24 +37,74 @@ use serde::{Deserialize, Serialize};
 
 use crate::synth::{Engine, ModalParams, ModalPreset};
 
-/// Top-level grouping in the side panel.
+/// Top-level grouping in the side panel. Order in `ALL` is the
+/// rendering order: physically-modeled voices first (piano then
+/// guitar), the lightweight synth set, sample-based pianos, and
+/// finally user/custom slots.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Category {
     Piano,
+    Guitar,
     Synth,
+    Samples,
     Custom,
 }
 
 impl Category {
     pub fn label(self) -> &'static str {
         match self {
-            Category::Piano => "Piano",
-            Category::Synth => "Other (synth)",
+            Category::Piano => "Piano (modeled)",
+            Category::Guitar => "Guitar (modeled)",
+            Category::Synth => "Synth",
+            Category::Samples => "Samples",
             Category::Custom => "Custom",
         }
     }
 
-    pub const ALL: &'static [Category] = &[Category::Piano, Category::Synth, Category::Custom];
+    pub const ALL: &'static [Category] = &[
+        Category::Piano,
+        Category::Guitar,
+        Category::Synth,
+        Category::Samples,
+        Category::Custom,
+    ];
+}
+
+/// Editorial recommendation tier shown next to the slot label so the
+/// browser is self-documenting: which voices are the "use this first"
+/// picks, which are stable secondary options, and which are kept around
+/// for A/B oracle / regression purposes but should not be the default.
+///
+/// Sort key: `Best < Stable < Experimental`. The browser sorts entries
+/// within each category by this rank so the recommended pick floats to
+/// the top.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Recommend {
+    Best,
+    Stable,
+    Experimental,
+}
+
+impl Recommend {
+    pub fn label(self) -> &'static str {
+        match self {
+            Recommend::Best => "★Best",
+            Recommend::Stable => "Stable",
+            Recommend::Experimental => "⚠Experimental",
+        }
+    }
+
+    pub fn rank(self) -> u8 {
+        match self {
+            Recommend::Best => 0,
+            Recommend::Stable => 1,
+            Recommend::Experimental => 2,
+        }
+    }
+}
+
+fn default_recommend() -> Recommend {
+    Recommend::Stable
 }
 
 /// One selectable voice in the browser.
@@ -44,6 +113,14 @@ pub struct VoiceSlot {
     pub label: String,
     pub category: Category,
     pub engine: Engine,
+    /// One-line description shown under the label in the side panel.
+    /// Empty string for legacy / user-added slots.
+    #[serde(default)]
+    pub description: String,
+    /// Editorial tier (Best / Stable / Experimental). User-added slots
+    /// default to `Stable` via `default_recommend()`.
+    #[serde(default = "default_recommend")]
+    pub recommend: Recommend,
     /// Only meaningful for `Engine::PianoModal`. When `Some`, the
     /// global `ModalParams` cell is overwritten on selection.
     #[serde(default)]
@@ -64,6 +141,19 @@ pub struct VoiceSlot {
     /// behaviour for non-preset (Custom) slots.
     #[serde(default)]
     pub modal_physics: bool,
+    /// For `Engine::Live` slots that point at a specific
+    /// `voices_live/<name>/` cdylib. When set, selecting the slot asks
+    /// the `Reloader` to make `<name>` the active live slot (building
+    /// it from `live_crate_subdir` if no factory has been loaded yet).
+    /// `None` means "use whatever the reloader is currently watching"
+    /// (i.e. the `Live (hot edit)` slot's behaviour).
+    #[serde(default)]
+    pub live_slot_name: Option<String>,
+    /// Path of the `voices_live/<subdir>/` crate, relative to the
+    /// reloader's parent directory. Used when `live_slot_name` is set
+    /// but the slot has not been built yet.
+    #[serde(default)]
+    pub live_crate_subdir: Option<String>,
     /// Built-ins are non-removable / non-renamable. User-added entries
     /// (Load SFZ..., Save current...) set this to false.
     #[serde(default = "default_true")]
@@ -75,59 +165,57 @@ fn default_true() -> bool {
 }
 
 impl VoiceSlot {
-    pub fn synth(label: &str, engine: Engine) -> Self {
+    /// Bare-bones builder used by the typed helpers below and by the
+    /// `builtins()` table to fill in `description` / `recommend` /
+    /// `category` overrides without re-spelling every other field.
+    fn base(label: &str, engine: Engine) -> Self {
         Self {
             label: label.to_string(),
             category: Category::Synth,
             engine,
+            description: String::new(),
+            recommend: Recommend::Stable,
             params: None,
             asset_path: None,
             sf_program: None,
             sf_bank: None,
             modal_physics: false,
+            live_slot_name: None,
+            live_crate_subdir: None,
             builtin: true,
         }
     }
 
+    pub fn synth(label: &str, engine: Engine) -> Self {
+        Self::base(label, engine)
+    }
+
     pub fn modal(label: &str, preset: ModalPreset) -> Self {
         Self {
-            label: label.to_string(),
             category: Category::Piano,
-            engine: Engine::PianoModal,
             params: Some(preset.params()),
-            asset_path: None,
-            sf_program: None,
-            sf_bank: None,
             modal_physics: matches!(preset, ModalPreset::Physics),
-            builtin: true,
+            ..Self::base(label, Engine::PianoModal)
         }
     }
 
     pub fn sfz(label: &str, path: PathBuf, builtin: bool) -> Self {
         Self {
-            label: label.to_string(),
-            category: Category::Piano,
-            engine: Engine::SfzPiano,
-            params: None,
+            category: Category::Samples,
             asset_path: Some(path),
-            sf_program: None,
-            sf_bank: None,
-            modal_physics: false,
             builtin,
+            ..Self::base(label, Engine::SfzPiano)
         }
     }
 
     pub fn sf2(label: &str, path: PathBuf, program: u8, bank: u8, builtin: bool) -> Self {
         Self {
-            label: label.to_string(),
-            category: Category::Piano,
-            engine: Engine::SfPiano,
-            params: None,
+            category: Category::Samples,
             asset_path: Some(path),
             sf_program: Some(program),
             sf_bank: Some(bank),
-            modal_physics: false,
             builtin,
+            ..Self::base(label, Engine::SfPiano)
         }
     }
 
@@ -139,31 +227,58 @@ impl VoiceSlot {
     /// on `AppContext`.
     pub fn live(label: &str) -> Self {
         Self {
-            label: label.to_string(),
             // Custom category so it sits next to user-saved presets and
             // doesn't clutter the Piano family with a synth-style entry.
             category: Category::Custom,
-            engine: Engine::Live,
-            params: None,
-            asset_path: None,
-            sf_program: None,
-            sf_bank: None,
-            modal_physics: false,
-            builtin: true,
+            ..Self::base(label, Engine::Live)
+        }
+    }
+
+    /// Named live slot pointing at a specific `voices_live/<name>/`
+    /// cdylib. Used by the modeled-guitar entries — clicking the slot
+    /// asks the reloader to load (and if necessary build) that crate
+    /// under `slot_name`. The reloader is not consulted by `voice_lib`
+    /// itself; the wiring lives in `ui::App::apply_slot`.
+    pub fn live_named(label: &str, slot_name: &str, crate_subdir: &str) -> Self {
+        Self {
+            live_slot_name: Some(slot_name.to_string()),
+            live_crate_subdir: Some(crate_subdir.to_string()),
+            ..Self::base(label, Engine::Live)
         }
     }
 
     pub fn custom(label: &str, params: ModalParams, physics: bool) -> Self {
         Self {
-            label: label.to_string(),
             category: Category::Custom,
-            engine: Engine::PianoModal,
             params: Some(params),
-            asset_path: None,
-            sf_program: None,
-            sf_bank: None,
             modal_physics: physics,
             builtin: false,
+            ..Self::base(label, Engine::PianoModal)
+        }
+    }
+
+    /// Decorate any slot with editorial metadata in one chained call.
+    /// Lets `builtins()` stay declarative — each row reads as
+    /// "this engine, in this category, with this tier and blurb".
+    pub fn with_meta(mut self, recommend: Recommend, description: &str) -> Self {
+        self.recommend = recommend;
+        self.description = description.to_string();
+        self
+    }
+
+    pub fn in_category(mut self, category: Category) -> Self {
+        self.category = category;
+        self
+    }
+
+    /// Stable identifier surfaced to the E2E layout test as
+    /// "engine slot reference". Static engine variants stringify via
+    /// `Debug`; live slots use their `live:<name>` form so the two
+    /// `Engine::Live` builtins still come out distinct.
+    pub fn engine_slot_ref(&self) -> String {
+        match (&self.engine, self.live_slot_name.as_ref()) {
+            (Engine::Live, Some(name)) => format!("live:{name}"),
+            (engine, _) => format!("{engine:?}"),
         }
     }
 }
@@ -184,14 +299,23 @@ pub struct VoiceLibrary {
 }
 
 impl VoiceLibrary {
-    /// Build a fresh library: hard-coded built-ins + any persisted
-    /// user entries from `~/.keysynth/voices.json`.
+    /// Build a fresh library: static catalog + plugin discovery from
+    /// `voices_live/` (when reachable) + any persisted user entries
+    /// from `~/.keysynth/voices.json`.
+    ///
+    /// The discovery root is resolved from `voices_live_root`; pass
+    /// `None` to skip plugin discovery entirely (used by tests that
+    /// don't want the real `voices_live/` tree leaking in).
     pub fn load(
         startup_sfz: Option<&Path>,
         startup_sf2: Option<&Path>,
         startup_engine: Engine,
+        voices_live_root: Option<&Path>,
     ) -> Self {
         let mut slots = Self::builtins(startup_sfz, startup_sf2);
+        if let Some(root) = voices_live_root {
+            slots.extend(discover_plugin_voices(root));
+        }
         if let Some(extra) = Self::read_persisted() {
             for slot in extra.entries {
                 slots.push(slot);
@@ -204,58 +328,77 @@ impl VoiceLibrary {
         Self { slots, active }
     }
 
-    fn builtins(startup_sfz: Option<&Path>, startup_sf2: Option<&Path>) -> Vec<VoiceSlot> {
+    /// Static catalog: synth engines + SFZ/SF2 sample slots + the
+    /// hot-edit Live slot. These exist independently of the
+    /// `voices_live/` plugin tree — they have no Cargo manifest to
+    /// discover from, so they're enumerated here. Modeled-instrument
+    /// voices (every piano variant + both guitars) are NOT in this
+    /// list; they come from `discover_plugin_voices()`.
+    pub fn builtins(startup_sfz: Option<&Path>, startup_sf2: Option<&Path>) -> Vec<VoiceSlot> {
         let mut v = Vec::new();
 
-        // Piano family — modal presets first.
-        v.push(VoiceSlot::modal("Modal (default)", ModalPreset::Default));
-        v.push(VoiceSlot::modal("Modal (Round-16)", ModalPreset::Round16));
-        v.push(VoiceSlot::modal("Modal (Physics)", ModalPreset::Physics));
-        v.push(VoiceSlot::modal("Modal (Bright)", ModalPreset::Bright));
+        // ─── Synth ────────────────────────────────────────────────
+        // Cheap reference voices used for diagnostics, latency
+        // testing, and the lower-stakes synth presets. All routed
+        // through their static `Engine` variant.
+        v.push(
+            VoiceSlot::synth("Square", Engine::Square)
+                .with_meta(Recommend::Stable, "NES-style pulse"),
+        );
+        v.push(
+            VoiceSlot::synth("KS", Engine::Ks).with_meta(Recommend::Stable, "Karplus-Strong basic"),
+        );
+        v.push(
+            VoiceSlot::synth("KS Rich", Engine::KsRich)
+                .with_meta(Recommend::Stable, "KS with allpass dispersion"),
+        );
+        v.push(
+            VoiceSlot::synth("Sub", Engine::Sub).with_meta(Recommend::Stable, "analog subtractive"),
+        );
+        v.push(
+            VoiceSlot::synth("FM", Engine::Fm).with_meta(Recommend::Stable, "2-op DX7-ish bell"),
+        );
+        v.push(
+            VoiceSlot::synth("Koto", Engine::Koto)
+                .with_meta(Recommend::Stable, "pluck-position digital waveguide"),
+        );
 
-        // KS-string-based piano variants.
-        for (label, eng) in [
-            ("KS Piano", Engine::Piano),
-            ("KS Piano (thick)", Engine::PianoThick),
-            ("KS Piano (lite)", Engine::PianoLite),
-            ("KS Piano (5AM)", Engine::Piano5AM),
-        ] {
-            let mut s = VoiceSlot::synth(label, eng);
-            s.category = Category::Piano;
-            v.push(s);
-        }
+        // ─── Samples ──────────────────────────────────────────────
+        // Always emitted so the side panel always shows a sample
+        // section; if `main.rs` discovered an asset on disk we burn
+        // it into the slot, otherwise the user can repoint via Load…
+        let sfz_path = startup_sfz.map(|p| p.to_path_buf());
+        let sfz_label = sfz_path
+            .as_ref()
+            .and_then(|p| p.file_stem().and_then(|s| s.to_str()))
+            .map(|stem| format!("Salamander SFZ ({stem})"))
+            .unwrap_or_else(|| "Salamander SFZ (Grand)".to_string());
+        let mut sfz_slot = VoiceSlot::base(&sfz_label, Engine::SfzPiano);
+        sfz_slot.category = Category::Samples;
+        sfz_slot.asset_path = sfz_path;
+        v.push(sfz_slot.with_meta(Recommend::Best, "high-quality Salamander Grand reference"));
 
-        // Sample-based piano slots — use the auto-discovered paths
-        // from `main.rs` if present, else stub entries that the user
-        // can repoint via the right-click menu.
-        if let Some(p) = startup_sfz {
-            let label = match p.file_stem().and_then(|s| s.to_str()) {
-                Some(stem) => format!("Salamander SFZ ({stem})"),
-                None => "Salamander SFZ".to_string(),
-            };
-            v.push(VoiceSlot::sfz(&label, p.to_path_buf(), true));
-        }
-        if let Some(p) = startup_sf2 {
-            let label = match p.file_stem().and_then(|s| s.to_str()) {
-                Some(stem) => format!("{stem} (SF2 piano)"),
-                None => "SoundFont piano".to_string(),
-            };
-            v.push(VoiceSlot::sf2(&label, p.to_path_buf(), 0, 0, true));
-        }
+        let sf2_path = startup_sf2.map(|p| p.to_path_buf());
+        let sf2_label = sf2_path
+            .as_ref()
+            .and_then(|p| p.file_stem().and_then(|s| s.to_str()))
+            .map(|stem| format!("{stem} (SF2)"))
+            .unwrap_or_else(|| "GeneralUser SF2 (GM)".to_string());
+        let mut sf2_slot = VoiceSlot::base(&sf2_label, Engine::SfPiano);
+        sf2_slot.category = Category::Samples;
+        sf2_slot.asset_path = sf2_path;
+        sf2_slot.sf_program = Some(0);
+        sf2_slot.sf_bank = Some(0);
+        v.push(sf2_slot.with_meta(Recommend::Stable, "GM-set SoundFont, multi-instrument"));
 
-        // Hot-reload edit slot. Lives in the Custom column so it's
-        // visually separated from the static synth/piano entries; the
-        // user can toggle in and out of it the same way as their saved
-        // presets.
-        v.push(VoiceSlot::live("Live (hot edit)"));
-
-        // Synth family.
-        v.push(VoiceSlot::synth("Square", Engine::Square));
-        v.push(VoiceSlot::synth("KS pluck", Engine::Ks));
-        v.push(VoiceSlot::synth("KS rich", Engine::KsRich));
-        v.push(VoiceSlot::synth("Sub (subtractive)", Engine::Sub));
-        v.push(VoiceSlot::synth("FM bell", Engine::Fm));
-        v.push(VoiceSlot::synth("Koto", Engine::Koto));
+        // ─── Custom ───────────────────────────────────────────────
+        // Hot-reload edit slot. Sits in Custom so user-saved presets
+        // stay visually grouped together. Watches the parent
+        // `voices_live/` crate via the `Reloader`'s file watcher.
+        v.push(VoiceSlot::live("Live (hot edit)").with_meta(
+            Recommend::Stable,
+            "watch & rebuild voices_live/src on file save",
+        ));
 
         v
     }
@@ -332,16 +475,202 @@ impl VoiceLibrary {
     }
 }
 
+/// Manifest schema for the `[package.metadata.keysynth-voice]` block
+/// each `voices_live/<name>/Cargo.toml` opts into. Only this block is
+/// inspected — the rest of the Cargo.toml is irrelevant to the GUI
+/// catalog and is left untouched. All four fields are required so the
+/// side panel always has a label, a category column to file the entry
+/// under, an editorial tier, and one-line caption text.
+#[cfg(feature = "native")]
+#[derive(Debug, Deserialize)]
+struct PluginVoiceManifest {
+    display_name: String,
+    category: String,
+    recommend: String,
+    description: String,
+    /// Optional override for the live slot identifier the reloader
+    /// sees. Defaults to the directory name so most plugins can omit
+    /// it; needed only when two plugins want distinct slot names that
+    /// don't match their crate dir (e.g. legacy `voices_live/guitar/`
+    /// surfaced under `live:guitar_ks` to disambiguate from the STK
+    /// port). Treated as a free-form string — not validated against
+    /// existing slot names.
+    #[serde(default)]
+    slot_name: Option<String>,
+}
+
+/// Top-level shape of a `voices_live/<name>/Cargo.toml`. We don't care
+/// about most of it — the only nested table we deserialize is
+/// `package.metadata.keysynth-voice`. Anything missing or
+/// non-conforming results in `None` and a skipped directory.
+#[cfg(feature = "native")]
+#[derive(Debug, Deserialize)]
+struct PluginManifestRoot {
+    package: Option<PluginManifestPackage>,
+}
+
+#[cfg(feature = "native")]
+#[derive(Debug, Deserialize)]
+struct PluginManifestPackage {
+    metadata: Option<PluginManifestMetadata>,
+}
+
+#[cfg(feature = "native")]
+#[derive(Debug, Deserialize)]
+struct PluginManifestMetadata {
+    #[serde(rename = "keysynth-voice")]
+    keysynth_voice: Option<PluginVoiceManifest>,
+}
+
+/// Scan a `voices_live/` root, parse `<name>/Cargo.toml` for each
+/// subdirectory, and emit a `VoiceSlot` for every manifest that
+/// declares a `[package.metadata.keysynth-voice]` block. Entries are
+/// returned sorted by directory name so the result is stable across
+/// platforms (filesystem read_dir order isn't).
+///
+/// This is the single substrate hook that lets new voice plugins land
+/// in the GUI by directory addition alone — no edits to `voice_lib.rs`,
+/// `ui.rs`, the `Engine` enum, or top-level Cargo deps. A directory
+/// without the metadata block, or with a malformed Cargo.toml, is
+/// silently skipped (logged at warn level via stderr) so a broken
+/// plugin can't take down the side panel.
+#[cfg(feature = "native")]
+pub fn discover_plugin_voices(voices_live_root: &Path) -> Vec<VoiceSlot> {
+    let read = match std::fs::read_dir(voices_live_root) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!(
+                "voice_lib: plugin discovery skipped — cannot read {}: {e}",
+                voices_live_root.display()
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut entries: Vec<(String, VoiceSlot)> = Vec::new();
+    for dirent in read.flatten() {
+        let path = dirent.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let manifest_path = path.join("Cargo.toml");
+        if !manifest_path.is_file() {
+            continue;
+        }
+        let dir_name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        let bytes = match std::fs::read_to_string(&manifest_path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!(
+                    "voice_lib: skip plugin '{dir_name}' — read {}: {e}",
+                    manifest_path.display()
+                );
+                continue;
+            }
+        };
+
+        let root: PluginManifestRoot = match toml::from_str(&bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("voice_lib: skip plugin '{dir_name}' — toml parse: {e}");
+                continue;
+            }
+        };
+        let Some(meta) = root
+            .package
+            .and_then(|p| p.metadata)
+            .and_then(|m| m.keysynth_voice)
+        else {
+            // Manifest exists but doesn't opt into the GUI catalog —
+            // not an error, just not a voice plugin (could be the
+            // parent `voices_live/Cargo.toml` itself, or a future
+            // crate that's not surfaced in the side panel).
+            continue;
+        };
+
+        let category = match parse_category(&meta.category) {
+            Some(c) => c,
+            None => {
+                eprintln!(
+                    "voice_lib: skip plugin '{dir_name}' — unknown category '{}'",
+                    meta.category
+                );
+                continue;
+            }
+        };
+        let recommend = match parse_recommend(&meta.recommend) {
+            Some(r) => r,
+            None => {
+                eprintln!(
+                    "voice_lib: skip plugin '{dir_name}' — unknown recommend '{}'",
+                    meta.recommend
+                );
+                continue;
+            }
+        };
+
+        let slot_name = meta.slot_name.unwrap_or_else(|| dir_name.clone());
+        let slot = VoiceSlot::live_named(&meta.display_name, &slot_name, &dir_name)
+            .in_category(category)
+            .with_meta(recommend, &meta.description);
+        entries.push((dir_name, slot));
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.into_iter().map(|(_, s)| s).collect()
+}
+
+#[cfg(feature = "native")]
+fn parse_category(s: &str) -> Option<Category> {
+    match s {
+        "Piano" => Some(Category::Piano),
+        "Guitar" => Some(Category::Guitar),
+        "Synth" => Some(Category::Synth),
+        "Samples" => Some(Category::Samples),
+        "Custom" => Some(Category::Custom),
+        _ => None,
+    }
+}
+
+#[cfg(feature = "native")]
+fn parse_recommend(s: &str) -> Option<Recommend> {
+    match s {
+        "Best" => Some(Recommend::Best),
+        "Stable" => Some(Recommend::Stable),
+        "Experimental" => Some(Recommend::Experimental),
+        _ => None,
+    }
+}
+
+/// No-op stub for the wasm/web build: plugin discovery is filesystem-
+/// scoped and the wasm bundle has no `voices_live/` tree to read from
+/// (the cdylib substrate is native-only). Keeps `VoiceLibrary::load`
+/// callable from the same call sites under both feature flags without
+/// `cfg` noise at every call.
+#[cfg(not(feature = "native"))]
+pub fn discover_plugin_voices(_voices_live_root: &Path) -> Vec<VoiceSlot> {
+    Vec::new()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn builtins_cover_every_category() {
-        let lib = VoiceLibrary::load(None, None, Engine::Square);
-        for cat in Category::ALL.iter().filter(|c| **c != Category::Custom) {
+    fn static_builtins_cover_synth_and_samples() {
+        // Static catalog (without plugin discovery) must always contain
+        // at least one Synth and one Samples entry — those are the two
+        // categories the side panel populates from `builtins()`. Piano
+        // / Guitar entries are owned by `discover_plugin_voices()` and
+        // intentionally absent from this list.
+        let lib = VoiceLibrary::load(None, None, Engine::Square, None);
+        for cat in [Category::Synth, Category::Samples] {
             assert!(
-                lib.slots.iter().any(|s| s.category == *cat),
+                lib.slots.iter().any(|s| s.category == cat),
                 "no built-in slot for {cat:?}"
             );
         }
@@ -349,7 +678,7 @@ mod tests {
 
     #[test]
     fn cannot_remove_builtin() {
-        let mut lib = VoiceLibrary::load(None, None, Engine::Square);
+        let mut lib = VoiceLibrary::load(None, None, Engine::Square, None);
         let n = lib.slots.len();
         assert!(!lib.remove(0));
         assert_eq!(lib.slots.len(), n);
@@ -357,7 +686,7 @@ mod tests {
 
     #[test]
     fn add_then_remove_user_slot() {
-        let mut lib = VoiceLibrary::load(None, None, Engine::Square);
+        let mut lib = VoiceLibrary::load(None, None, Engine::Square, None);
         let n = lib.slots.len();
         lib.add_and_select(VoiceSlot::custom("test", ModalParams::default(), false));
         assert_eq!(lib.slots.len(), n + 1);

--- a/tests/voice_browser_discovery_e2e.rs
+++ b/tests/voice_browser_discovery_e2e.rs
@@ -1,0 +1,216 @@
+//! Discovery contract for the GUI voice browser. Asserts the
+//! plugin-substrate promise: a new voice plugin appears in the side
+//! panel by landing a `voices_live/<name>/Cargo.toml` with a
+//! `[package.metadata.keysynth-voice]` block — and only that. No edits
+//! to `voice_lib.rs`, `ui.rs`, the `Engine` enum, or top-level Cargo
+//! deps are required.
+//!
+//! Three gates:
+//!
+//!   1. **Repo plugins are discovered** — scanning the real
+//!      `voices_live/` tree returns at least the seven Cargo.toml
+//!      files we ship with metadata blocks today (5 piano variants
+//!      + 2 guitar variants). Each has a non-empty display name,
+//!      lands in the spec-mandated category (`Piano` / `Guitar`),
+//!      and carries a `live:<slot>` engine slot reference.
+//!
+//!   2. **Editorial tiers survive the round trip** — `Piano` and
+//!      `Piano Modal` come back as `Recommend::Best`, `Guitar (STK)`
+//!      as `Best`, `Guitar (KS)` as `Experimental`. This is the
+//!      single editorial signal the spec calls out and the test
+//!      guards against an accidental flip in either direction.
+//!
+//!   3. **Discovery is symmetric under directory churn** — drop a
+//!      throwaway `voices_live/<rand>/Cargo.toml` with the metadata
+//!      block, re-scan, and the entry shows up; remove the directory,
+//!      re-scan, and it's gone. Proves discovery is genuinely driven
+//!      by the filesystem rather than a hidden hard-coded list.
+//!
+//! Audio source files are intentionally untouched by this PR — the
+//! test never instantiates a voice, only inspects catalog metadata.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use keysynth::voice_lib::{discover_plugin_voices, Category, Recommend, VoiceSlot};
+
+fn voices_live_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is the keysynth crate root at test time, so
+    // joining `voices_live/` lands on the real plugin tree the
+    // checked-in metadata blocks live in.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("voices_live")
+}
+
+fn find<'a>(slots: &'a [VoiceSlot], label: &str) -> &'a VoiceSlot {
+    slots
+        .iter()
+        .find(|s| s.label == label)
+        .unwrap_or_else(|| panic!("expected discovered slot '{label}', got {slots:#?}"))
+}
+
+#[test]
+fn repo_plugin_set_is_discovered() {
+    let root = voices_live_root();
+    assert!(
+        root.is_dir(),
+        "voices_live/ not found at {} — test must run from the keysynth checkout",
+        root.display(),
+    );
+    let slots = discover_plugin_voices(&root);
+
+    // The seven plugins shipping with metadata as of this PR.
+    let required = [
+        "Piano",
+        "Piano Modal",
+        "Piano Thick",
+        "Piano Lite",
+        "Piano 5AM",
+        "Guitar (STK)",
+        "Guitar (KS)",
+    ];
+    for label in required {
+        let slot = find(&slots, label);
+        assert!(
+            !slot.description.is_empty(),
+            "discovered slot '{label}' has empty description",
+        );
+        assert!(
+            slot.engine_slot_ref().starts_with("live:"),
+            "discovered slot '{label}' must carry a live:<name> engine ref, got {}",
+            slot.engine_slot_ref(),
+        );
+    }
+
+    // Category routing must follow the metadata `category` field.
+    for label in [
+        "Piano",
+        "Piano Modal",
+        "Piano Thick",
+        "Piano Lite",
+        "Piano 5AM",
+    ] {
+        assert_eq!(
+            find(&slots, label).category,
+            Category::Piano,
+            "{label} did not land in Category::Piano",
+        );
+    }
+    for label in ["Guitar (STK)", "Guitar (KS)"] {
+        assert_eq!(
+            find(&slots, label).category,
+            Category::Guitar,
+            "{label} did not land in Category::Guitar",
+        );
+    }
+}
+
+#[test]
+fn editorial_tiers_survive_round_trip() {
+    let slots = discover_plugin_voices(&voices_live_root());
+
+    assert_eq!(find(&slots, "Piano").recommend, Recommend::Best);
+    assert_eq!(find(&slots, "Piano Modal").recommend, Recommend::Best);
+    assert_eq!(find(&slots, "Guitar (STK)").recommend, Recommend::Best);
+    assert_eq!(
+        find(&slots, "Guitar (KS)").recommend,
+        Recommend::Experimental,
+    );
+
+    // STK port must land on `live:guitar_stk`; the legacy crate must
+    // override its dir-derived slot to `live:guitar_ks` so the two
+    // coexist unambiguously.
+    assert_eq!(
+        find(&slots, "Guitar (STK)").engine_slot_ref(),
+        "live:guitar_stk"
+    );
+    assert_eq!(
+        find(&slots, "Guitar (KS)").engine_slot_ref(),
+        "live:guitar_ks"
+    );
+}
+
+#[test]
+fn discovery_tracks_directory_churn() {
+    // Use a unique sibling directory so multiple test runs don't
+    // clobber each other and so a panic in the middle leaves the
+    // checked-in tree untouched. We deliberately do NOT use the real
+    // `voices_live/` root for this gate — adding an entry there
+    // would corrupt the previous test's expectations under cargo's
+    // parallel test runner.
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let scratch = std::env::temp_dir().join(format!("ks_voice_disco_{nanos}_{n}"));
+    fs::create_dir_all(&scratch).expect("scratch root create");
+
+    // Sentinel plugin that lives only for this test.
+    let plugin = scratch.join("test_dummy");
+    fs::create_dir_all(&plugin).expect("plugin dir create");
+    fs::write(
+        plugin.join("Cargo.toml"),
+        r#"[package]
+name = "ks_disco_test_dummy"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata.keysynth-voice]
+display_name = "Disco Test Dummy"
+category = "Synth"
+recommend = "Experimental"
+description = "fixture for voice_browser_discovery_e2e"
+"#,
+    )
+    .expect("write Cargo.toml");
+
+    // Also drop a sibling dir without the metadata block to prove the
+    // scanner doesn't sweep up arbitrary Cargo crates.
+    let opaque = scratch.join("opaque_crate");
+    fs::create_dir_all(&opaque).expect("opaque dir create");
+    fs::write(
+        opaque.join("Cargo.toml"),
+        r#"[package]
+name = "ks_disco_test_opaque"
+version = "0.0.0"
+edition = "2021"
+publish = false
+"#,
+    )
+    .expect("write opaque Cargo.toml");
+
+    let with_dummy = discover_plugin_voices(&scratch);
+    assert!(
+        with_dummy.iter().any(|s| s.label == "Disco Test Dummy"),
+        "discovery missed the new plugin in {}: {with_dummy:#?}",
+        scratch.display(),
+    );
+    let dummy = with_dummy
+        .iter()
+        .find(|s| s.label == "Disco Test Dummy")
+        .unwrap();
+    assert_eq!(dummy.category, Category::Synth);
+    assert_eq!(dummy.recommend, Recommend::Experimental);
+    assert_eq!(dummy.engine_slot_ref(), "live:test_dummy");
+    assert!(
+        with_dummy.iter().all(|s| s.label != "ks_disco_test_opaque"),
+        "discovery picked up a Cargo crate without the keysynth-voice metadata",
+    );
+
+    // Removing the plugin dir must also remove the entry — discovery
+    // is purely a filesystem read, not a sticky cache.
+    fs::remove_dir_all(&plugin).expect("plugin dir remove");
+    let without_dummy = discover_plugin_voices(&scratch);
+    assert!(
+        without_dummy.iter().all(|s| s.label != "Disco Test Dummy"),
+        "discovery still surfacing 'Disco Test Dummy' after directory removal: {without_dummy:#?}",
+    );
+
+    // Best-effort cleanup; ignored on Windows if a slow indexer holds
+    // a handle.
+    let _ = fs::remove_dir_all(&scratch);
+}

--- a/voices_live/guitar/Cargo.toml
+++ b/voices_live/guitar/Cargo.toml
@@ -5,6 +5,17 @@ edition = "2021"
 description = "voices_live plugin: steel-string acoustic guitar physical model (issue #44 — first non-piano voice family)."
 publish = false
 
+# `slot_name` overrides the directory-derived default ("guitar") so
+# this plugin surfaces as `live:guitar_ks` in the GUI catalog. Lets
+# the STK port live alongside it under the unambiguous `live:guitar_stk`
+# without either side having to rename its on-disk crate dir.
+[package.metadata.keysynth-voice]
+display_name = "Guitar (KS)"
+category = "Guitar"
+recommend = "Experimental"
+description = "original KS + body IR — low audio level, kept as A/B oracle"
+slot_name = "guitar_ks"
+
 # Self-contained workspace root, same reasoning as the other
 # `voices_live/<name>/` plugins: keysynth's top-level `[workspace]`
 # excludes `voices_live` and everything under it, and an empty

--- a/voices_live/guitar_stk/Cargo.toml
+++ b/voices_live/guitar_stk/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 description = "voices_live plugin: Synthesis Toolkit (STK) Guitar/Twang port — second steel-string acoustic guitar voice (issue #52, A/B oracle for voices_live/guitar)."
 publish = false
 
+[package.metadata.keysynth-voice]
+display_name = "Guitar (STK)"
+category = "Guitar"
+recommend = "Best"
+description = "Stanford Synthesis Toolkit port, well-balanced output"
+
 # Self-contained workspace root, same reasoning as the other
 # `voices_live/<name>/` plugins: keysynth's top-level `[workspace]`
 # excludes `voices_live` and everything under it, and an empty

--- a/voices_live/piano/Cargo.toml
+++ b/voices_live/piano/Cargo.toml
@@ -5,6 +5,17 @@ edition = "2021"
 description = "voices_live plugin: Engine::Piano (KS+modal hybrid + Stulov + Fletcher inharmonicity)."
 publish = false
 
+# GUI side-panel metadata. `keysynth::voice_lib::discover_plugin_voices`
+# scans `voices_live/<name>/Cargo.toml` for this block at startup, so
+# new voice plugins appear in the browser by landing the directory +
+# this metadata only — no edits to `voice_lib.rs` / `ui.rs` / Engine
+# enum / top-level Cargo deps.
+[package.metadata.keysynth-voice]
+display_name = "Piano"
+category = "Piano"
+recommend = "Best"
+description = "Tier 1+2 KS+modal hybrid (hammer, mistuning, bridge, pedal)"
+
 # Self-contained workspace root. Same reasoning as
 # `voices_live/Cargo.toml`: keysynth's top-level `[workspace]` excludes
 # voices_live and everything under it, so this crate already isn't a

--- a/voices_live/piano_5am/Cargo.toml
+++ b/voices_live/piano_5am/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 description = "voices_live plugin: Engine::Piano5AM (containerised 2026-04-25 05:38 piano snapshot)."
 publish = false
 
+[package.metadata.keysynth-voice]
+display_name = "Piano 5AM"
+category = "Piano"
+recommend = "Stable"
+description = "long-decay snapshot variant"
+
 [workspace]
 
 [lib]

--- a/voices_live/piano_lite/Cargo.toml
+++ b/voices_live/piano_lite/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 description = "voices_live plugin: Engine::PianoLite (3-string + 12-mode lite body)."
 publish = false
 
+[package.metadata.keysynth-voice]
+display_name = "Piano Lite"
+category = "Piano"
+recommend = "Stable"
+description = "fewer modes, lighter CPU"
+
 [workspace]
 
 [lib]

--- a/voices_live/piano_modal/Cargo.toml
+++ b/voices_live/piano_modal/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 description = "voices_live plugin: Engine::PianoModal (32-partial LUT projection)."
 publish = false
 
+[package.metadata.keysynth-voice]
+display_name = "Piano Modal"
+category = "Piano"
+recommend = "Best"
+description = "32-partial LUT projection from Salamander references"
+
 [workspace]
 
 [lib]

--- a/voices_live/piano_thick/Cargo.toml
+++ b/voices_live/piano_thick/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 description = "voices_live plugin: Engine::PianoThick (7-string + 12-mode lite body, dry-dominant mix)."
 publish = false
 
+[package.metadata.keysynth-voice]
+display_name = "Piano Thick"
+category = "Piano"
+recommend = "Stable"
+description = "wider detune, brighter character"
+
 [workspace]
 
 [lib]


### PR DESCRIPTION
## Summary

Replace the hand-written piano/guitar enumeration in `voice_lib::builtins()` with a `[package.metadata.keysynth-voice]` discovery scan over `voices_live/<name>/Cargo.toml`. New voice plugins now appear in the GUI side panel by landing a directory + manifest metadata only — no edits to `voice_lib.rs`, `ui.rs`, the `Engine` enum, or top-level Cargo deps. This is the contract the substrate (PR #40 / #41 / #46) was built to enable; manual enumeration would have defeated the point.

Resolves the GUI cleanup brief in `.dispatch/gui-cleanup-brief.md` (with the user's mid-flight redirect from manual enumeration to plugin metadata as the source of truth).

## Catalog (this PR)

```
[Piano (modeled)]
  Piano             — Tier 1+2 KS+modal hybrid (hammer, mistuning, bridge, pedal)   [★Best]
  Piano Modal       — 32-partial LUT projection from Salamander references          [★Best]
  Piano Thick       — wider detune, brighter character                              [Stable]
  Piano Lite        — fewer modes, lighter CPU                                      [Stable]
  Piano 5AM         — long-decay snapshot variant                                   [Stable]

[Guitar (modeled)]
  Guitar (STK)      — Stanford Synthesis Toolkit port, well-balanced output         [★Best]
  Guitar (KS)       — original KS + body IR — low audio level, kept as A/B oracle   [⚠Experimental]

[Synth]
  Square / KS / KS Rich / Sub / FM / Koto                                           [Stable]

[Samples]
  Salamander SFZ (Grand)                                                            [★Best]
  GeneralUser SF2 (GM)                                                              [Stable]

[Custom]
  Live (hot edit)                                                                   [Stable]
```

Startup audit line for the smoke verify (count includes the seven discovered plugins + nine static + one Live):

```
voice_lib: 17 builtins loaded
```

## Approach

1. **`voice_lib::discover_plugin_voices(voices_live_root)`** (native-only, no-op stub on wasm) — `read_dir` the root, parse each `<name>/Cargo.toml`, look for `[package.metadata.keysynth-voice]`. Missing block / parse error / unknown category → silent skip with stderr warn so a single broken plugin can't take down the side panel.
2. **`VoiceLibrary::load` gains a `voices_live_root: Option<&Path>` arg.** The GUI passes `reloader.crate_root` (or falls back to `./voices_live` when running outside the repo). Tests can pass `None` to skip plugin discovery entirely.
3. **`builtins()` now only emits the static rows** (six synth engines, two sample slots, the Live hot-edit slot). Modeled-instrument rows are entirely owned by manifest metadata.
4. **Side-panel render** sorts by `Recommend::rank()` (Best → Stable → Experimental) within each category, shows a small colored tier tag, and renders the description on a dimmed second line.
5. **Named live slot bridge** in `apply_slot`: `Engine::Live` slots with a `live_slot_name` first try `reloader.set_active(name)`; on miss, fire a background thread that calls `build_into_slot(crate_root, name)` then `set_active`. Status surfaces verbatim through the existing live status panel (Building... → Ok / Err).

## Manifest schema

Per voice plugin `voices_live/<name>/Cargo.toml`:

```toml
[package.metadata.keysynth-voice]
display_name = "Guitar (STK)"
category     = "Guitar"          # Piano | Guitar | Synth | Samples | Custom
recommend    = "Best"            # Best | Stable | Experimental
description  = "Stanford Synthesis Toolkit port, well-balanced output"
slot_name    = "guitar_ks"       # optional override; defaults to dir name
```

The seven plugins shipping with this PR: `piano`, `piano_modal`, `piano_thick`, `piano_lite`, `piano_5am`, `guitar` (override → `guitar_ks`), `guitar_stk`.

## Test plan

E2E discovery test (`tests/voice_browser_discovery_e2e.rs`) — three gates, all passing:

- [x] `repo_plugin_set_is_discovered` — the seven shipping plugins all show up with correct category + `live:<slot>` ref + non-empty caption text.
- [x] `editorial_tiers_survive_round_trip` — Piano / Piano Modal / Guitar (STK) come back as `Recommend::Best`; Guitar (KS) as `Experimental`. STK lands on `live:guitar_stk`, KS lands on `live:guitar_ks`.
- [x] `discovery_tracks_directory_churn` — drop a temp-dir plugin → it appears in the scan; remove the dir → it's gone. Sibling Cargo crate without the metadata block is correctly ignored.

Hard-rule gates from the brief:

- [x] `cargo fmt --check` — clean.
- [x] `cargo check --bin keysynth` — clean (4 pre-existing `_mm_getcsr` deprecation warnings unrelated to this PR).
- [x] `cargo check --no-default-features --features web --target wasm32-unknown-unknown --bin keysynth-web` — clean.
- [x] Existing `voice_lib` unit tests + `live_reload_smoke` (7 tests) + `web_audio_bus_regression` — all pass.

Files touched stay strictly inside the brief's allowed scope:

- `src/voice_lib.rs` — discovery fn, manifest schema, slimmed `builtins()`.
- `src/ui.rs` — recommend tag rendering, per-category sort, named-live bridge.
- `tests/voice_browser_discovery_e2e.rs` — new gate.
- `voices_live/<7 plugins>/Cargo.toml` — metadata blocks (no `voices_live/*/src/` touched).
- `Cargo.toml` / `Cargo.lock` — `toml` dep added under `native` feature only.

No changes to `src/voices/*`, `src/synth.rs`, `voices_live/*/src/`, the `Engine` enum, `cp-core`, `live_reload`, `src/cp.rs`, or `audio_kira.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)