### PR TITLE
chore(gitignore): ignore dispatch briefs + PR body drafts + target-codex/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,9 @@ bench-out/CHIPTUNE/
 Salamander/
 sfz-libraries/
 .claude/worktrees/
+
+# Dispatch / planning artifacts (per-deck briefs, PR draft bodies, codex target dirs)
+.dispatch/
+pr_body.md
+target-codex/
+target-claude/


### PR DESCRIPTION
Per-deck dispatch briefs (.dispatch/) and PR body drafts (pr_body.md) are conversation context, not deliverables. Stop showing them as untracked. Also adds target-codex / target-claude (CARGO_TARGET_DIR overrides used by Codex/Claude decks).