### PR TITLE
feat(render_midi): wire voices_live/guitar + guitar_stk through Engine::Live

### DIFF
--- a/src/bin/render_midi.rs
+++ b/src/bin/render_midi.rs
@@ -11,12 +11,16 @@
 
 use std::env;
 use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
 
 use hound::{SampleFormat, WavSpec, WavWriter};
 use midly::{MetaMessage, MidiMessage, Smf, Timing, TrackEventKind};
 
+use keysynth::live_reload::{build_and_load, LiveFactory};
 use keysynth::sfz::SfzPlayer;
-use keysynth::synth::{make_voice, midi_to_freq, Engine, ModalLut, MODAL_LUT};
+use keysynth::synth::{
+    make_voice, midi_to_freq, set_live_voice_factory, Engine, ModalLut, VoiceImpl, MODAL_LUT,
+};
 
 pub const SR: u32 = 44100;
 pub const RELEASE_TAIL_SEC: f32 = 2.5;
@@ -36,6 +40,11 @@ struct Args {
     sfz_path: Option<PathBuf>,
     modal_lut_path: Option<PathBuf>,
     tempo_scale: f32,
+    /// `voices_live/<name>/` crate root to build + load when `engine ==
+    /// Engine::Live`. Set automatically by the `--engine guitar` and
+    /// `--engine guitar-stk` aliases; can be overridden explicitly via
+    /// `--live-crate-root`.
+    live_crate_root: Option<PathBuf>,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -45,6 +54,7 @@ fn parse_args() -> Result<Args, String> {
     let mut sfz_path: Option<PathBuf> = None;
     let mut modal_lut_path: Option<PathBuf> = None;
     let mut tempo_scale: f32 = 1.0;
+    let mut live_crate_root: Option<PathBuf> = None;
 
     let mut iter = env::args().skip(1);
     while let Some(a) = iter.next() {
@@ -65,6 +75,23 @@ fn parse_args() -> Result<Args, String> {
                     "piano-modal" => Engine::PianoModal,
                     "sfz-piano" => Engine::SfzPiano,
                     "koto" => Engine::Koto,
+                    // Live-loaded voice families. The string aliases pin the
+                    // crate root so the user does not have to repeat
+                    // `--live-crate-root voices_live/...` for the canonical
+                    // builds.
+                    "guitar" => {
+                        if live_crate_root.is_none() {
+                            live_crate_root = Some(PathBuf::from("voices_live/guitar"));
+                        }
+                        Engine::Live
+                    }
+                    "guitar-stk" => {
+                        if live_crate_root.is_none() {
+                            live_crate_root = Some(PathBuf::from("voices_live/guitar_stk"));
+                        }
+                        Engine::Live
+                    }
+                    "live" => Engine::Live, // requires --live-crate-root
                     other => return Err(format!("unknown engine: {other}")),
                 });
             }
@@ -82,6 +109,11 @@ fn parse_args() -> Result<Args, String> {
                     .parse()
                     .map_err(|e| format!("--tempo-scale parse: {e}"))?;
             }
+            "--live-crate-root" => {
+                live_crate_root = Some(PathBuf::from(
+                    iter.next().ok_or("--live-crate-root needs a value")?,
+                ));
+            }
             other => return Err(format!("unknown arg: {other}")),
         }
     }
@@ -93,7 +125,24 @@ fn parse_args() -> Result<Args, String> {
         sfz_path,
         modal_lut_path,
         tempo_scale,
+        live_crate_root,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Live (voices_live/*) factory wiring.
+//
+// `Engine::Live` dispatches through `keysynth::synth::set_live_voice_factory`,
+// which expects a plain `fn(sr, freq, vel) -> Option<Box<dyn VoiceImpl + Send>>`
+// (no captures). We satisfy that by parking the loaded LiveFactory in a
+// static OnceLock and reading it from a trampoline that matches the
+// expected signature.
+// ---------------------------------------------------------------------------
+
+static LIVE_FACTORY_SLOT: OnceLock<Arc<LiveFactory>> = OnceLock::new();
+
+fn live_voice_trampoline(sr: f32, freq: f32, vel: u8) -> Option<Box<dyn VoiceImpl + Send>> {
+    LIVE_FACTORY_SLOT.get().map(|f| f.make_voice(sr, freq, vel))
 }
 
 /// Parse a Standard MIDI File and convert to a flat list of NoteEvent
@@ -374,6 +423,45 @@ fn main() {
             std::process::exit(2);
         }
     };
+
+    // For Engine::Live (guitar / guitar-stk / generic --live-crate-root),
+    // build the cdylib first and register the factory trampoline so
+    // `Engine::Live` dispatches through it instead of falling back to
+    // SilentVoice. Build is a `cargo build` invocation against the
+    // sibling crate; output is the cdylib path which `LiveFactory::load`
+    // opens via libloading.
+    if args.engine == Engine::Live {
+        let crate_root = match args.live_crate_root.as_ref() {
+            Some(p) => p.clone(),
+            None => {
+                eprintln!(
+                    "render_midi: --engine live requires --live-crate-root \
+                     (or use the `guitar` / `guitar-stk` aliases that pin it)"
+                );
+                std::process::exit(2);
+            }
+        };
+        eprintln!(
+            "render_midi: building live voice from {} (cargo build, may take a moment)",
+            crate_root.display(),
+        );
+        let factory = match build_and_load(&crate_root) {
+            Ok(f) => Arc::new(f),
+            Err(e) => {
+                eprintln!("render_midi: build_and_load({}): {e}", crate_root.display());
+                std::process::exit(2);
+            }
+        };
+        eprintln!(
+            "render_midi: live voice loaded from {}",
+            factory.dll_path.display(),
+        );
+        if LIVE_FACTORY_SLOT.set(factory).is_err() {
+            eprintln!("render_midi: LIVE_FACTORY_SLOT was already set");
+            std::process::exit(2);
+        }
+        set_live_voice_factory(live_voice_trampoline);
+    }
 
     let bytes = match std::fs::read(&args.input) {
         Ok(b) => b,


### PR DESCRIPTION
## Summary

Adds `--engine guitar` and `--engine guitar-stk` to `render_midi` so a real MIDI piece can be rendered through the two non-piano voice families (PR #51 acoustic guitar physical model, PR #55 STK port) without manually wiring `Engine::Live` and the `voices_live/<crate>` plugin path on every invocation.

Pairs with [PR #57](https://github.com/YuujiKamura/keysynth/pull/57) (gemini/guitar-ground-truth-corpus) — that PR provides the permissive-license MIDI inputs this CLI now consumes.

## CLI surface

```bash
# Render a MIDI file through the acoustic guitar voice (voices_live/guitar)
cargo run --release --bin render_midi --features native -- \
    --in song.mid --engine guitar --out out.wav

# Render through the STK port (voices_live/guitar_stk)
cargo run --release --bin render_midi --features native -- \
    --in song.mid --engine guitar-stk --out out.wav

# Generic escape hatch for other voices_live crates
cargo run --release --bin render_midi --features native -- \
    --in song.mid --engine live --live-crate-root voices_live/<other> --out out.wav
```

The `guitar` / `guitar-stk` aliases auto-pin the canonical crate roots so you don't have to pass `--live-crate-root` for the in-tree builds. An explicit `--live-crate-root` still takes priority when set ahead of `--engine`.

## Wiring detail

`Engine::Live` dispatches through `set_live_voice_factory`, which expects a plain `fn(sr, freq, vel) -> Option<Box<dyn VoiceImpl + Send>>` (no captures). We park the loaded `Arc<LiveFactory>` in a `OnceLock` inside `render_midi` and read it from a trampoline matching the expected signature — same pattern `src/main.rs:400` already uses for the GUI hot-reload path.

## Smoke test

Rendered Aguado Op. 3 No. 1 (Mutopia, public domain — 325 note events, 47.7 s) through both new aliases:

```
$ render_midi --in aguado.mid --engine guitar-stk --out aguado_guitar_stk.wav
render_midi: building live voice from voices_live/guitar_stk (cargo build, may take a moment)
render_midi: live voice loaded from .../keysynth_voice_guitar_stk-...dll
render_midi: input='aguado.mid' engine=Live events=325 duration=47.7s tempo_scale=1.00
render_midi: raw peak=0.993 → normalised -3 dBFS (gain 0.713)
render_midi: wrote aguado_guitar_stk.wav (stereo)

$ render_midi --in aguado.mid --engine guitar --out aguado_guitar.wav
render_midi: live voice loaded from .../keysynth_voice_guitar-...dll
render_midi: raw peak=1.108 → normalised -3 dBFS (gain 0.639)
```

Both voices produce non-zero audio (peaks 0.993 and 1.108). Without this PR, `Engine::Live` falls through to the `SilentVoice` placeholder in `render_midi` because no live factory was registered in this binary.

## Scope

- One file changed: `src/bin/render_midi.rs`
- No changes to `voices_live/*`, `cp-core/`, or any voice source
- No changes to the existing engine strings — `square`, `ks`, `piano-*`, `sfz-piano`, `koto` etc. all still work exactly as before
- `cargo fmt --check` clean on the modified file
- Pre-existing clippy warnings on the rest of the tree are not addressed here (out of scope)

## Test plan

- [x] `cargo build --release --bin render_midi --features native` builds clean
- [x] `--engine guitar-stk` renders Aguado Op. 3 No. 1 to a non-zero stereo WAV
- [x] `--engine guitar` renders the same MIDI to a non-zero stereo WAV
- [x] `cargo fmt -- --check src/bin/render_midi.rs` clean
- [ ] Listened-through audition (subjective) — left to whoever pulls the branch
- [ ] Side-by-side A/B against `--engine ks` baseline — natural follow-up, can be a quick `score` invocation against the corpus references

🤖 Generated with [Claude Code](https://claude.com/claude-code)