### PR TITLE
feat(jukebox): rebuild 3 lite variants on shared core layer

### DIFF
--- a/JUKEBOX_REBUILD.md
+++ b/JUKEBOX_REBUILD.md
@@ -1,0 +1,166 @@
+# Jukebox Lite Rebuild — Architecture Spec
+
+## 動機
+
+現状の `jukebox_lite` / `jukebox_lite_c` / `jukebox_lite_g` 3 変種は、各 AI が独立に 1200〜2200 行の bin を書いた結果、egui の暗黙前提 (first frame で必ず paint 完了する・状態変化で repaint を要求する) を踏み外す壊れ方をしている。
+
+具体例 (Gemini 版 `jukebox_lite_g`):
+- ウィンドウ作成後 `WS_VISIBLE` が立たないまま `frame_id=1` で停止
+- `request_repaint_after` が条件分岐 (再生中のみ) で first paint 失敗時に静止
+- CP コマンドは push されるが `ctx.request_repaint()` を呼ばないため main thread が起きない
+
+**結論**: 共通コア層が無く、各変種が壊れやすい同じ罠を独自コードで踏んでいる。コア層を抽出して UI 層を薄くする。
+
+## 設計方針
+
+### 層分離
+
+```
+┌──────────────────────────────────────────┐
+│ UI Layer (per variant)                    │
+│  - jukebox_lite     (Claude: card grid)   │
+│  - jukebox_lite_c   (Codex: dense list)   │
+│  - jukebox_lite_g   (Gemini: foobar2k)    │
+│  各 ~400 行以内、render() のみ            │
+└──────────────────────────────────────────┘
+                    │
+                    ▼
+┌──────────────────────────────────────────┐
+│ jukebox_core (新規 module: src/jukebox_core.rs) │
+│  - JukeboxState        (single source of truth) │
+│  - JukeboxLibrary      (track scan + library_db)│
+│  - JukeboxAudio        (cpal mixer + decoder)   │
+│  - JukeboxControl      (CP server + repaint)    │
+│  - JukeboxApp trait    (UI hook)                │
+│  - default update()    (repaint backstop)       │
+└──────────────────────────────────────────┘
+                    │
+                    ▼
+   keysynth lib (既存: library_db, play_log, gui_cp, synth, …)
+```
+
+### コア層の責務 (`src/jukebox_core.rs`)
+
+```rust
+pub struct JukeboxCore {
+    pub library: JukeboxLibrary,       // tracks, song_index, voice_count
+    pub audio: JukeboxAudio,            // mixer, sample_rate, pending_render
+    pub selection: JukeboxSelection,    // tile, search, sort, selected_label
+    pub history: JukeboxHistory,        // play_log, favorites, recent
+    pub control: JukeboxControl,        // cp_state, cp_handle, repaint_signal
+}
+
+impl JukeboxCore {
+    pub fn new(dirs: Vec<PathBuf>, app_name: &'static str) -> Result<Self, String>;
+    pub fn tick(&mut self, ctx: &egui::Context);  // drain CP, poll mixer, sync state
+    pub fn play(&mut self, label: &str);
+    pub fn stop(&mut self);
+    pub fn rescan(&mut self);
+    pub fn visible_tracks(&self) -> Vec<&Track>;
+}
+
+pub trait JukeboxApp {
+    fn render(&mut self, ctx: &egui::Context, core: &mut JukeboxCore);
+}
+
+// default eframe::App impl that all variants share
+pub struct JukeboxRunner<A: JukeboxApp> { core: JukeboxCore, app: A }
+
+impl<A: JukeboxApp> eframe::App for JukeboxRunner<A> {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.core.tick(ctx);
+        self.app.render(ctx, &mut self.core);
+        ctx.request_repaint_after(Duration::from_millis(500));  // backstop
+    }
+}
+```
+
+### バグを構造で殺す不変条件
+
+1. **First-paint 必達**: `JukeboxRunner::update` 末尾に**無条件** `request_repaint_after(500ms)` → first paint が完了し eframe が `ShowWindow` を呼ぶ
+2. **CP コマンドで repaint**: `JukeboxControl` 内の callback は `egui_ctx.request_repaint()` をクローン経由で呼ぶ → main thread を起こす
+3. **エラー伝播**: `JukeboxCore::new` が `Result` で全失敗を返す。panic は禁止 (silent first-paint failure を防ぐ)
+4. **state 単一所有**: 各 UI は `&mut JukeboxCore` を経由してのみ state を変更する。`Mutex` 重複ロックを禁止
+
+### UI 層の責務 (per variant)
+
+各 bin は 1 ファイル、200〜400 行目安。
+
+```rust
+struct JukeboxLiteG { /* UI-only state: scroll pos, hover etc */ }
+
+impl JukeboxApp for JukeboxLiteG {
+    fn render(&mut self, ctx: &egui::Context, core: &mut JukeboxCore) {
+        // ここで egui::SidePanel/CentralPanel/TopBottomPanel を組む
+        // core.library.tracks / core.audio.is_playing() / core.selection.tile を読む
+        // クリック時は core.play(label) / core.stop() / core.selection.set_tile(...) を呼ぶ
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let dirs = vec![PathBuf::from("bench-out/songs"), PathBuf::from("bench-out/CHIPTUNE")];
+    let core = JukeboxCore::new(dirs, "jukebox_lite_g")?;
+    let app = JukeboxLiteG::default();
+    let runner = JukeboxRunner::new(core, app);
+    eframe::run_native("JUKEBOX G",
+        eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default()
+                .with_inner_size([1100.0, 700.0])
+                .with_title("JUKEBOX G")
+                .with_visible(true),  // 明示
+            ..Default::default()
+        },
+        Box::new(|cc| {
+            keysynth::ui::setup_japanese_fonts(&cc.egui_ctx);
+            cc.egui_ctx.set_visuals(egui::Visuals::dark());
+            Ok(Box::new(runner))
+        }),
+    ).map_err(|e| format!("eframe: {e}").into())
+}
+```
+
+## チーム実行プラン
+
+### 入口・役割・キュー (5要素)
+
+| 要素 | 内容 |
+|---|---|
+| **入口** | この `JUKEBOX_REBUILD.md` |
+| **キュー** | Phase 1 (CORE) → Phase 2 (UI x3 並列) → Phase 3 (統合) |
+| **役割** | CORE agent / UI-A agent / UI-C agent / UI-G agent / Hub (Claude) |
+| **完了条件** | (1) `cargo build --release --bin <name>` 通過 (2) 起動後 5 秒以内に `IsWindowVisible` = true (3) frame_id が 5 秒で 10+ |
+| **停止条件** | ビルド3回失敗 or smoke test失敗 → hub に報告して停止 (自己修正ループは禁止) |
+
+### Phase 1: CORE 抽出 (1 agent, foreground)
+
+- worktree base: `team/jukebox-rebuild`
+- 触るファイル: `src/lib.rs` (mod 追加), `src/jukebox_core.rs` (新規)
+- 既存 `src/bin/jukebox_lite*.rs` には触らない
+- commit: `feat(jukebox_core): extract shared core (state/audio/cp/runner)`
+
+### Phase 2: UI 書き直し (3 agents, parallel)
+
+各エージェントは別 worktree。base は Phase 1 commit。
+
+| Agent | 担当ファイル | 既存スタイル参照 |
+|---|---|---|
+| UI-A | `src/bin/jukebox_lite.rs` | YouTube-style card grid |
+| UI-C | `src/bin/jukebox_lite_c.rs` | foobar2000-style dense list |
+| UI-G | `src/bin/jukebox_lite_g.rs` | Spotify-style with sidebar |
+
+各 agent commit: `refactor(jukebox_lite_X): rewrite on jukebox_core`
+
+### Phase 3: 統合 + smoke test (Hub)
+
+- 4 worktree の commit を `team/jukebox-rebuild` に順次 merge
+- `cargo build --release --bin jukebox_lite --bin jukebox_lite_c --bin jukebox_lite_g`
+- 3 バイナリそれぞれを別ターゲットに起動して `IsWindowVisible == true` を 5 秒以内に確認
+- PR を `team/jukebox-rebuild` → `main` に作成
+
+### 規律
+
+- **同一ファイルを2 agent で並列改変禁止** (worktree-isolation で物理的に分ける)
+- **`git add .` 禁止** (`git add <path>` のみ)
+- **brief は1 step = 1 tool call**
+- **build artifact は worktree 別 prefix** (`F:/rust-targets/<wt名>`) で衝突回避
+- agent は完了条件を満たさない場合 hub に報告して停止 (自己修正は最大3回)

--- a/src/bin/jukebox_lite.rs
+++ b/src/bin/jukebox_lite.rs
@@ -1,1861 +1,493 @@
-//! jukebox_lite — YouTube-style minimal jukebox (team/jukebox-lite-rebuild).
+//! `jukebox_lite` — Claude variant of the jukebox UI, rebuilt on
+//! [`keysynth::jukebox_core`].
 //!
-//! Why this exists: the main `jukebox` bin grew to 4600+ lines of
-//! per-row mixer / marker / personal-note / multi-tag controls and a
-//! flat catalog list — VLM critique reads "high willingness" but the
-//! lived experience says "わかりにくい、作り直した方がいい". Root cause is panel
-//! overload + per-row noise + no mood/genre nav.
+//! All shared concerns (cpal mixer, library scan, play_log, CP server,
+//! first-paint backstop, render-queue draining) live in the core. This
+//! file is *only* the YouTube-style card grid layout:
 //!
-//! Lite layout, modeled on YouTube:
-//!   - top header: logo / search / ⓘ stats popover
-//!   - left sidebar: mood/genre tiles (All / Favorites / Recent /
-//!     Classical / Game / Folk) — collapsible nav
-//!   - center: song-card grid (composer + era badge + 1-click play)
-//!   - bottom (when playing): Now Playing bar (title + composer +
-//!     progress + stop)
-//!   - right (when playing): "same composer / same era" recommendations
+//! ```text
+//!  ┌─────────────────────────────────────────────────────────────┐
+//!  │ TopBottomPanel top   — search + tile pills                  │
+//!  ├─────────────────────────────────────────────────────────────┤
+//!  │                                                             │
+//!  │ CentralPanel         — ScrollArea + grid of cards           │
+//!  │                        each card = title / composer / play  │
+//!  │                                                             │
+//!  ├─────────────────────────────────────────────────────────────┤
+//!  │ TopBottomPanel bot.  — now playing + progress + volume      │
+//!  └─────────────────────────────────────────────────────────────┘
+//! ```
 //!
-//! Deliberately NOT in lite: mixer panel, research panel, marker tags,
-//! personal-note editor, per-row voice picker, per-row checkbox / x2
-//! play-count column. Voice is picked automatically from mood:
-//!   Classical → piano-modal, Game → square, Folk → guitar-stk.
-//!
-//! Backend reuse: keysynth::library_db / play_log / preview_cache /
-//! gui_cp / ui::setup_japanese_fonts. Audio path is a single decoded
-//! slot (no multi-track mixer) wired to one cpal stream.
+//! No left side panel — that's the variant signature.
 
-use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::path::PathBuf;
+use std::time::Duration;
 
-use cp_core::RpcError;
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{SampleFormat, StreamConfig};
 use eframe::egui;
-use hound::{SampleFormat as WavSampleFormat, WavReader};
-use serde::Serialize;
-use serde_json::json;
-use symphonia::core::audio::{AudioBufferRef, Signal};
-use symphonia::core::codecs::{Decoder, DecoderOptions, CODEC_TYPE_NULL};
-use symphonia::core::errors::Error as SymphoniaError;
-use symphonia::core::formats::{FormatOptions, FormatReader};
-use symphonia::core::io::MediaSourceStream;
-use symphonia::core::meta::MetadataOptions;
-use symphonia::core::probe::Hint;
 
-use keysynth::gui_cp;
-use keysynth::library_db::{LibraryDb, Song, SongFilter, SongSort, VoiceFilter};
-use keysynth::play_log::{PlayEntry, PlayLogDb};
+use keysynth::jukebox_core::{
+    AudioSnapshot, Format, JukeboxApp, JukeboxCore, JukeboxRunner, Tile, Track,
+};
+use keysynth::library_db::Song;
 
 // ---------------------------------------------------------------------------
-// Source files
+// Layout constants
 // ---------------------------------------------------------------------------
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Format {
-    Wav,
-    Mp3,
-    Mid,
-}
-
-impl Format {
-    fn from_ext(ext: &str) -> Option<Self> {
-        match ext.to_ascii_lowercase().as_str() {
-            "wav" => Some(Format::Wav),
-            "mp3" => Some(Format::Mp3),
-            "mid" | "midi" => Some(Format::Mid),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct Track {
-    path: PathBuf,
-    /// Stable id (file stem) — joins to `Song::id` and `play_log` keys.
-    label: String,
-    format: Format,
-}
-
-fn scan_dirs(dirs: &[&Path]) -> Vec<Track> {
-    let mut out: Vec<Track> = Vec::new();
-    for d in dirs {
-        let read = match std::fs::read_dir(d) {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
-        // Per-dir dedup: prefer MP3 over same-stem WAV (matches the
-        // main jukebox's transition strategy).
-        let mut dir_tracks: Vec<Track> = Vec::new();
-        for ent in read.flatten() {
-            let p = ent.path();
-            let ext = match p.extension().and_then(|s| s.to_str()) {
-                Some(e) => e.to_ascii_lowercase(),
-                None => continue,
-            };
-            let fmt = match Format::from_ext(&ext) {
-                Some(f) => f,
-                None => continue,
-            };
-            let stem = match p.file_stem().and_then(|s| s.to_str()) {
-                Some(s) => s.to_string(),
-                None => continue,
-            };
-            dir_tracks.push(Track {
-                path: p,
-                label: stem,
-                format: fmt,
-            });
-        }
-        let mp3_stems: HashSet<String> = dir_tracks
-            .iter()
-            .filter(|t| t.format == Format::Mp3)
-            .map(|t| t.label.clone())
-            .collect();
-        for t in dir_tracks {
-            if t.format == Format::Wav && mp3_stems.contains(&t.label) {
-                continue;
-            }
-            out.push(t);
-        }
-    }
-    out.sort_by(|a, b| a.label.cmp(&b.label));
-    out
-}
+const CARD_MIN_W: f32 = 240.0;
+const CARD_HEIGHT: f32 = 110.0;
+const CARD_GAP: f32 = 10.0;
 
 // ---------------------------------------------------------------------------
-// Decoder (WAV via hound, MP3 via symphonia)
+// JukeboxLite — UI-only state
 // ---------------------------------------------------------------------------
 
-struct Mp3State {
-    /// Source path retained for diagnostic logs. Not read by the
-    /// decode loop; jukebox_lite never reopens (no in-loop seek).
-    #[allow(dead_code)]
-    path: PathBuf,
-    format: Box<dyn FormatReader>,
-    decoder: Box<dyn Decoder>,
-    track_id: u32,
-    scratch: Vec<f32>,
-    scratch_pos: usize,
-    eof: bool,
-}
-
-enum DecoderState {
-    Wav {
-        reader: WavReader<BufReader<File>>,
-        sample_format: WavSampleFormat,
-        bits_per_sample: u16,
-    },
-    Mp3(Mp3State),
-}
-
-struct DecodedTrack {
-    state: DecoderState,
-    sample_rate: u32,
-    channels: u16,
-    total_samples: u64,
-}
-
-fn open_wav(path: &Path) -> Result<DecodedTrack, String> {
-    let reader = WavReader::open(path).map_err(|e| format!("hound open: {e}"))?;
-    let spec = reader.spec();
-    let total = reader.duration() as u64 * spec.channels as u64;
-    Ok(DecodedTrack {
-        sample_rate: spec.sample_rate,
-        channels: spec.channels,
-        total_samples: total,
-        state: DecoderState::Wav {
-            reader,
-            sample_format: spec.sample_format,
-            bits_per_sample: spec.bits_per_sample,
-        },
-    })
-}
-
-fn open_mp3(path: &Path) -> Result<DecodedTrack, String> {
-    let file = File::open(path).map_err(|e| format!("mp3 open: {e}"))?;
-    let mss = MediaSourceStream::new(Box::new(file), Default::default());
-    let mut hint = Hint::new();
-    if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-        hint.with_extension(ext);
-    }
-    let probed = symphonia::default::get_probe()
-        .format(
-            &hint,
-            mss,
-            &FormatOptions::default(),
-            &MetadataOptions::default(),
-        )
-        .map_err(|e| format!("mp3 probe: {e}"))?;
-    let format = probed.format;
-    let track = format
-        .tracks()
-        .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
-        .ok_or_else(|| "mp3: no decodable track".to_string())?;
-    let track_id = track.id;
-    let cp = track.codec_params.clone();
-    let sr = cp
-        .sample_rate
-        .ok_or_else(|| "mp3: missing sample rate".to_string())?;
-    let ch = cp.channels.map(|c| c.count() as u16).unwrap_or(2);
-    let total = cp.n_frames.map(|n| n * ch as u64).unwrap_or(0);
-    let decoder = symphonia::default::get_codecs()
-        .make(&cp, &DecoderOptions::default())
-        .map_err(|e| format!("mp3 codec: {e}"))?;
-    Ok(DecodedTrack {
-        sample_rate: sr,
-        channels: ch,
-        total_samples: total,
-        state: DecoderState::Mp3(Mp3State {
-            path: path.to_path_buf(),
-            format,
-            decoder,
-            track_id,
-            scratch: Vec::new(),
-            scratch_pos: 0,
-            eof: false,
-        }),
-    })
-}
-
-fn open_decoded(path: &Path) -> Result<DecodedTrack, String> {
-    let ext = path
-        .extension()
-        .and_then(|s| s.to_str())
-        .map(|s| s.to_ascii_lowercase())
-        .unwrap_or_default();
-    match ext.as_str() {
-        "wav" => open_wav(path),
-        "mp3" => open_mp3(path),
-        other => Err(format!("unsupported format: {other}")),
-    }
-}
-
-fn mp3_decode_next(state: &mut Mp3State) -> Result<(), String> {
-    if state.eof {
-        return Ok(());
-    }
-    loop {
-        let packet = match state.format.next_packet() {
-            Ok(p) => p,
-            Err(SymphoniaError::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(SymphoniaError::ResetRequired) => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(e) => return Err(format!("mp3 next_packet: {e}")),
-        };
-        if packet.track_id() != state.track_id {
-            continue;
-        }
-        let decoded = match state.decoder.decode(&packet) {
-            Ok(d) => d,
-            Err(SymphoniaError::DecodeError(_)) => continue,
-            Err(SymphoniaError::IoError(_)) => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(e) => return Err(format!("mp3 decode: {e}")),
-        };
-        let frames = decoded.frames();
-        let spec = *decoded.spec();
-        let ch = spec.channels.count();
-        state.scratch.clear();
-        state.scratch_pos = 0;
-        state.scratch.reserve(frames * ch);
-        match decoded {
-            AudioBufferRef::F32(buf) => {
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f]);
-                    }
-                }
-            }
-            AudioBufferRef::S16(buf) => {
-                let inv = 1.0f32 / i16::MAX as f32;
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32 * inv);
-                    }
-                }
-            }
-            AudioBufferRef::S32(buf) => {
-                let inv = 1.0f32 / i32::MAX as f32;
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32 * inv);
-                    }
-                }
-            }
-            AudioBufferRef::F64(buf) => {
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32);
-                    }
-                }
-            }
-            // Rarer formats — skip the packet rather than panic; the
-            // jukebox-lite catalogue is overwhelmingly MIDI→WAV via
-            // preview_cache, so this branch is best-effort.
-            _ => continue,
-        }
-        if state.scratch.is_empty() {
-            continue;
-        }
-        return Ok(());
-    }
-}
-
-fn read_one_sample(dec: &mut DecodedTrack) -> Option<f32> {
-    match &mut dec.state {
-        DecoderState::Wav {
-            reader,
-            sample_format,
-            bits_per_sample,
-        } => match *sample_format {
-            WavSampleFormat::Int => {
-                let s: i32 = reader.samples::<i32>().next()?.ok()?;
-                let max = ((1u32 << (*bits_per_sample as u32 - 1)) - 1) as f32;
-                Some(s as f32 / max)
-            }
-            WavSampleFormat::Float => {
-                let s: f32 = reader.samples::<f32>().next()?.ok()?;
-                Some(s)
-            }
-        },
-        DecoderState::Mp3(state) => {
-            if state.scratch_pos >= state.scratch.len() {
-                if state.eof {
-                    return None;
-                }
-                if mp3_decode_next(state).is_err() {
-                    state.eof = true;
-                    return None;
-                }
-                if state.scratch_pos >= state.scratch.len() {
-                    return None;
-                }
-            }
-            let s = state.scratch[state.scratch_pos];
-            state.scratch_pos += 1;
-            Some(s)
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Audio mixer (single slot, mono-stereo aware)
-// ---------------------------------------------------------------------------
-
-struct AudioState {
-    decoded: Option<DecodedTrack>,
-    is_playing: bool,
-    cursor_frames: u64,
-    /// File label currently loaded (`Track::label`). Empty when idle.
-    label: String,
-    volume: f32,
-}
-
-impl AudioState {
-    fn new() -> Self {
-        Self {
-            decoded: None,
-            is_playing: false,
-            cursor_frames: 0,
-            label: String::new(),
-            volume: 0.85,
-        }
-    }
-}
-
-struct Mixer {
-    state: Arc<Mutex<AudioState>>,
-    _stream: cpal::Stream,
-}
-
-fn fill_callback(out: &mut [f32], channels: u16, state: &Arc<Mutex<AudioState>>) {
-    for s in out.iter_mut() {
-        *s = 0.0;
-    }
-    let mut st = match state.lock() {
-        Ok(g) => g,
-        Err(_) => return,
-    };
-    if !st.is_playing {
-        return;
-    }
-    let vol = st.volume.clamp(0.0, 1.5);
-    let dec = match st.decoded.as_mut() {
-        Some(d) => d,
-        None => {
-            st.is_playing = false;
-            return;
-        }
-    };
-    let dec_ch = dec.channels;
-    let frames = out.len() / channels.max(1) as usize;
-    let mut cursor_advanced: u64 = 0;
-    let mut hit_eof = false;
-    for f in 0..frames {
-        let (l, r) = match dec_ch {
-            1 => {
-                let s = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                (s, s)
-            }
-            2 => {
-                let l = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                let r = read_one_sample(dec).unwrap_or(l);
-                (l, r)
-            }
-            n => {
-                let l = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                let r = read_one_sample(dec).unwrap_or(l);
-                for _ in 2..n {
-                    let _ = read_one_sample(dec);
-                }
-                (l, r)
-            }
-        };
-        cursor_advanced += 1;
-        let bus_l = (l * vol).tanh();
-        let bus_r = (r * vol).tanh();
-        let base = f * channels as usize;
-        match channels {
-            1 => out[base] = (bus_l + bus_r) * 0.5,
-            2 => {
-                out[base] = bus_l;
-                out[base + 1] = bus_r;
-            }
-            n => {
-                out[base] = bus_l;
-                out[base + 1] = bus_r;
-                for c in 2..n as usize {
-                    out[base + c] = 0.0;
-                }
-            }
-        }
-    }
-    st.cursor_frames = st.cursor_frames.saturating_add(cursor_advanced);
-    if hit_eof {
-        st.is_playing = false;
-    }
-}
-
-fn build_mixer_stream(state: Arc<Mutex<AudioState>>) -> Result<Mixer, String> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or_else(|| "no default output device".to_string())?;
-    let supported = device
-        .default_output_config()
-        .map_err(|e| format!("default_output_config: {e}"))?;
-    let sample_format = supported.sample_format();
-    let channels = supported.channels();
-    let stream_cfg: StreamConfig = supported.into();
-    let err_fn = |err| eprintln!("jukebox_lite audio stream error: {err}");
-    let stream = match sample_format {
-        SampleFormat::F32 => {
-            let st = state.clone();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [f32], _| fill_callback(out, channels, &st),
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build f32: {e}"))?
-        }
-        SampleFormat::I16 => {
-            let st = state.clone();
-            let mut scratch: Vec<f32> = Vec::new();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [i16], _| {
-                        if scratch.len() != out.len() {
-                            scratch.resize(out.len(), 0.0);
-                        }
-                        for s in scratch.iter_mut() {
-                            *s = 0.0;
-                        }
-                        fill_callback(&mut scratch, channels, &st);
-                        for (dst, src) in out.iter_mut().zip(scratch.iter()) {
-                            let c = src.clamp(-1.0, 1.0);
-                            *dst = (c * i16::MAX as f32) as i16;
-                        }
-                    },
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build i16: {e}"))?
-        }
-        SampleFormat::U16 => {
-            let st = state.clone();
-            let mut scratch: Vec<f32> = Vec::new();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [u16], _| {
-                        if scratch.len() != out.len() {
-                            scratch.resize(out.len(), 0.0);
-                        }
-                        for s in scratch.iter_mut() {
-                            *s = 0.0;
-                        }
-                        fill_callback(&mut scratch, channels, &st);
-                        for (dst, src) in out.iter_mut().zip(scratch.iter()) {
-                            let c = src.clamp(-1.0, 1.0);
-                            *dst = (((c + 1.0) * 0.5) * u16::MAX as f32) as u16;
-                        }
-                    },
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build u16: {e}"))?
-        }
-        other => return Err(format!("unsupported sample format: {other:?}")),
-    };
-    stream.play().map_err(|e| format!("stream.play: {e}"))?;
-    Ok(Mixer {
-        state,
-        _stream: stream,
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Preview cache (MIDI → WAV via render_midi subprocess)
-// ---------------------------------------------------------------------------
-
-fn render_midi_binary_path() -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    let dir = exe.parent()?;
-    let candidates = if cfg!(windows) {
-        vec!["render_midi.exe"]
-    } else {
-        vec!["render_midi"]
-    };
-    candidates
-        .into_iter()
-        .map(|name| dir.join(name))
-        .find(|p| p.is_file())
-}
-
-fn cache_key(track_path: &Path, voice_id: &str) -> keysynth::preview_cache::CacheKey {
-    keysynth::preview_cache::CacheKey {
-        song_path: track_path.to_path_buf(),
-        voice_id: voice_id.to_string(),
-        voice_dll: None,
-        render_params: keysynth::preview_cache::RenderParams::default(),
-    }
-}
-
-fn open_preview_cache() -> Result<keysynth::preview_cache::Cache, String> {
-    let cache_dir = PathBuf::from("bench-out/cache");
-    keysynth::preview_cache::Cache::new(&cache_dir, 1_073_741_824)
-        .map_err(|e| format!("Cache::new: {e}"))
-}
-
-fn lookup_in_cache(track_path: &Path, voice_id: &str) -> Result<Option<PathBuf>, String> {
-    let cache = open_preview_cache()?;
-    let key = cache_key(track_path, voice_id);
-    cache.lookup(&key).map_err(|e| format!("lookup: {e}"))
-}
-
-fn render_midi_blocking(midi_path: &Path, voice_id: &str) -> Result<PathBuf, String> {
-    let cache = open_preview_cache()?;
-    let key = cache_key(midi_path, voice_id);
-    let bin = render_midi_binary_path()
-        .ok_or_else(|| "render_midi binary not found alongside jukebox_lite".to_string())?;
-    keysynth::preview_cache::render_to_cache(&cache, &key, voice_id, &bin)
-        .map_err(|e| format!("render_to_cache: {e}"))
-}
-
-// ---------------------------------------------------------------------------
-// Sidebar tile semantics
-// ---------------------------------------------------------------------------
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Tile {
-    All,
-    Favorites,
-    Recent,
-    Classical,
-    Game,
-    Folk,
-}
-
-impl Tile {
-    fn label(self) -> &'static str {
-        match self {
-            Tile::All => "All",
-            Tile::Favorites => "Favorites",
-            Tile::Recent => "Recent",
-            Tile::Classical => "Classical",
-            Tile::Game => "Game",
-            Tile::Folk => "Folk",
-        }
-    }
-    fn icon(self) -> &'static str {
-        match self {
-            Tile::All => "\u{1F3B5}",     // 🎵
-            Tile::Favorites => "\u{2B50}", // ⭐
-            Tile::Recent => "\u{1F551}",   // 🕑
-            Tile::Classical => "\u{1F3B9}", // 🎹
-            Tile::Game => "\u{1F3AE}",      // 🎮
-            Tile::Folk => "\u{1FA95}",      // 🪕
-        }
-    }
-    fn all() -> &'static [Tile] {
-        &[
-            Tile::All,
-            Tile::Favorites,
-            Tile::Recent,
-            Tile::Classical,
-            Tile::Game,
-            Tile::Folk,
-        ]
-    }
-}
-
-/// Pick the default voice for a track based on its mood.
-/// Mood is derived first from the active sidebar tile (when the user
-/// clicked into a genre, that's their explicit context), then from
-/// per-track Song metadata, then from a stem heuristic.
-fn pick_voice(tile: Tile, song: Option<&Song>, track: &Track) -> &'static str {
-    if matches!(track.format, Format::Wav | Format::Mp3) {
-        // Already-rendered audio doesn't need a voice; cached WAVs play
-        // verbatim. Returning a sentinel keeps the snapshot/CP wire
-        // honest.
-        return "—";
-    }
-    match tile {
-        Tile::Classical => return "piano-modal",
-        Tile::Game => return "square",
-        Tile::Folk => return "guitar-stk",
-        _ => {}
-    }
-    if let Some(s) = song {
-        let ins = s.instrument.to_ascii_lowercase();
-        if ins.contains("guitar") {
-            return "guitar-stk";
-        }
-        if ins.contains("piano") {
-            return "piano-modal";
-        }
-        if let Some(era) = s.era.as_deref() {
-            if matches!(era, "Baroque" | "Classical" | "Romantic" | "Modern") {
-                return "piano-modal";
-            }
-            if era == "Traditional" {
-                return "guitar-stk";
-            }
-        }
-    }
-    let stem = track.label.to_ascii_lowercase();
-    if stem.starts_with("cc0_")
-        || stem.starts_with("parodius")
-        || stem.starts_with("bgm_v")
-        || stem.starts_with('v')
-    {
-        return "square";
-    }
-    "guitar-stk"
-}
-
-/// Decide whether `track` belongs in `tile`. Tracks without DB
-/// metadata fall through `Game` (catch-all for filename-only entries
-/// like `cc0_*` chiptune dumps).
-fn track_matches_tile(
-    tile: Tile,
-    track: &Track,
-    song: Option<&Song>,
-    favorites: &HashSet<String>,
-    recent: &HashSet<String>,
-) -> bool {
-    match tile {
-        Tile::All => true,
-        Tile::Favorites => favorites.contains(&track.label),
-        Tile::Recent => recent.contains(&track.label),
-        Tile::Classical => song
-            .and_then(|s| s.era.as_deref())
-            .map(|e| matches!(e, "Baroque" | "Classical" | "Romantic" | "Modern"))
-            .unwrap_or(false),
-        Tile::Folk => song
-            .map(|s| {
-                s.instrument.to_ascii_lowercase().contains("guitar")
-                    || s.era.as_deref() == Some("Traditional")
-            })
-            .unwrap_or(false),
-        Tile::Game => {
-            if song.is_none() {
-                return true;
-            }
-            let s = song.unwrap();
-            let ins = s.instrument.to_ascii_lowercase();
-            ins.contains("synth") || ins.contains("game") || ins.contains("chip")
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Visual helpers
-// ---------------------------------------------------------------------------
-
-fn era_color(era: &str) -> egui::Color32 {
-    match era {
-        "Baroque" => egui::Color32::from_rgb(200, 160, 100),
-        "Classical" => egui::Color32::from_rgb(140, 220, 160),
-        "Romantic" => egui::Color32::from_rgb(220, 160, 230),
-        "Modern" => egui::Color32::from_rgb(120, 200, 240),
-        "Traditional" => egui::Color32::from_rgb(240, 200, 120),
-        _ => egui::Color32::from_rgb(170, 170, 170),
-    }
-}
-
-fn compact_composer(composer: &str) -> String {
-    let core = match composer.split_once('(') {
-        Some((before, _)) => before,
-        None => composer,
-    };
-    core.trim().to_string()
-}
-
-// ---------------------------------------------------------------------------
-// Library + history bootstrap
-// ---------------------------------------------------------------------------
-
-fn load_library_index() -> (HashMap<String, Song>, usize) {
-    let db_path = PathBuf::from("bench-out/library.db");
-    let manifest = PathBuf::from("bench-out/songs/manifest.json");
-    let voices_live = PathBuf::from("voices_live");
-    let mut db = match LibraryDb::open(&db_path) {
-        Ok(db) => db,
-        Err(e) => {
-            eprintln!(
-                "jukebox_lite: library_db open failed ({}): {e} — running without DB metadata",
-                db_path.display()
-            );
-            return (HashMap::new(), 0);
-        }
-    };
-    if let Err(e) = db.migrate() {
-        eprintln!("jukebox_lite: library_db migrate failed: {e}");
-        return (HashMap::new(), 0);
-    }
-    if manifest.is_file() {
-        if let Err(e) = db.import_songs(&manifest) {
-            eprintln!("jukebox_lite: library_db import_songs failed: {e}");
-        }
-    }
-    if voices_live.is_dir() {
-        if let Err(e) = db.import_voices(&voices_live) {
-            eprintln!("jukebox_lite: library_db import_voices failed: {e}");
-        }
-    }
-    let songs = db
-        .query_songs(&SongFilter {
-            sort: SongSort::ByComposer,
-            ..Default::default()
-        })
-        .unwrap_or_default();
-    let voice_count = db
-        .query_voices(&VoiceFilter::default())
-        .map(|v| v.len())
-        .unwrap_or(0);
-    let mut idx = HashMap::new();
-    for s in songs {
-        idx.insert(s.id.clone(), s);
-    }
-    (idx, voice_count)
-}
-
-fn load_play_log() -> Option<PlayLogDb> {
-    let db_path = PathBuf::from("bench-out/play_log.db");
-    let mut db = match PlayLogDb::open(&db_path) {
-        Ok(db) => db,
-        Err(e) => {
-            eprintln!("jukebox_lite: play_log open failed: {e}");
-            return None;
-        }
-    };
-    if let Err(e) = db.migrate() {
-        eprintln!("jukebox_lite: play_log migrate failed: {e}");
-        return None;
-    }
-    Some(db)
-}
-
-const RECENT_WINDOW: usize = 24;
-
-fn snapshot_history(
-    log: Option<&PlayLogDb>,
-) -> (HashSet<String>, HashSet<String>, Vec<PlayEntry>) {
-    let mut favs: HashSet<String> = HashSet::new();
-    let mut recent_ids: HashSet<String> = HashSet::new();
-    let mut recent_entries: Vec<PlayEntry> = Vec::new();
-    if let Some(db) = log {
-        if let Ok(f) = db.favorites() {
-            favs = f.into_iter().collect();
-        }
-        if let Ok(r) = db.recent_plays(RECENT_WINDOW) {
-            for e in &r {
-                recent_ids.insert(e.song_id.clone());
-            }
-            recent_entries = r;
-        }
-    }
-    (favs, recent_ids, recent_entries)
-}
-
-// ---------------------------------------------------------------------------
-// CP server snapshot/command types
-// ---------------------------------------------------------------------------
-
-#[derive(Clone, Debug, Default, Serialize)]
-struct CpSnapshot {
-    frame_id: u64,
-    track_count: usize,
-    db_song_count: usize,
-    db_voice_count: usize,
-    selected_label: Option<String>,
-    selected_tile: String,
-    any_playing: bool,
-    /// `Track::label` of whatever the user has loaded into the slot.
-    loaded_label: Option<String>,
-    cursor_frames: u64,
-    total_frames: u64,
-    sample_rate: u32,
-    /// Catalog rows visible after current tile + filter, in display order.
-    visible_labels: Vec<String>,
-    /// Every catalog row label, regardless of filter — verifiers use
-    /// this to pick a known label without having to mirror filter
-    /// semantics.
-    all_labels: Vec<String>,
-}
-
-#[derive(Clone, Debug)]
-enum CpCommand {
-    LoadTrack { label: String },
-    Play,
-    Stop,
-    SelectTile { tile: String },
-    Rescan,
-}
-
-fn spawn_cp_server(
-    state: gui_cp::State<CpSnapshot, CpCommand>,
-) -> std::io::Result<gui_cp::Handle> {
-    let endpoint = gui_cp::resolve_endpoint("jukebox_lite", None);
-    let st_get = state.clone();
-    let st_load = state.clone();
-    let st_play = state.clone();
-    let st_stop = state.clone();
-    let st_tile = state.clone();
-    let st_rescan = state.clone();
-    let st_list = state.clone();
-    gui_cp::Builder::new("jukebox_lite", &endpoint)
-        .register("get_state", move |_p| match st_get.read_snapshot() {
-            Some(snap) => gui_cp::encode_result(snap),
-            None => Ok(json!({"frame_id": 0, "warming_up": true})),
-        })
-        .register("load_track", move |p| {
-            #[derive(serde::Deserialize)]
-            struct Args {
-                label: String,
-            }
-            let a: Args = gui_cp::decode_params(p)?;
-            st_load.push_command(CpCommand::LoadTrack {
-                label: a.label.clone(),
-            });
-            Ok(json!({"queued": "load_track", "label": a.label}))
-        })
-        .register("play", move |_p| {
-            st_play.push_command(CpCommand::Play);
-            Ok(json!({"queued": "play"}))
-        })
-        .register("stop", move |_p| {
-            st_stop.push_command(CpCommand::Stop);
-            Ok(json!({"queued": "stop"}))
-        })
-        .register("select_tile", move |p| {
-            #[derive(serde::Deserialize)]
-            struct Args {
-                tile: String,
-            }
-            let a: Args = gui_cp::decode_params(p)?;
-            st_tile.push_command(CpCommand::SelectTile {
-                tile: a.tile.clone(),
-            });
-            Ok(json!({"queued": "select_tile", "tile": a.tile}))
-        })
-        .register("rescan", move |_p| {
-            st_rescan.push_command(CpCommand::Rescan);
-            Ok(json!({"queued": "rescan"}))
-        })
-        .register("list_tracks", move |p| {
-            #[derive(serde::Deserialize, Default)]
-            #[serde(default)]
-            struct Args {
-                limit: Option<usize>,
-                contains: Option<String>,
-            }
-            let a: Args = serde_json::from_value(p)
-                .map_err(|e| RpcError::invalid_params(format!("param parse: {e}")))?;
-            let snap = match st_list.read_snapshot() {
-                Some(s) => s,
-                None => return Ok(json!({"warming_up": true, "tracks": []})),
-            };
-            let needle = a.contains.unwrap_or_default().to_ascii_lowercase();
-            let limit = a.limit.unwrap_or(usize::MAX);
-            let tracks: Vec<&str> = snap
-                .all_labels
-                .iter()
-                .filter(|l| needle.is_empty() || l.to_ascii_lowercase().contains(&needle))
-                .take(limit)
-                .map(|s| s.as_str())
-                .collect();
-            Ok(json!({
-                "tracks": tracks,
-                "track_count": snap.track_count,
-            }))
-        })
-        .serve()
-}
-
-fn tile_from_str(s: &str) -> Option<Tile> {
-    match s.to_ascii_lowercase().as_str() {
-        "all" => Some(Tile::All),
-        "favorites" | "favs" | "fav" => Some(Tile::Favorites),
-        "recent" => Some(Tile::Recent),
-        "classical" => Some(Tile::Classical),
-        "game" => Some(Tile::Game),
-        "folk" => Some(Tile::Folk),
-        _ => None,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Pending background renders
-// ---------------------------------------------------------------------------
-
-struct PendingRender {
-    track_label: String,
-    voice_id: String,
-    started: Instant,
-    rx: std::sync::mpsc::Receiver<Result<PathBuf, String>>,
-    _handle: std::thread::JoinHandle<()>,
-}
-
-// ---------------------------------------------------------------------------
-// App
-// ---------------------------------------------------------------------------
-
+/// Per-frame UI state. Anything persistent (selected track, playing
+/// label, library, history) lives in [`JukeboxCore`]; this struct only
+/// owns the bits that don't survive into the CP snapshot — namely the
+/// search-box echo we keep in sync with `core.selection.search`.
+#[derive(Default)]
 struct JukeboxLite {
-    tracks: Vec<Track>,
-    song_index: HashMap<String, Song>,
-    db_voice_count: usize,
-    play_log: Option<PlayLogDb>,
-    favorites: HashSet<String>,
-    recent_ids: HashSet<String>,
-    recent_entries: Vec<PlayEntry>,
+    /// Local mirror of the search box, kept in lockstep with
+    /// `core.selection.search`. We need a separate `String` because
+    /// `egui::TextEdit` borrows `&mut String` for the full pass and
+    /// we can't borrow `core` mutably twice.
+    search_buf: String,
+    search_synced: bool,
+}
 
-    mixer: Mixer,
-    sample_rate_for_progress: u32,
-    pending_render: Option<PendingRender>,
+impl JukeboxApp for JukeboxLite {
+    fn render(&mut self, ctx: &egui::Context, core: &mut JukeboxCore, visible: &[Track]) {
+        // First entry: pull the CP-driven search value into our buffer.
+        if !self.search_synced {
+            self.search_buf = core.selection.search.clone();
+            self.search_synced = true;
+        }
 
-    /// Currently active tile in the left sidebar.
-    tile: Tile,
-    /// Substring filter from the header search input.
-    search: String,
-    /// Track::label currently loaded (or last-loaded) — drives the
-    /// selected-row glyph and recommendations panel.
-    selected_label: Option<String>,
-    /// Show the ⓘ stats popover next to the search box.
-    show_stats: bool,
+        self.draw_top_bar(ctx, core, visible.len());
+        self.draw_now_playing(ctx, core);
+        self.draw_card_grid(ctx, core, visible);
 
-    refresh_dirs: Vec<PathBuf>,
-
-    cp_state: gui_cp::State<CpSnapshot, CpCommand>,
-    _cp_handle: Option<gui_cp::Handle>,
-    cp_frame_id: u64,
+        // While audio is rolling, ask for a faster refresh so the
+        // progress bar advances smoothly. The Runner already enforces
+        // a 500ms backstop for first-paint; this is purely cosmetic.
+        if core.audio.is_playing() || core.audio.pending_render.is_some() {
+            ctx.request_repaint_after(Duration::from_millis(100));
+        }
+    }
 }
 
 impl JukeboxLite {
-    fn new(dirs: Vec<PathBuf>) -> Result<Self, String> {
-        let (song_index, db_voice_count) = load_library_index();
-        let dir_refs: Vec<&Path> = dirs.iter().map(|p| p.as_path()).collect();
-        let tracks = scan_dirs(&dir_refs);
-        println!(
-            "jukebox_lite: library_db catalog \u{2192} {} songs / {} voices ({} files on disk)",
-            song_index.len(),
-            db_voice_count,
-            tracks.len(),
-        );
-        let play_log = load_play_log();
-        let (favorites, recent_ids, recent_entries) = snapshot_history(play_log.as_ref());
-
-        let audio = Arc::new(Mutex::new(AudioState::new()));
-        let mixer = build_mixer_stream(audio).map_err(|e| format!("audio: {e}"))?;
-        let sample_rate_for_progress = 44_100;
-
-        let cp_state: gui_cp::State<CpSnapshot, CpCommand> = gui_cp::State::new();
-        let cp_handle = match spawn_cp_server(cp_state.clone()) {
-            Ok(h) => Some(h),
-            Err(e) => {
-                eprintln!("jukebox_lite: CP server failed: {e}");
-                None
-            }
-        };
-
-        let initial_label = recent_entries
-            .first()
-            .map(|e| e.song_id.clone())
-            .or_else(|| favorites.iter().next().cloned())
-            .or_else(|| tracks.first().map(|t| t.label.clone()));
-
-        Ok(Self {
-            tracks,
-            song_index,
-            db_voice_count,
-            play_log,
-            favorites,
-            recent_ids,
-            recent_entries,
-            mixer,
-            sample_rate_for_progress,
-            pending_render: None,
-            tile: Tile::All,
-            search: String::new(),
-            selected_label: initial_label,
-            show_stats: false,
-            refresh_dirs: dirs,
-            cp_state,
-            _cp_handle: cp_handle,
-            cp_frame_id: 0,
-        })
-    }
-
-    fn rescan(&mut self) {
-        let dir_refs: Vec<&Path> = self.refresh_dirs.iter().map(|p| p.as_path()).collect();
-        self.tracks = scan_dirs(&dir_refs);
-        let (idx, vc) = load_library_index();
-        self.song_index = idx;
-        self.db_voice_count = vc;
-        let (f, r, re) = snapshot_history(self.play_log.as_ref());
-        self.favorites = f;
-        self.recent_ids = r;
-        self.recent_entries = re;
-    }
-
-    fn refresh_history(&mut self) {
-        let (f, r, re) = snapshot_history(self.play_log.as_ref());
-        self.favorites = f;
-        self.recent_ids = r;
-        self.recent_entries = re;
-    }
-
-    /// Compute the visible track set after applying current tile +
-    /// search. Returns clones so the GUI can borrow `self` for
-    /// playback during iteration.
-    fn visible_tracks(&self) -> Vec<Track> {
-        let needle = self.search.trim().to_ascii_lowercase();
-        let mut out: Vec<Track> = self
-            .tracks
-            .iter()
-            .filter(|t| {
-                let song = self.song_index.get(&t.label);
-                if !track_matches_tile(self.tile, t, song, &self.favorites, &self.recent_ids) {
-                    return false;
-                }
-                if needle.is_empty() {
-                    return true;
-                }
-                let title = song.map(|s| s.title.as_str()).unwrap_or("");
-                let composer = song.map(|s| s.composer.as_str()).unwrap_or("");
-                t.label.to_ascii_lowercase().contains(&needle)
-                    || title.to_ascii_lowercase().contains(&needle)
-                    || composer.to_ascii_lowercase().contains(&needle)
-            })
-            .cloned()
-            .collect();
-        // For Recent, sort by most-recent-first using recent_entries
-        // order; everything else stays in the catalog (composer) order
-        // already produced by `scan_dirs` + the DB index.
-        if self.tile == Tile::Recent {
-            let order: HashMap<&str, usize> = self
-                .recent_entries
-                .iter()
-                .enumerate()
-                .map(|(i, e)| (e.song_id.as_str(), i))
-                .collect();
-            out.sort_by_key(|t| order.get(t.label.as_str()).copied().unwrap_or(usize::MAX));
-        } else if !self.song_index.is_empty() {
-            out.sort_by(|a, b| {
-                let ka = self.song_index.get(&a.label).map(|s| s.composer_key.clone());
-                let kb = self.song_index.get(&b.label).map(|s| s.composer_key.clone());
-                match (ka, kb) {
-                    (Some(x), Some(y)) => x.cmp(&y).then_with(|| a.label.cmp(&b.label)),
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                    (None, None) => a.label.cmp(&b.label),
-                }
-            });
-        }
-        out
-    }
-
-    fn play_track(&mut self, track: Track) {
-        let song = self.song_index.get(&track.label).cloned();
-        let voice = pick_voice(self.tile, song.as_ref(), &track).to_string();
-        self.selected_label = Some(track.label.clone());
-
-        let playable: PathBuf = match track.format {
-            Format::Mid => match lookup_in_cache(&track.path, &voice) {
-                Ok(Some(p)) => p,
-                Ok(None) => {
-                    self.spawn_render(&track, &voice);
-                    return;
-                }
-                Err(e) => {
-                    eprintln!("jukebox_lite: cache lookup {}: {e}", track.path.display());
-                    return;
-                }
-            },
-            Format::Wav | Format::Mp3 => track.path.clone(),
-        };
-        self.load_resolved(track.label.clone(), playable, &voice);
-    }
-
-    fn spawn_render(&mut self, track: &Track, voice: &str) {
-        let path = track.path.clone();
-        let voice_for_thread = voice.to_string();
-        let label = track.label.clone();
-        let (tx, rx) = std::sync::mpsc::channel();
-        let handle = std::thread::Builder::new()
-            .name("jukebox-lite-render".into())
-            .spawn(move || {
-                let result = render_midi_blocking(&path, &voice_for_thread);
-                let _ = tx.send(result);
-            })
-            .expect("spawn render thread");
-        eprintln!(
-            "jukebox_lite: render queued ({}) — voice={}",
-            track.path.display(),
-            voice
-        );
-        self.pending_render = Some(PendingRender {
-            track_label: label,
-            voice_id: voice.to_string(),
-            started: Instant::now(),
-            rx,
-            _handle: handle,
-        });
-    }
-
-    fn poll_pending_render(&mut self) {
-        let pending = match self.pending_render.as_ref() {
-            Some(p) => p,
-            None => return,
-        };
-        let result = match pending.rx.try_recv() {
-            Ok(r) => r,
-            Err(std::sync::mpsc::TryRecvError::Empty) => return,
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                self.pending_render = None;
-                return;
-            }
-        };
-        let pending = self.pending_render.take().expect("guarded");
-        let elapsed = pending.started.elapsed().as_millis();
-        match result {
-            Ok(wav) => {
-                eprintln!(
-                    "jukebox_lite: render done ({}) in {} ms",
-                    wav.display(),
-                    elapsed
-                );
-                self.load_resolved(pending.track_label, wav, &pending.voice_id);
-            }
-            Err(e) => {
-                eprintln!("jukebox_lite: render failed: {e}");
-            }
-        }
-    }
-
-    fn load_resolved(&mut self, label: String, playable: PathBuf, voice: &str) {
-        let dec = match open_decoded(&playable) {
-            Ok(d) => d,
-            Err(e) => {
-                eprintln!("jukebox_lite: open {}: {e}", playable.display());
-                return;
-            }
-        };
-        let sr = dec.sample_rate;
-        {
-            let mut st = match self.mixer.state.lock() {
-                Ok(g) => g,
-                Err(_) => return,
-            };
-            st.decoded = Some(dec);
-            st.is_playing = true;
-            st.cursor_frames = 0;
-            st.label = label.clone();
-        }
-        self.sample_rate_for_progress = sr;
-        self.selected_label = Some(label.clone());
-
-        // play_log: voice column carries the mood-derived voice id so
-        // history reflects what was actually rendered/heard.
-        if let Some(db) = self.play_log.as_mut() {
-            let v = if voice == "—" { None } else { Some(voice) };
-            if let Err(e) = db.record_play(&label, v, None) {
-                eprintln!("jukebox_lite: record_play({label}): {e}");
-            }
-        }
-        self.refresh_history();
-    }
-
-    fn stop(&mut self) {
-        if let Ok(mut st) = self.mixer.state.lock() {
-            st.is_playing = false;
-        }
-    }
-
-    fn drain_cp_commands(&mut self) {
-        for cmd in self.cp_state.drain_commands() {
-            match cmd {
-                CpCommand::LoadTrack { label } => {
-                    if let Some(t) = self.tracks.iter().find(|t| t.label == label).cloned() {
-                        self.play_track(t);
-                    } else {
-                        eprintln!("jukebox_lite: CP load_track unknown label={label}");
-                    }
-                }
-                CpCommand::Play => {
-                    if let Ok(mut st) = self.mixer.state.lock() {
-                        if st.decoded.is_some() {
-                            st.is_playing = true;
-                        }
-                    }
-                }
-                CpCommand::Stop => self.stop(),
-                CpCommand::SelectTile { tile } => {
-                    if let Some(t) = tile_from_str(&tile) {
-                        self.tile = t;
-                    }
-                }
-                CpCommand::Rescan => self.rescan(),
-            }
-        }
-    }
-
-    fn publish_cp_snapshot(&mut self, visible: &[Track]) {
-        self.cp_frame_id = self.cp_frame_id.saturating_add(1);
-        let (any_playing, loaded_label, cursor_frames, total_frames) = {
-            let st = self.mixer.state.lock().ok();
-            match st {
-                Some(g) => (
-                    g.is_playing,
-                    if g.label.is_empty() {
-                        None
-                    } else {
-                        Some(g.label.clone())
-                    },
-                    g.cursor_frames,
-                    g.decoded
-                        .as_ref()
-                        .map(|d| d.total_samples / d.channels.max(1) as u64)
-                        .unwrap_or(0),
-                ),
-                None => (false, None, 0, 0),
-            }
-        };
-        let snap = CpSnapshot {
-            frame_id: self.cp_frame_id,
-            track_count: self.tracks.len(),
-            db_song_count: self.song_index.len(),
-            db_voice_count: self.db_voice_count,
-            selected_label: self.selected_label.clone(),
-            selected_tile: self.tile.label().to_string(),
-            any_playing,
-            loaded_label,
-            cursor_frames,
-            total_frames,
-            sample_rate: self.sample_rate_for_progress,
-            visible_labels: visible.iter().map(|t| t.label.clone()).collect(),
-            all_labels: self.tracks.iter().map(|t| t.label.clone()).collect(),
-        };
-        self.cp_state.publish(snap);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// UI rendering
-// ---------------------------------------------------------------------------
-
-const SIDEBAR_WIDTH: f32 = 200.0;
-const CARD_MIN_W: f32 = 220.0;
-const CARD_HEIGHT: f32 = 96.0;
-
-impl eframe::App for JukeboxLite {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Drain any queued CP commands and pending background renders
-        // first so the UI reflects them in the same paint.
-        self.drain_cp_commands();
-        self.poll_pending_render();
-
-        let visible = self.visible_tracks();
-
-        // Top header
-        egui::TopBottomPanel::top("jukebox_lite_header")
-            .exact_height(54.0)
+    // -----------------------------------------------------------------
+    // Top bar — search box + tile pills
+    // -----------------------------------------------------------------
+    fn draw_top_bar(&mut self, ctx: &egui::Context, core: &mut JukeboxCore, result_count: usize) {
+        egui::TopBottomPanel::top("jukebox_lite_top")
+            .exact_height(58.0)
             .show(ctx, |ui| {
                 ui.add_space(6.0);
                 ui.horizontal(|ui| {
                     ui.add_space(8.0);
-                    ui.heading("\u{1F3B5}  jukebox lite");
-                    ui.add_space(20.0);
-                    ui.label("\u{1F50D}");
-                    ui.add(
-                        egui::TextEdit::singleline(&mut self.search)
-                            .desired_width(280.0)
-                            .hint_text("Search composer / title…"),
-                    );
-                    ui.add_space(8.0);
-                    if ui.button("\u{2716} clear").clicked() {
-                        self.search.clear();
+                    ui.label(egui::RichText::new("\u{1F50D}").size(16.0));
+                    let search = egui::TextEdit::singleline(&mut self.search_buf)
+                        .hint_text("search title / composer / id…")
+                        .desired_width(280.0);
+                    let resp = ui.add(search);
+                    if resp.changed() {
+                        core.selection.search = self.search_buf.clone();
                     }
-                    // Push the stats button to the far right.
+                    if !self.search_buf.is_empty() {
+                        if ui.small_button("\u{2715}").clicked() {
+                            self.search_buf.clear();
+                            core.selection.search.clear();
+                        }
+                    }
+                    ui.add_space(12.0);
+                    ui.separator();
+                    ui.add_space(6.0);
+
+                    // Tile pills
+                    for &tile in Tile::all() {
+                        let active = core.selection.tile == tile;
+                        let label = tile.label();
+                        let txt = if active {
+                            egui::RichText::new(label)
+                                .strong()
+                                .color(egui::Color32::WHITE)
+                        } else {
+                            egui::RichText::new(label).color(egui::Color32::LIGHT_GRAY)
+                        };
+                        let fill = if active {
+                            egui::Color32::from_rgb(80, 130, 200)
+                        } else {
+                            egui::Color32::from_rgb(50, 50, 58)
+                        };
+                        let btn = egui::Button::new(txt).fill(fill).rounding(14.0);
+                        if ui.add(btn).clicked() {
+                            core.select_tile(tile);
+                        }
+                    }
+
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.add_space(8.0);
-                        let stats = format!(
-                            "\u{2139} {} songs · {} voices",
-                            self.song_index.len(),
-                            self.db_voice_count
+                        ui.label(
+                            egui::RichText::new(format!("{} results", result_count))
+                                .color(egui::Color32::GRAY)
+                                .small(),
                         );
-                        let resp = ui.button(stats);
-                        if resp.clicked() {
-                            self.show_stats = !self.show_stats;
-                        }
-                        let popup_id = ui.make_persistent_id("jukebox_lite_stats_popup");
-                        if self.show_stats {
-                            egui::popup::popup_below_widget(
-                                ui,
-                                popup_id,
-                                &resp,
-                                egui::PopupCloseBehavior::CloseOnClick,
-                                |ui| {
-                                    ui.set_min_width(280.0);
-                                    ui.heading("Library");
-                                    ui.label(format!(
-                                        "On-disk catalog rows: {}",
-                                        self.tracks.len()
-                                    ));
-                                    ui.label(format!("DB songs: {}", self.song_index.len()));
-                                    ui.label(format!("DB voices: {}", self.db_voice_count));
-                                    ui.label(format!(
-                                        "Favorites: {}",
-                                        self.favorites.len()
-                                    ));
-                                    ui.label(format!(
-                                        "Recent plays (window): {}",
-                                        self.recent_entries.len()
-                                    ));
-                                    ui.separator();
-                                    if ui.button("Rescan files").clicked() {
-                                        self.rescan();
-                                    }
-                                },
+                        if let Some(p) = core.audio.pending_render.as_ref() {
+                            ui.add_space(8.0);
+                            ui.spinner();
+                            ui.label(
+                                egui::RichText::new(format!("rendering {}…", p.track_label))
+                                    .color(egui::Color32::LIGHT_BLUE)
+                                    .small(),
                             );
-                            // Auto-close when a click happens outside.
-                            ctx.memory_mut(|m| m.open_popup(popup_id));
                         }
                     });
                 });
+                ui.add_space(2.0);
             });
+    }
 
-        // Bottom Now Playing bar (always present so the layout doesn't
-        // jump when audio starts; idle state shows a placeholder line).
+    // -----------------------------------------------------------------
+    // Now playing bar (bottom)
+    // -----------------------------------------------------------------
+    fn draw_now_playing(&mut self, ctx: &egui::Context, core: &mut JukeboxCore) {
+        let snap: AudioSnapshot = core.audio.snapshot();
+        let song: Option<Song> = snap
+            .label
+            .as_ref()
+            .and_then(|l| core.library.song(l).cloned());
+
         egui::TopBottomPanel::bottom("jukebox_lite_now_playing")
             .exact_height(72.0)
             .show(ctx, |ui| {
                 ui.add_space(6.0);
-                self.show_now_playing(ui);
-            });
+                ui.horizontal(|ui| {
+                    ui.add_space(10.0);
+                    let icon = if snap.is_playing {
+                        "\u{25B6}"
+                    } else if snap.label.is_some() {
+                        "\u{23F8}"
+                    } else {
+                        "\u{1F3B5}"
+                    };
+                    ui.label(egui::RichText::new(icon).size(22.0));
+                    ui.add_space(8.0);
 
-        // Right recommendations panel — visible only while audio is
-        // actually rolling. Idle state stays clean (matches the
-        // YouTube reference: rec rail appears once you start watching,
-        // not while you're still browsing).
-        let any_playing_now = self
-            .mixer
-            .state
-            .lock()
-            .map(|s| s.is_playing)
-            .unwrap_or(false);
-        let show_recommend = any_playing_now
-            && self
-                .selected_label
-                .as_ref()
-                .map(|l| self.song_index.contains_key(l))
-                .unwrap_or(false);
-        if show_recommend {
-            egui::SidePanel::right("jukebox_lite_recommend")
-                .resizable(false)
-                .exact_width(220.0)
-                .show(ctx, |ui| {
-                    self.show_recommendations(ui);
-                });
-        }
+                    ui.vertical(|ui| {
+                        let title = match (snap.label.as_ref(), song.as_ref()) {
+                            (Some(_), Some(s)) => s.title.clone(),
+                            (Some(l), None) => l.clone(),
+                            (None, _) => "Nothing playing".to_string(),
+                        };
+                        ui.label(egui::RichText::new(title).strong().size(15.0));
+                        let sub = song
+                            .as_ref()
+                            .map(|s| compact_composer(&s.composer))
+                            .unwrap_or_else(|| "—".to_string());
+                        ui.label(
+                            egui::RichText::new(sub)
+                                .color(egui::Color32::LIGHT_GRAY)
+                                .small(),
+                        );
+                    });
 
-        // Left sidebar (tiles).
-        egui::SidePanel::left("jukebox_lite_sidebar")
-            .resizable(false)
-            .exact_width(SIDEBAR_WIDTH)
-            .show(ctx, |ui| {
-                ui.add_space(8.0);
-                ui.heading("Library");
-                ui.add_space(6.0);
-                for &tile in Tile::all() {
-                    let count = self
-                        .tracks
-                        .iter()
-                        .filter(|t| {
-                            track_matches_tile(
-                                tile,
-                                t,
-                                self.song_index.get(&t.label),
-                                &self.favorites,
-                                &self.recent_ids,
-                            )
-                        })
-                        .count();
-                    let selected = self.tile == tile;
-                    let label = format!("{}  {}   ({})", tile.icon(), tile.label(), count);
-                    let btn = egui::SelectableLabel::new(selected, label);
-                    if ui.add_sized([SIDEBAR_WIDTH - 18.0, 32.0], btn).clicked() {
-                        self.tile = tile;
+                    ui.add_space(20.0);
+
+                    // Progress bar (fills remaining width before volume).
+                    let total = snap.total_frames.max(1);
+                    let cursor = snap.cursor_frames.min(total);
+                    let fraction = cursor as f32 / total as f32;
+                    let sr = core.audio.sample_rate_for_progress.max(1);
+                    let cur_secs = cursor as f64 / sr as f64;
+                    let tot_secs = total as f64 / sr as f64;
+                    ui.vertical(|ui| {
+                        ui.add(
+                            egui::ProgressBar::new(fraction)
+                                .desired_width(360.0)
+                                .show_percentage(),
+                        );
+                        ui.label(
+                            egui::RichText::new(format!(
+                                "{} / {}",
+                                fmt_secs(cur_secs),
+                                fmt_secs(tot_secs),
+                            ))
+                            .small()
+                            .color(egui::Color32::GRAY),
+                        );
+                    });
+
+                    ui.add_space(18.0);
+
+                    // Stop / resume
+                    if snap.is_playing {
+                        if ui.button("\u{23F8} pause").clicked() {
+                            core.audio.stop();
+                        }
+                    } else if snap.label.is_some() {
+                        if ui.button("\u{25B6} resume").clicked() {
+                            core.audio.resume();
+                        }
                     }
-                }
-                ui.add_space(12.0);
-                ui.separator();
-                ui.label(
-                    egui::RichText::new("Voice picks per tile:")
-                        .small()
-                        .color(egui::Color32::GRAY),
-                );
-                ui.label(egui::RichText::new("Classical → piano-modal").small());
-                ui.label(egui::RichText::new("Game → square").small());
-                ui.label(egui::RichText::new("Folk → guitar-stk").small());
-            });
+                    if ui.button("\u{23F9} stop").clicked() {
+                        core.stop();
+                    }
 
-        // Center: card grid.
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        ui.add_space(10.0);
+                        let mut vol = match core.audio.mixer.state.lock() {
+                            Ok(g) => g.volume,
+                            Err(_) => 0.85,
+                        };
+                        let resp = ui.add(
+                            egui::Slider::new(&mut vol, 0.0..=1.5)
+                                .text("vol")
+                                .show_value(false),
+                        );
+                        if resp.changed() {
+                            if let Ok(mut g) = core.audio.mixer.state.lock() {
+                                g.volume = vol;
+                            }
+                        }
+                    });
+                });
+            });
+    }
+
+    // -----------------------------------------------------------------
+    // Central card grid
+    // -----------------------------------------------------------------
+    fn draw_card_grid(
+        &mut self,
+        ctx: &egui::Context,
+        core: &mut JukeboxCore,
+        visible: &[Track],
+    ) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.add_space(6.0);
             ui.horizontal(|ui| {
-                ui.heading(self.tile.label());
+                ui.heading(core.selection.tile.label());
                 ui.add_space(8.0);
                 ui.label(
-                    egui::RichText::new(format!("{} results", visible.len()))
-                        .color(egui::Color32::GRAY),
+                    egui::RichText::new(format!("{} tracks", visible.len()))
+                        .color(egui::Color32::GRAY)
+                        .small(),
                 );
-                if let Some(p) = self.pending_render.as_ref() {
-                    ui.add_space(20.0);
-                    ui.spinner();
-                    ui.label(
-                        egui::RichText::new(format!(
-                            "rendering {}…",
-                            p.track_label
-                        ))
-                        .color(egui::Color32::LIGHT_BLUE),
-                    );
-                }
             });
             ui.separator();
+
+            if visible.is_empty() {
+                ui.add_space(40.0);
+                ui.vertical_centered(|ui| {
+                    ui.label(
+                        egui::RichText::new("Nothing here yet.")
+                            .heading()
+                            .color(egui::Color32::GRAY),
+                    );
+                    ui.label("Pick a different tile or clear the search box.");
+                });
+                return;
+            }
+
             egui::ScrollArea::vertical()
                 .auto_shrink([false; 2])
                 .show(ui, |ui| {
-                    self.draw_card_grid(ui, &visible);
+                    let avail = ui.available_width();
+                    let cols = ((avail / CARD_MIN_W).floor() as usize).max(1);
+                    let card_w = (avail / cols as f32) - CARD_GAP;
+                    let row_count = (visible.len() + cols - 1) / cols;
+                    let mut to_play: Option<String> = None;
+
+                    for r in 0..row_count {
+                        ui.horizontal(|ui| {
+                            for c in 0..cols {
+                                let i = r * cols + c;
+                                if i >= visible.len() {
+                                    ui.add_space(card_w + CARD_GAP);
+                                    continue;
+                                }
+                                let t = &visible[i];
+                                let song = core.library.song(&t.label).cloned();
+                                let is_selected = core
+                                    .selection
+                                    .selected_label
+                                    .as_ref()
+                                    .map(|l| l == &t.label)
+                                    .unwrap_or(false);
+                                let is_fav = core.history.favorites.contains(&t.label);
+                                if draw_card(ui, card_w, t, song.as_ref(), is_selected, is_fav) {
+                                    to_play = Some(t.label.clone());
+                                }
+                                ui.add_space(CARD_GAP);
+                            }
+                        });
+                        ui.add_space(CARD_GAP);
+                    }
+
+                    if let Some(label) = to_play {
+                        core.play_label(&label);
+                    }
                 });
         });
-
-        // Tail: publish CP snapshot for verifiers.
-        self.publish_cp_snapshot(&visible);
-
-        // Repaint while audio is rolling so the progress bar advances.
-        let any_playing = self
-            .mixer
-            .state
-            .lock()
-            .map(|s| s.is_playing)
-            .unwrap_or(false);
-        if any_playing || self.pending_render.is_some() {
-            ctx.request_repaint_after(std::time::Duration::from_millis(120));
-        }
     }
 }
 
-impl JukeboxLite {
-    fn draw_card_grid(&mut self, ui: &mut egui::Ui, visible: &[Track]) {
-        if visible.is_empty() {
-            ui.add_space(40.0);
-            ui.vertical_centered(|ui| {
-                ui.label(
-                    egui::RichText::new("Nothing here yet.")
-                        .heading()
-                        .color(egui::Color32::GRAY),
-                );
-                ui.label("Pick a different tile or clear the search box.");
-            });
-            return;
-        }
-        let avail = ui.available_width();
-        let cols = ((avail / CARD_MIN_W).floor() as usize).max(1);
-        let card_w = (avail / cols as f32) - 12.0;
-        let row_count = (visible.len() + cols - 1) / cols;
-        let mut to_play: Option<Track> = None;
-        for r in 0..row_count {
-            ui.horizontal(|ui| {
-                for c in 0..cols {
-                    let i = r * cols + c;
-                    if i >= visible.len() {
-                        ui.add_space(card_w + 6.0);
-                        continue;
-                    }
-                    let t = &visible[i];
-                    let song = self.song_index.get(&t.label).cloned();
-                    let is_selected = self
-                        .selected_label
-                        .as_ref()
-                        .map(|l| l == &t.label)
-                        .unwrap_or(false);
-                    let is_fav = self.favorites.contains(&t.label);
-                    if Self::draw_card(ui, card_w, t, song.as_ref(), is_selected, is_fav) {
-                        to_play = Some(t.clone());
-                    }
-                    ui.add_space(6.0);
-                }
-            });
-            ui.add_space(6.0);
-        }
-        if let Some(t) = to_play {
-            self.play_track(t);
-        }
-    }
+// ---------------------------------------------------------------------------
+// Card rendering (free function — needs no `&mut self`)
+// ---------------------------------------------------------------------------
 
-    /// Draws one card, returns true when the user clicked play.
-    fn draw_card(
-        ui: &mut egui::Ui,
-        width: f32,
-        track: &Track,
-        song: Option<&Song>,
-        selected: bool,
-        fav: bool,
-    ) -> bool {
-        // Dark cards on the (light) panel — gives a YouTube-light
-        // look where the user's eye lands on the song tiles, not on
-        // the chrome. Selected card swaps to a brighter blue so a
-        // verifier (and user) can see at a glance which row is loaded.
-        let frame_color = if selected {
-            egui::Color32::from_rgb(60, 100, 170)
-        } else {
-            egui::Color32::from_rgb(36, 36, 42)
-        };
-        let stroke_color = if selected {
-            egui::Color32::from_rgb(150, 200, 255)
-        } else {
-            egui::Color32::from_rgb(80, 80, 90)
-        };
-        let mut clicked = false;
-        let frame = egui::Frame::none()
-            .fill(frame_color)
-            .stroke(egui::Stroke::new(1.0, stroke_color))
-            .rounding(8.0)
-            .inner_margin(egui::Margin::symmetric(10.0, 8.0));
-        frame.show(ui, |ui| {
-            ui.set_width(width);
-            ui.set_min_height(CARD_HEIGHT);
-            ui.vertical(|ui| {
-                // Top row: era badge + license + ★
-                ui.horizontal(|ui| {
-                    if let Some(s) = song {
-                        if let Some(era) = s.era.as_deref() {
-                            let badge = egui::RichText::new(format!(" {} ", era))
-                                .background_color(era_color(era))
-                                .color(egui::Color32::BLACK)
-                                .small();
-                            ui.label(badge);
-                        }
+/// Returns `true` when the user clicked the play button on this card.
+fn draw_card(
+    ui: &mut egui::Ui,
+    width: f32,
+    track: &Track,
+    song: Option<&Song>,
+    selected: bool,
+    fav: bool,
+) -> bool {
+    let frame_color = if selected {
+        egui::Color32::from_rgb(60, 100, 170)
+    } else {
+        egui::Color32::from_rgb(36, 36, 42)
+    };
+    let stroke_color = if selected {
+        egui::Color32::from_rgb(150, 200, 255)
+    } else {
+        egui::Color32::from_rgb(80, 80, 90)
+    };
+    let mut clicked = false;
+    let frame = egui::Frame::none()
+        .fill(frame_color)
+        .stroke(egui::Stroke::new(1.0, stroke_color))
+        .rounding(8.0)
+        .inner_margin(egui::Margin::symmetric(10.0, 8.0));
+    frame.show(ui, |ui| {
+        ui.set_width(width);
+        ui.set_min_height(CARD_HEIGHT);
+        ui.vertical(|ui| {
+            // Top row: era badge / format / fav star
+            ui.horizontal(|ui| {
+                if let Some(s) = song {
+                    if let Some(era) = s.era.as_deref() {
+                        let badge = egui::RichText::new(format!(" {} ", era))
+                            .background_color(era_color(era))
+                            .color(egui::Color32::BLACK)
+                            .small();
+                        ui.label(badge);
+                    }
+                    if !s.instrument.is_empty() {
                         ui.label(
                             egui::RichText::new(format!("· {}", s.instrument))
                                 .small()
                                 .color(egui::Color32::LIGHT_GRAY),
                         );
-                    } else {
-                        ui.label(
-                            egui::RichText::new(format!("[{:?}]", track.format))
-                                .small()
-                                .color(egui::Color32::DARK_GRAY),
-                        );
                     }
-                    if fav {
-                        ui.with_layout(
-                            egui::Layout::right_to_left(egui::Align::Center),
-                            |ui| {
-                                ui.label(
-                                    egui::RichText::new("\u{2605}")
-                                        .color(egui::Color32::from_rgb(255, 200, 80)),
-                                );
-                            },
-                        );
-                    }
-                });
-                // Title (1 strong line)
-                let title = song.map(|s| s.title.as_str()).unwrap_or(&track.label);
-                ui.label(egui::RichText::new(title).strong().size(15.0));
-                // Composer (subtle)
-                let composer = song
-                    .map(|s| compact_composer(&s.composer))
-                    .unwrap_or_else(|| "—".to_string());
-                ui.label(
-                    egui::RichText::new(composer)
-                        .color(egui::Color32::LIGHT_GRAY)
-                        .small(),
-                );
-                // Bottom row: play button.
-                ui.add_space(2.0);
-                ui.horizontal(|ui| {
-                    let play = egui::Button::new(
-                        egui::RichText::new("\u{25B6} play").size(14.0),
-                    )
-                    .fill(egui::Color32::from_rgb(80, 130, 200))
-                    .rounding(4.0);
-                    if ui.add(play).clicked() {
-                        clicked = true;
-                    }
-                });
-            });
-        });
-        clicked
-    }
-
-    fn show_now_playing(&mut self, ui: &mut egui::Ui) {
-        let (label, is_playing, cursor, total) = {
-            let st = self.mixer.state.lock().ok();
-            match st {
-                Some(g) => (
-                    if g.label.is_empty() {
-                        None
-                    } else {
-                        Some(g.label.clone())
-                    },
-                    g.is_playing,
-                    g.cursor_frames,
-                    g.decoded
-                        .as_ref()
-                        .map(|d| d.total_samples / d.channels.max(1) as u64)
-                        .unwrap_or(0),
-                ),
-                None => (None, false, 0, 0),
-            }
-        };
-        let song = label.as_ref().and_then(|l| self.song_index.get(l)).cloned();
-        ui.horizontal(|ui| {
-            ui.add_space(8.0);
-            // Big play state icon
-            let icon = if is_playing {
-                "\u{25B6}"
-            } else if label.is_some() {
-                "\u{23F8}"
-            } else {
-                "\u{1F3B5}"
-            };
-            ui.label(egui::RichText::new(icon).size(22.0));
-            ui.add_space(8.0);
-            ui.vertical(|ui| {
-                let title_text = match (label.as_ref(), song.as_ref()) {
-                    (Some(_), Some(s)) => s.title.clone(),
-                    (Some(l), None) => l.clone(),
-                    (None, _) => "Nothing playing".to_string(),
-                };
-                ui.label(egui::RichText::new(title_text).strong().size(15.0));
-                let sub = match song.as_ref() {
-                    Some(s) => {
-                        let mut line = compact_composer(&s.composer);
-                        if let Some(era) = s.era.as_deref() {
-                            line.push_str(" · ");
-                            line.push_str(era);
-                        }
-                        line
-                    }
-                    None => label.clone().unwrap_or_else(|| {
-                        "Pick a card on the right to start listening.".to_string()
-                    }),
-                };
-                ui.label(
-                    egui::RichText::new(sub)
-                        .color(egui::Color32::LIGHT_GRAY)
-                        .small(),
-                );
-            });
-            // Progress bar fills the middle.
-            ui.add_space(16.0);
-            let progress = if total > 0 {
-                (cursor as f32 / total as f32).clamp(0.0, 1.0)
-            } else {
-                0.0
-            };
-            let bar = egui::ProgressBar::new(progress)
-                .desired_width(ui.available_width() - 90.0)
-                .text(if total > 0 {
-                    let secs = cursor as u32 / self.sample_rate_for_progress.max(1);
-                    let total_secs = total as u32 / self.sample_rate_for_progress.max(1);
-                    format!(
-                        "{:01}:{:02} / {:01}:{:02}",
-                        secs / 60,
-                        secs % 60,
-                        total_secs / 60,
-                        total_secs % 60
-                    )
                 } else {
-                    "—:—".to_string()
-                });
-            ui.add(bar);
-            // Stop on the right edge.
-            ui.add_space(6.0);
-            let stop = egui::Button::new(egui::RichText::new("\u{25A0} stop").size(14.0))
-                .fill(egui::Color32::from_rgb(170, 80, 80));
-            if ui.add(stop).clicked() {
-                self.stop();
-            }
-            ui.add_space(8.0);
-        });
-    }
+                    ui.label(
+                        egui::RichText::new(format!("[{}]", format_label(track.format)))
+                            .small()
+                            .color(egui::Color32::DARK_GRAY),
+                    );
+                }
+                if fav {
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        ui.label(
+                            egui::RichText::new("\u{2605}")
+                                .color(egui::Color32::from_rgb(255, 200, 80)),
+                        );
+                    });
+                }
+            });
 
-    fn show_recommendations(&mut self, ui: &mut egui::Ui) {
-        ui.add_space(8.0);
-        ui.heading("Up next");
-        let label = match self.selected_label.clone() {
-            Some(l) => l,
-            None => return,
-        };
-        let song = match self.song_index.get(&label).cloned() {
-            Some(s) => s,
-            None => return,
-        };
-        ui.add_space(6.0);
-        ui.label(
-            egui::RichText::new(format!("Same composer · {}", compact_composer(&song.composer)))
-                .small()
-                .color(egui::Color32::LIGHT_GRAY),
-        );
-        let same_composer: Vec<Track> = self
-            .tracks
-            .iter()
-            .filter(|t| {
-                if t.label == label {
-                    return false;
-                }
-                self.song_index
-                    .get(&t.label)
-                    .map(|s| s.composer_key == song.composer_key)
-                    .unwrap_or(false)
-            })
-            .take(3)
-            .cloned()
-            .collect();
-        if same_composer.is_empty() {
-            ui.label(egui::RichText::new("(no other works in catalog)").small());
-        } else {
-            let mut to_play: Option<Track> = None;
-            for t in &same_composer {
-                let title = self
-                    .song_index
-                    .get(&t.label)
-                    .map(|s| s.title.clone())
-                    .unwrap_or_else(|| t.label.clone());
-                if ui.button(format!("\u{25B6} {title}")).clicked() {
-                    to_play = Some(t.clone());
-                }
-            }
-            if let Some(t) = to_play {
-                self.play_track(t);
-            }
-        }
-        ui.add_space(10.0);
-        if let Some(era) = song.era.as_deref() {
+            // Title (1 strong line)
+            let title = song.map(|s| s.title.as_str()).unwrap_or(&track.label);
             ui.label(
-                egui::RichText::new(format!("Same era · {era}"))
-                    .small()
-                    .color(egui::Color32::LIGHT_GRAY),
+                egui::RichText::new(title)
+                    .strong()
+                    .size(15.0)
+                    .color(egui::Color32::WHITE),
             );
-            let same_era: Vec<Track> = self
-                .tracks
-                .iter()
-                .filter(|t| {
-                    if t.label == label {
-                        return false;
-                    }
-                    self.song_index
-                        .get(&t.label)
-                        .and_then(|s| s.era.as_deref())
-                        .map(|e| e == era)
-                        .unwrap_or(false)
-                })
-                .filter(|t| {
-                    self.song_index
-                        .get(&t.label)
-                        .map(|s| s.composer_key != song.composer_key)
-                        .unwrap_or(true)
-                })
-                .take(3)
-                .cloned()
-                .collect();
-            if same_era.is_empty() {
-                ui.label(egui::RichText::new("(only this composer)").small());
-            } else {
-                let mut to_play: Option<Track> = None;
-                for t in &same_era {
-                    let title = self
-                        .song_index
-                        .get(&t.label)
-                        .map(|s| s.title.clone())
-                        .unwrap_or_else(|| t.label.clone());
-                    if ui.button(format!("\u{25B6} {title}")).clicked() {
-                        to_play = Some(t.clone());
-                    }
+
+            // Composer (subtle)
+            let composer = song
+                .map(|s| compact_composer(&s.composer))
+                .unwrap_or_else(|| "—".to_string());
+            ui.label(
+                egui::RichText::new(composer)
+                    .color(egui::Color32::LIGHT_GRAY)
+                    .small(),
+            );
+
+            // Bottom row: play button.
+            ui.add_space(2.0);
+            ui.horizontal(|ui| {
+                let play =
+                    egui::Button::new(egui::RichText::new("\u{25B6} play").size(14.0).strong())
+                        .fill(egui::Color32::from_rgb(80, 130, 200))
+                        .rounding(4.0);
+                if ui.add(play).clicked() {
+                    clicked = true;
                 }
-                if let Some(t) = to_play {
-                    self.play_track(t);
-                }
-            }
+            });
+        });
+    });
+    clicked
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+fn era_color(era: &str) -> egui::Color32 {
+    match era {
+        "Baroque" => egui::Color32::from_rgb(255, 220, 150),
+        "Classical" => egui::Color32::from_rgb(200, 230, 255),
+        "Romantic" => egui::Color32::from_rgb(255, 190, 200),
+        "Modern" => egui::Color32::from_rgb(200, 255, 220),
+        "Traditional" => egui::Color32::from_rgb(220, 220, 180),
+        _ => egui::Color32::from_rgb(220, 220, 220),
+    }
+}
+
+fn format_label(f: Format) -> &'static str {
+    match f {
+        Format::Wav => "WAV",
+        Format::Mp3 => "MP3",
+        Format::Mid => "MIDI",
+    }
+}
+
+/// "Wolfgang Amadeus Mozart" → "W.A. Mozart". One name → unchanged.
+fn compact_composer(name: &str) -> String {
+    let parts: Vec<&str> = name.split_whitespace().collect();
+    if parts.len() <= 1 {
+        return name.to_string();
+    }
+    let mut out = String::new();
+    for p in &parts[..parts.len() - 1] {
+        if let Some(c) = p.chars().next() {
+            out.push(c);
+            out.push('.');
         }
     }
+    if !out.is_empty() {
+        out.push(' ');
+    }
+    out.push_str(parts[parts.len() - 1]);
+    out
+}
+
+fn fmt_secs(s: f64) -> String {
+    if !s.is_finite() || s < 0.0 {
+        return "0:00".to_string();
+    }
+    let total = s as u64;
+    let m = total / 60;
+    let r = total % 60;
+    format!("{}:{:02}", m, r)
 }
 
 // ---------------------------------------------------------------------------
@@ -1868,11 +500,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         PathBuf::from("bench-out/CHIPTUNE"),
         PathBuf::from("bench-out/iterH"),
     ];
-    let app = JukeboxLite::new(dirs)?;
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1200.0, 760.0])
-            .with_title("keysynth jukebox lite"),
+            .with_title("keysynth jukebox lite")
+            .with_visible(true),
         ..Default::default()
     };
     eframe::run_native(
@@ -1880,17 +512,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         options,
         Box::new(|cc| {
             keysynth::ui::setup_japanese_fonts(&cc.egui_ctx);
-            // Lock to light theme. We deliberately want the
-            // "dark-cards-on-light-chrome" YouTube-light feel: the
-            // dark card surfaces give the user's eye a clear focal
-            // target while the chrome (header / sidebar / nowplaying
-            // bar) stays out of the way. egui's dark theme was tried
-            // first but its panel bg (#303030) is too close to the
-            // chosen card bg (#24242a) — the gui_audit primary-
-            // contrast pair both ended up as near-identical dark
-            // greys which trips the WCAG blocker.
-            cc.egui_ctx.set_theme(egui::ThemePreference::Light);
-            Ok(Box::new(app))
+            cc.egui_ctx.set_visuals(egui::Visuals::dark());
+            let core = match JukeboxCore::new(dirs, "jukebox_lite", cc.egui_ctx.clone()) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("jukebox_lite: core init failed: {e}");
+                    return Err(format!("core: {e}").into());
+                }
+            };
+            let app = JukeboxLite::default();
+            Ok(Box::new(JukeboxRunner::new(core, app)))
         }),
     )
     .map_err(|e| -> Box<dyn std::error::Error> { format!("eframe: {e}").into() })?;
@@ -1906,139 +537,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_from_extension() {
-        assert_eq!(Format::from_ext("mid"), Some(Format::Mid));
-        assert_eq!(Format::from_ext("MIDI"), Some(Format::Mid));
-        assert_eq!(Format::from_ext("wav"), Some(Format::Wav));
-        assert_eq!(Format::from_ext("mp3"), Some(Format::Mp3));
-        assert_eq!(Format::from_ext("flac"), None);
+    fn compact_composer_initials_on_multiword() {
+        assert_eq!(
+            compact_composer("Wolfgang Amadeus Mozart"),
+            "W.A. Mozart"
+        );
+        assert_eq!(compact_composer("Bach"), "Bach");
+        assert_eq!(compact_composer(""), "");
     }
 
     #[test]
-    fn tile_label_round_trip() {
-        for &t in Tile::all() {
-            assert_eq!(tile_from_str(t.label()), Some(t));
-        }
+    fn fmt_secs_basic() {
+        assert_eq!(fmt_secs(0.0), "0:00");
+        assert_eq!(fmt_secs(5.4), "0:05");
+        assert_eq!(fmt_secs(65.0), "1:05");
+        assert_eq!(fmt_secs(-1.0), "0:00");
     }
 
     #[test]
-    fn pick_voice_uses_active_tile_first() {
-        let track = Track {
-            path: PathBuf::from("dummy.mid"),
-            label: "dummy".into(),
-            format: Format::Mid,
-        };
-        // Tile-driven mood overrides per-track metadata.
-        assert_eq!(pick_voice(Tile::Classical, None, &track), "piano-modal");
-        assert_eq!(pick_voice(Tile::Game, None, &track), "square");
-        assert_eq!(pick_voice(Tile::Folk, None, &track), "guitar-stk");
-    }
-
-    #[test]
-    fn pick_voice_falls_back_to_song_metadata() {
-        let track = Track {
-            path: PathBuf::from("x.mid"),
-            label: "x".into(),
-            format: Format::Mid,
-        };
-        let song = Song {
-            id: "x".into(),
-            title: "T".into(),
-            composer: "C".into(),
-            composer_key: "c".into(),
-            era: Some("Baroque".into()),
-            instrument: "guitar".into(),
-            license: "PD".into(),
-            source: None,
-            source_url: None,
-            suggested_voice: None,
-            midi_path: PathBuf::from("x.mid"),
-            context: None,
-            tags: vec![],
-        };
-        // All-tile defers to instrument: guitar wins.
-        assert_eq!(pick_voice(Tile::All, Some(&song), &track), "guitar-stk");
-    }
-
-    #[test]
-    fn rendered_audio_uses_no_voice_sentinel() {
-        let track = Track {
-            path: PathBuf::from("foo.wav"),
-            label: "foo".into(),
-            format: Format::Wav,
-        };
-        assert_eq!(pick_voice(Tile::All, None, &track), "—");
-    }
-
-    #[test]
-    fn classical_tile_includes_baroque_classical_romantic_modern() {
-        let mk = |era: Option<&str>, ins: &str| Song {
-            id: "x".into(),
-            title: "T".into(),
-            composer: "C".into(),
-            composer_key: "c".into(),
-            era: era.map(String::from),
-            instrument: ins.into(),
-            license: "PD".into(),
-            source: None,
-            source_url: None,
-            suggested_voice: None,
-            midi_path: PathBuf::from("x.mid"),
-            context: None,
-            tags: vec![],
-        };
-        let t = Track {
-            path: PathBuf::from("x.mid"),
-            label: "x".into(),
-            format: Format::Mid,
-        };
-        let favs = HashSet::new();
-        let recent = HashSet::new();
-        for era in ["Baroque", "Classical", "Romantic", "Modern"] {
-            let s = mk(Some(era), "piano");
-            assert!(track_matches_tile(
-                Tile::Classical,
-                &t,
-                Some(&s),
-                &favs,
-                &recent
-            ));
-        }
-        let s = mk(Some("Traditional"), "guitar");
-        assert!(!track_matches_tile(
-            Tile::Classical,
-            &t,
-            Some(&s),
-            &favs,
-            &recent
-        ));
-        assert!(track_matches_tile(Tile::Folk, &t, Some(&s), &favs, &recent));
-    }
-
-    #[test]
-    fn game_tile_catches_metadata_less_tracks() {
-        let t = Track {
-            path: PathBuf::from("v01_chip.mid"),
-            label: "v01_chip".into(),
-            format: Format::Mid,
-        };
-        let favs = HashSet::new();
-        let recent = HashSet::new();
-        assert!(track_matches_tile(Tile::Game, &t, None, &favs, &recent));
-    }
-
-    #[test]
-    fn scan_dirs_dedups_mp3_over_same_stem_wav() {
-        let dir = std::env::temp_dir().join("keysynth_jukebox_lite_dedup_test");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("a.wav"), b"RIFF").unwrap();
-        std::fs::write(dir.join("a.mp3"), b"ID3").unwrap();
-        std::fs::write(dir.join("b.wav"), b"RIFF").unwrap();
-        let tracks = scan_dirs(&[dir.as_path()]);
-        assert_eq!(tracks.len(), 2);
-        let a = tracks.iter().find(|t| t.label == "a").unwrap();
-        assert_eq!(a.format, Format::Mp3);
-        let _ = std::fs::remove_dir_all(&dir);
+    fn format_label_covers_all_variants() {
+        assert_eq!(format_label(Format::Wav), "WAV");
+        assert_eq!(format_label(Format::Mp3), "MP3");
+        assert_eq!(format_label(Format::Mid), "MIDI");
     }
 }

--- a/src/bin/jukebox_lite_c.rs
+++ b/src/bin/jukebox_lite_c.rs
@@ -1,2463 +1,394 @@
-//! jukebox_lite_c — dense list-view music browser for keysynth.
+//! jukebox_lite_c — Codex variant: foobar2000-style dense list browser.
 //!
-//! This is a sibling to `jukebox_lite`, but deliberately not a card grid.
-//! The interaction model is closer to Finder list view / foobar2000 /
-//! Spotify's Songs table: filter rail, ledger-style track list, detail
-//! inspector, and a persistent transport strip.
-//!
-//! Backend reuse stays unchanged: `library_db`, `play_log`,
-//! `preview_cache`, `gui_cp`, `ui::setup_japanese_fonts`, and
-//! `audio_audit`.
+//! All audio / library / play-log / CP-server scaffolding lives in
+//! [`keysynth::jukebox_core`]; this binary only owns UI state (sort
+//! column / direction) and renders a tight column table.
 
-use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::path::PathBuf;
 
-use cp_core::RpcError;
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{SampleFormat, StreamConfig};
 use eframe::egui;
-use hound::{SampleFormat as WavSampleFormat, WavReader};
-use serde::Serialize;
-use serde_json::json;
-use symphonia::core::audio::{AudioBufferRef, Signal};
-use symphonia::core::codecs::{Decoder, DecoderOptions, CODEC_TYPE_NULL};
-use symphonia::core::errors::Error as SymphoniaError;
-use symphonia::core::formats::{FormatOptions, FormatReader};
-use symphonia::core::io::MediaSourceStream;
-use symphonia::core::meta::MetadataOptions;
-use symphonia::core::probe::Hint;
+use keysynth::jukebox_core::{
+    Format, JukeboxApp, JukeboxCore, JukeboxRunner, Tile, Track,
+};
+use keysynth::library_db::Song;
 
-use keysynth::audio_audit::{self, DominantFrequency};
-use keysynth::gui_cp;
-use keysynth::library_db::{LibraryDb, Song, SongFilter, SongSort, VoiceFilter};
-use keysynth::play_log::{PlayEntry, PlayLogDb};
+const ROW_H: f32 = 22.0;
+const TILE_BAR_H: f32 = 22.0;
+const TRANSPORT_H: f32 = 28.0;
+const PROGRESS_H: f32 = 4.0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Format {
-    Wav,
-    Mp3,
-    Mid,
+enum SortColumn {
+    Title,
+    Composer,
+    Era,
+    Format,
 }
 
-impl Format {
-    fn from_ext(ext: &str) -> Option<Self> {
-        match ext.to_ascii_lowercase().as_str() {
-            "wav" => Some(Format::Wav),
-            "mp3" => Some(Format::Mp3),
-            "mid" | "midi" => Some(Format::Mid),
-            _ => None,
-        }
-    }
-
+impl SortColumn {
     fn label(self) -> &'static str {
         match self {
-            Format::Wav => "WAV",
-            Format::Mp3 => "MP3",
-            Format::Mid => "MID",
+            SortColumn::Title => "title",
+            SortColumn::Composer => "composer",
+            SortColumn::Era => "era",
+            SortColumn::Format => "format",
         }
     }
-}
-
-#[derive(Clone, Debug)]
-struct Track {
-    path: PathBuf,
-    label: String,
-    format: Format,
-}
-
-fn scan_dirs(dirs: &[&Path]) -> Vec<Track> {
-    let mut out = Vec::new();
-    for d in dirs {
-        let read = match std::fs::read_dir(d) {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
-        let mut dir_tracks = Vec::new();
-        for ent in read.flatten() {
-            let p = ent.path();
-            let ext = match p.extension().and_then(|s| s.to_str()) {
-                Some(e) => e.to_ascii_lowercase(),
-                None => continue,
-            };
-            let fmt = match Format::from_ext(&ext) {
-                Some(f) => f,
-                None => continue,
-            };
-            let stem = match p.file_stem().and_then(|s| s.to_str()) {
-                Some(s) => s.to_string(),
-                None => continue,
-            };
-            dir_tracks.push(Track {
-                path: p,
-                label: stem,
-                format: fmt,
-            });
-        }
-        let mp3_stems: HashSet<String> = dir_tracks
-            .iter()
-            .filter(|t| t.format == Format::Mp3)
-            .map(|t| t.label.clone())
-            .collect();
-        for t in dir_tracks {
-            if t.format == Format::Wav && mp3_stems.contains(&t.label) {
-                continue;
-            }
-            out.push(t);
-        }
-    }
-    out.sort_by(|a, b| a.label.cmp(&b.label));
-    out
-}
-
-struct Mp3State {
-    #[allow(dead_code)]
-    path: PathBuf,
-    format: Box<dyn FormatReader>,
-    decoder: Box<dyn Decoder>,
-    track_id: u32,
-    scratch: Vec<f32>,
-    scratch_pos: usize,
-    eof: bool,
-}
-
-enum DecoderState {
-    Wav {
-        reader: WavReader<BufReader<File>>,
-        sample_format: WavSampleFormat,
-        bits_per_sample: u16,
-    },
-    Mp3(Mp3State),
-}
-
-struct DecodedTrack {
-    state: DecoderState,
-    sample_rate: u32,
-    channels: u16,
-    total_samples: u64,
-}
-
-fn open_wav(path: &Path) -> Result<DecodedTrack, String> {
-    let reader = WavReader::open(path).map_err(|e| format!("hound open: {e}"))?;
-    let spec = reader.spec();
-    let total = reader.duration() as u64 * spec.channels as u64;
-    Ok(DecodedTrack {
-        sample_rate: spec.sample_rate,
-        channels: spec.channels,
-        total_samples: total,
-        state: DecoderState::Wav {
-            reader,
-            sample_format: spec.sample_format,
-            bits_per_sample: spec.bits_per_sample,
-        },
-    })
-}
-
-fn open_mp3(path: &Path) -> Result<DecodedTrack, String> {
-    let file = File::open(path).map_err(|e| format!("mp3 open: {e}"))?;
-    let mss = MediaSourceStream::new(Box::new(file), Default::default());
-    let mut hint = Hint::new();
-    if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-        hint.with_extension(ext);
-    }
-    let probed = symphonia::default::get_probe()
-        .format(
-            &hint,
-            mss,
-            &FormatOptions::default(),
-            &MetadataOptions::default(),
-        )
-        .map_err(|e| format!("mp3 probe: {e}"))?;
-    let format = probed.format;
-    let track = format
-        .tracks()
-        .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
-        .ok_or_else(|| "mp3: no decodable track".to_string())?;
-    let track_id = track.id;
-    let cp = track.codec_params.clone();
-    let sr = cp
-        .sample_rate
-        .ok_or_else(|| "mp3: missing sample rate".to_string())?;
-    let ch = cp.channels.map(|c| c.count() as u16).unwrap_or(2);
-    let total = cp.n_frames.map(|n| n * ch as u64).unwrap_or(0);
-    let decoder = symphonia::default::get_codecs()
-        .make(&cp, &DecoderOptions::default())
-        .map_err(|e| format!("mp3 codec: {e}"))?;
-    Ok(DecodedTrack {
-        sample_rate: sr,
-        channels: ch,
-        total_samples: total,
-        state: DecoderState::Mp3(Mp3State {
-            path: path.to_path_buf(),
-            format,
-            decoder,
-            track_id,
-            scratch: Vec::new(),
-            scratch_pos: 0,
-            eof: false,
-        }),
-    })
-}
-
-fn open_decoded(path: &Path) -> Result<DecodedTrack, String> {
-    let ext = path
-        .extension()
-        .and_then(|s| s.to_str())
-        .map(|s| s.to_ascii_lowercase())
-        .unwrap_or_default();
-    match ext.as_str() {
-        "wav" => open_wav(path),
-        "mp3" => open_mp3(path),
-        other => Err(format!("unsupported format: {other}")),
-    }
-}
-
-fn mp3_decode_next(state: &mut Mp3State) -> Result<(), String> {
-    if state.eof {
-        return Ok(());
-    }
-    loop {
-        let packet = match state.format.next_packet() {
-            Ok(p) => p,
-            Err(SymphoniaError::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(SymphoniaError::ResetRequired) => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(e) => return Err(format!("mp3 next_packet: {e}")),
-        };
-        if packet.track_id() != state.track_id {
-            continue;
-        }
-        let decoded = match state.decoder.decode(&packet) {
-            Ok(d) => d,
-            Err(SymphoniaError::DecodeError(_)) => continue,
-            Err(SymphoniaError::IoError(_)) => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(e) => return Err(format!("mp3 decode: {e}")),
-        };
-        let frames = decoded.frames();
-        let spec = *decoded.spec();
-        let ch = spec.channels.count();
-        state.scratch.clear();
-        state.scratch_pos = 0;
-        state.scratch.reserve(frames * ch);
-        match decoded {
-            AudioBufferRef::F32(buf) => {
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f]);
-                    }
-                }
-            }
-            AudioBufferRef::S16(buf) => {
-                let inv = 1.0f32 / i16::MAX as f32;
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32 * inv);
-                    }
-                }
-            }
-            AudioBufferRef::S32(buf) => {
-                let inv = 1.0f32 / i32::MAX as f32;
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32 * inv);
-                    }
-                }
-            }
-            AudioBufferRef::F64(buf) => {
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32);
-                    }
-                }
-            }
-            _ => continue,
-        }
-        if state.scratch.is_empty() {
-            continue;
-        }
-        return Ok(());
-    }
-}
-
-fn read_one_sample(dec: &mut DecodedTrack) -> Option<f32> {
-    match &mut dec.state {
-        DecoderState::Wav {
-            reader,
-            sample_format,
-            bits_per_sample,
-        } => match *sample_format {
-            WavSampleFormat::Int => {
-                let s: i32 = reader.samples::<i32>().next()?.ok()?;
-                let max = ((1u32 << (*bits_per_sample as u32 - 1)) - 1) as f32;
-                Some(s as f32 / max)
-            }
-            WavSampleFormat::Float => {
-                let s: f32 = reader.samples::<f32>().next()?.ok()?;
-                Some(s)
-            }
-        },
-        DecoderState::Mp3(state) => {
-            if state.scratch_pos >= state.scratch.len() {
-                if state.eof {
-                    return None;
-                }
-                if mp3_decode_next(state).is_err() {
-                    state.eof = true;
-                    return None;
-                }
-                if state.scratch_pos >= state.scratch.len() {
-                    return None;
-                }
-            }
-            let s = state.scratch[state.scratch_pos];
-            state.scratch_pos += 1;
-            Some(s)
-        }
-    }
-}
-
-struct AudioState {
-    decoded: Option<DecodedTrack>,
-    is_playing: bool,
-    cursor_frames: u64,
-    label: String,
-    volume: f32,
-}
-
-impl AudioState {
-    fn new() -> Self {
-        Self {
-            decoded: None,
-            is_playing: false,
-            cursor_frames: 0,
-            label: String::new(),
-            volume: 0.82,
-        }
-    }
-}
-
-struct Mixer {
-    state: Arc<Mutex<AudioState>>,
-    _stream: cpal::Stream,
-}
-
-fn fill_callback(out: &mut [f32], channels: u16, state: &Arc<Mutex<AudioState>>) {
-    for s in out.iter_mut() {
-        *s = 0.0;
-    }
-    let mut st = match state.lock() {
-        Ok(g) => g,
-        Err(_) => return,
-    };
-    if !st.is_playing {
-        return;
-    }
-    let vol = st.volume.clamp(0.0, 1.5);
-    let dec = match st.decoded.as_mut() {
-        Some(d) => d,
-        None => {
-            st.is_playing = false;
-            return;
-        }
-    };
-    let dec_ch = dec.channels;
-    let frames = out.len() / channels.max(1) as usize;
-    let mut cursor_advanced = 0u64;
-    let mut hit_eof = false;
-    for f in 0..frames {
-        let (l, r) = match dec_ch {
-            1 => {
-                let s = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                (s, s)
-            }
-            2 => {
-                let l = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                let r = read_one_sample(dec).unwrap_or(l);
-                (l, r)
-            }
-            n => {
-                let l = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                let r = read_one_sample(dec).unwrap_or(l);
-                for _ in 2..n {
-                    let _ = read_one_sample(dec);
-                }
-                (l, r)
-            }
-        };
-        cursor_advanced += 1;
-        let bus_l = (l * vol).tanh();
-        let bus_r = (r * vol).tanh();
-        let base = f * channels as usize;
-        match channels {
-            1 => out[base] = (bus_l + bus_r) * 0.5,
-            2 => {
-                out[base] = bus_l;
-                out[base + 1] = bus_r;
-            }
-            n => {
-                out[base] = bus_l;
-                out[base + 1] = bus_r;
-                for c in 2..n as usize {
-                    out[base + c] = 0.0;
-                }
-            }
-        }
-    }
-    st.cursor_frames = st.cursor_frames.saturating_add(cursor_advanced);
-    if hit_eof {
-        st.is_playing = false;
-    }
-}
-
-fn build_mixer_stream(state: Arc<Mutex<AudioState>>) -> Result<Mixer, String> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or_else(|| "no default output device".to_string())?;
-    let supported = device
-        .default_output_config()
-        .map_err(|e| format!("default_output_config: {e}"))?;
-    let sample_format = supported.sample_format();
-    let channels = supported.channels();
-    let stream_cfg: StreamConfig = supported.into();
-    let err_fn = |err| eprintln!("jukebox_lite_c audio stream error: {err}");
-    let stream = match sample_format {
-        SampleFormat::F32 => {
-            let st = state.clone();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [f32], _| fill_callback(out, channels, &st),
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build f32: {e}"))?
-        }
-        SampleFormat::I16 => {
-            let st = state.clone();
-            let mut scratch = Vec::<f32>::new();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [i16], _| {
-                        if scratch.len() != out.len() {
-                            scratch.resize(out.len(), 0.0);
-                        }
-                        fill_callback(&mut scratch, channels, &st);
-                        for (dst, src) in out.iter_mut().zip(scratch.iter()) {
-                            *dst = (src.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
-                        }
-                    },
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build i16: {e}"))?
-        }
-        SampleFormat::U16 => {
-            let st = state.clone();
-            let mut scratch = Vec::<f32>::new();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [u16], _| {
-                        if scratch.len() != out.len() {
-                            scratch.resize(out.len(), 0.0);
-                        }
-                        fill_callback(&mut scratch, channels, &st);
-                        for (dst, src) in out.iter_mut().zip(scratch.iter()) {
-                            *dst = (((src.clamp(-1.0, 1.0) + 1.0) * 0.5) * u16::MAX as f32) as u16;
-                        }
-                    },
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build u16: {e}"))?
-        }
-        other => return Err(format!("unsupported sample format: {other:?}")),
-    };
-    stream.play().map_err(|e| format!("stream.play: {e}"))?;
-    Ok(Mixer {
-        state,
-        _stream: stream,
-    })
-}
-
-fn render_midi_binary_path() -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    let dir = exe.parent()?;
-    let candidates = if cfg!(windows) {
-        vec!["render_midi.exe"]
-    } else {
-        vec!["render_midi"]
-    };
-    candidates
-        .into_iter()
-        .map(|name| dir.join(name))
-        .find(|p| p.is_file())
-}
-
-fn cache_key(track_path: &Path, voice_id: &str) -> keysynth::preview_cache::CacheKey {
-    keysynth::preview_cache::CacheKey {
-        song_path: track_path.to_path_buf(),
-        voice_id: voice_id.to_string(),
-        voice_dll: None,
-        render_params: keysynth::preview_cache::RenderParams::default(),
-    }
-}
-
-fn open_preview_cache() -> Result<keysynth::preview_cache::Cache, String> {
-    let cache_dir = PathBuf::from("bench-out/cache");
-    keysynth::preview_cache::Cache::new(&cache_dir, 1_073_741_824)
-        .map_err(|e| format!("Cache::new: {e}"))
-}
-
-fn lookup_in_cache(track_path: &Path, voice_id: &str) -> Result<Option<PathBuf>, String> {
-    let cache = open_preview_cache()?;
-    let key = cache_key(track_path, voice_id);
-    cache.lookup(&key).map_err(|e| format!("lookup: {e}"))
-}
-
-fn render_midi_blocking(midi_path: &Path, voice_id: &str) -> Result<PathBuf, String> {
-    let cache = open_preview_cache()?;
-    let key = cache_key(midi_path, voice_id);
-    let bin = render_midi_binary_path()
-        .ok_or_else(|| "render_midi binary not found alongside jukebox_lite_c".to_string())?;
-    keysynth::preview_cache::render_to_cache(&cache, &key, voice_id, &bin)
-        .map_err(|e| format!("render_to_cache: {e}"))
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Tile {
-    All,
-    Favorites,
-    Recent,
-    Classical,
-    Game,
-    Folk,
-}
-
-impl Tile {
-    fn label(self) -> &'static str {
-        match self {
-            Tile::All => "All",
-            Tile::Favorites => "Favorites",
-            Tile::Recent => "Recent",
-            Tile::Classical => "Classical",
-            Tile::Game => "Game",
-            Tile::Folk => "Folk",
-        }
-    }
-
-    fn all() -> &'static [Tile] {
-        &[
-            Tile::All,
-            Tile::Favorites,
-            Tile::Recent,
-            Tile::Classical,
-            Tile::Game,
-            Tile::Folk,
-        ]
-    }
-}
-
-fn pick_voice(tile: Tile, song: Option<&Song>, track: &Track) -> &'static str {
-    if matches!(track.format, Format::Wav | Format::Mp3) {
-        return "direct";
-    }
-    match tile {
-        Tile::Classical => return "piano-modal",
-        Tile::Game => return "square",
-        Tile::Folk => return "guitar-stk",
-        _ => {}
-    }
-    if let Some(s) = song {
-        let ins = s.instrument.to_ascii_lowercase();
-        if ins.contains("guitar") {
-            return "guitar-stk";
-        }
-        if ins.contains("piano") {
-            return "piano-modal";
-        }
-        if let Some(era) = s.era.as_deref() {
-            if matches!(era, "Baroque" | "Classical" | "Romantic" | "Modern") {
-                return "piano-modal";
-            }
-            if era == "Traditional" {
-                return "guitar-stk";
-            }
-        }
-    }
-    let stem = track.label.to_ascii_lowercase();
-    if stem.starts_with("cc0_")
-        || stem.starts_with("parodius")
-        || stem.starts_with("bgm_v")
-        || stem.starts_with('v')
-    {
-        return "square";
-    }
-    "guitar-stk"
-}
-
-fn track_matches_tile(
-    tile: Tile,
-    track: &Track,
-    song: Option<&Song>,
-    favorites: &HashSet<String>,
-    recent: &HashSet<String>,
-) -> bool {
-    match tile {
-        Tile::All => true,
-        Tile::Favorites => favorites.contains(&track.label),
-        Tile::Recent => recent.contains(&track.label),
-        Tile::Classical => song
-            .and_then(|s| s.era.as_deref())
-            .map(|e| matches!(e, "Baroque" | "Classical" | "Romantic" | "Modern"))
-            .unwrap_or(false),
-        Tile::Folk => song
-            .map(|s| {
-                s.instrument.to_ascii_lowercase().contains("guitar")
-                    || s.era.as_deref() == Some("Traditional")
-            })
-            .unwrap_or(false),
-        Tile::Game => {
-            if song.is_none() {
-                return true;
-            }
-            let s = song.unwrap();
-            let ins = s.instrument.to_ascii_lowercase();
-            ins.contains("synth") || ins.contains("game") || ins.contains("chip")
-        }
-    }
-}
-
-fn tile_from_str(s: &str) -> Option<Tile> {
-    match s.to_ascii_lowercase().as_str() {
-        "all" => Some(Tile::All),
-        "favorites" | "favs" | "fav" => Some(Tile::Favorites),
-        "recent" => Some(Tile::Recent),
-        "classical" => Some(Tile::Classical),
-        "game" => Some(Tile::Game),
-        "folk" => Some(Tile::Folk),
-        _ => None,
-    }
-}
-
-fn compact_composer(composer: &str) -> String {
-    let core = match composer.split_once('(') {
-        Some((before, _)) => before,
-        None => composer,
-    };
-    core.trim().to_string()
-}
-
-fn humanize_ago(secs: i64) -> String {
-    let s = secs.max(0);
-    if s < 60 {
-        format!("{s}s ago")
-    } else if s < 3_600 {
-        format!("{}m ago", s / 60)
-    } else if s < 86_400 {
-        format!("{}h ago", s / 3_600)
-    } else {
-        format!("{}d ago", s / 86_400)
-    }
-}
-
-fn unix_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
-}
-
-fn era_badge_color(era: Option<&str>) -> egui::Color32 {
-    match era {
-        Some("Baroque") => egui::Color32::from_rgb(201, 172, 112),
-        Some("Classical") => egui::Color32::from_rgb(165, 199, 155),
-        Some("Romantic") => egui::Color32::from_rgb(211, 173, 190),
-        Some("Modern") => egui::Color32::from_rgb(153, 187, 208),
-        Some("Traditional") => egui::Color32::from_rgb(213, 189, 134),
-        _ => egui::Color32::from_rgb(191, 191, 191),
-    }
-}
-
-fn source_bucket(track: &Track, song: Option<&Song>) -> &'static str {
-    match track.format {
-        Format::Mid if song.is_some() => "CAT",
-        Format::Mid => "MID",
-        Format::Mp3 => "MP3",
-        Format::Wav => "WAV",
-    }
-}
-
-fn display_title(song: Option<&Song>, track: &Track) -> String {
-    song.map(|s| s.title.clone())
-        .unwrap_or_else(|| track.label.clone())
-}
-
-fn display_composer(song: Option<&Song>) -> String {
-    song.map(|s| compact_composer(&s.composer))
-        .unwrap_or_else(|| "-".to_string())
-}
-
-fn display_voice_label(voice: Option<&str>) -> &'static str {
-    match voice {
-        Some("direct") => "direct file",
-        Some("piano-modal") => "piano-modal",
-        Some("guitar-stk") => "guitar-stk",
-        Some("square") => "square",
-        Some(_) => "custom",
-        None => "-",
-    }
-}
-
-fn load_library_index() -> (HashMap<String, Song>, usize) {
-    let db_path = PathBuf::from("bench-out/library.db");
-    let manifest = PathBuf::from("bench-out/songs/manifest.json");
-    let voices_live = PathBuf::from("voices_live");
-    let mut db = match LibraryDb::open(&db_path) {
-        Ok(db) => db,
-        Err(e) => {
-            eprintln!(
-                "jukebox_lite_c: library_db open failed ({}): {e} — running without DB metadata",
-                db_path.display()
-            );
-            return (HashMap::new(), 0);
-        }
-    };
-    if let Err(e) = db.migrate() {
-        eprintln!("jukebox_lite_c: library_db migrate failed: {e}");
-        return (HashMap::new(), 0);
-    }
-    if manifest.is_file() {
-        if let Err(e) = db.import_songs(&manifest) {
-            eprintln!("jukebox_lite_c: library_db import_songs failed: {e}");
-        }
-    }
-    if voices_live.is_dir() {
-        if let Err(e) = db.import_voices(&voices_live) {
-            eprintln!("jukebox_lite_c: library_db import_voices failed: {e}");
-        }
-    }
-    let songs = db
-        .query_songs(&SongFilter {
-            sort: SongSort::ByComposer,
-            ..Default::default()
-        })
-        .unwrap_or_default();
-    let voice_count = db
-        .query_voices(&VoiceFilter::default())
-        .map(|v| v.len())
-        .unwrap_or(0);
-    let mut idx = HashMap::new();
-    for s in songs {
-        idx.insert(s.id.clone(), s);
-    }
-    (idx, voice_count)
-}
-
-fn load_play_log() -> Option<PlayLogDb> {
-    let db_path = PathBuf::from("bench-out/play_log.db");
-    let mut db = match PlayLogDb::open(&db_path) {
-        Ok(db) => db,
-        Err(e) => {
-            eprintln!("jukebox_lite_c: play_log open failed: {e}");
-            return None;
-        }
-    };
-    if let Err(e) = db.migrate() {
-        eprintln!("jukebox_lite_c: play_log migrate failed: {e}");
-        return None;
-    }
-    Some(db)
-}
-
-const RECENT_WINDOW: usize = 24;
-
-fn snapshot_history(
-    log: Option<&PlayLogDb>,
-) -> (
-    HashSet<String>,
-    HashSet<String>,
-    Vec<PlayEntry>,
-    HashMap<String, i64>,
-) {
-    let mut favs = HashSet::new();
-    let mut recent_ids = HashSet::new();
-    let mut recent_entries = Vec::new();
-    let mut play_counts = HashMap::new();
-    if let Some(db) = log {
-        if let Ok(f) = db.favorites() {
-            favs = f.into_iter().collect();
-        }
-        if let Ok(r) = db.recent_plays(RECENT_WINDOW) {
-            for e in &r {
-                recent_ids.insert(e.song_id.clone());
-            }
-            recent_entries = r;
-        }
-        if let Ok(p) = db.play_counts() {
-            play_counts = p;
-        }
-    }
-    (favs, recent_ids, recent_entries, play_counts)
-}
-
-#[derive(Clone, Debug, Default, Serialize)]
-struct CpSnapshot {
-    frame_id: u64,
-    track_count: usize,
-    db_song_count: usize,
-    db_voice_count: usize,
-    selected_label: Option<String>,
-    selected_tile: String,
-    any_playing: bool,
-    loaded_label: Option<String>,
-    cursor_frames: u64,
-    total_frames: u64,
-    sample_rate: u32,
-    visible_labels: Vec<String>,
-    all_labels: Vec<String>,
-}
-
-#[derive(Clone, Debug)]
-enum CpCommand {
-    LoadTrack { label: String },
-    Play,
-    Stop,
-    SelectTile { tile: String },
-    Rescan,
-}
-
-fn spawn_cp_server(state: gui_cp::State<CpSnapshot, CpCommand>) -> std::io::Result<gui_cp::Handle> {
-    let endpoint = gui_cp::resolve_endpoint("jukebox_lite_c", None);
-    let st_get = state.clone();
-    let st_load = state.clone();
-    let st_play = state.clone();
-    let st_stop = state.clone();
-    let st_tile = state.clone();
-    let st_rescan = state.clone();
-    let st_list = state.clone();
-    gui_cp::Builder::new("jukebox_lite_c", &endpoint)
-        .register("get_state", move |_p| match st_get.read_snapshot() {
-            Some(snap) => gui_cp::encode_result(snap),
-            None => Ok(json!({"frame_id": 0, "warming_up": true})),
-        })
-        .register("load_track", move |p| {
-            #[derive(serde::Deserialize)]
-            struct Args {
-                label: String,
-            }
-            let a: Args = gui_cp::decode_params(p)?;
-            st_load.push_command(CpCommand::LoadTrack {
-                label: a.label.clone(),
-            });
-            Ok(json!({"queued": "load_track", "label": a.label}))
-        })
-        .register("play", move |_p| {
-            st_play.push_command(CpCommand::Play);
-            Ok(json!({"queued": "play"}))
-        })
-        .register("stop", move |_p| {
-            st_stop.push_command(CpCommand::Stop);
-            Ok(json!({"queued": "stop"}))
-        })
-        .register("select_tile", move |p| {
-            #[derive(serde::Deserialize)]
-            struct Args {
-                tile: String,
-            }
-            let a: Args = gui_cp::decode_params(p)?;
-            st_tile.push_command(CpCommand::SelectTile {
-                tile: a.tile.clone(),
-            });
-            Ok(json!({"queued": "select_tile", "tile": a.tile}))
-        })
-        .register("rescan", move |_p| {
-            st_rescan.push_command(CpCommand::Rescan);
-            Ok(json!({"queued": "rescan"}))
-        })
-        .register("list_tracks", move |p| {
-            #[derive(serde::Deserialize, Default)]
-            #[serde(default)]
-            struct Args {
-                limit: Option<usize>,
-                contains: Option<String>,
-            }
-            let a: Args = serde_json::from_value(p)
-                .map_err(|e| RpcError::invalid_params(format!("param parse: {e}")))?;
-            let snap = match st_list.read_snapshot() {
-                Some(s) => s,
-                None => return Ok(json!({"warming_up": true, "tracks": []})),
-            };
-            let needle = a.contains.unwrap_or_default().to_ascii_lowercase();
-            let limit = a.limit.unwrap_or(usize::MAX);
-            let tracks: Vec<&str> = snap
-                .all_labels
-                .iter()
-                .filter(|l| needle.is_empty() || l.to_ascii_lowercase().contains(&needle))
-                .take(limit)
-                .map(|s| s.as_str())
-                .collect();
-            Ok(json!({
-                "tracks": tracks,
-                "track_count": snap.track_count,
-            }))
-        })
-        .serve()
-}
-
-#[derive(Clone, Debug)]
-struct AudioAuditSnapshot {
-    track_label: String,
-    playable_path: PathBuf,
-    duration_sec: f32,
-    peak_dbfs: f32,
-    rms_dbfs: f32,
-    crest_factor_db: f32,
-    silence_count: usize,
-    longest_silence_sec: f32,
-    dominant: Vec<DominantFrequency>,
-    tone_balance: [f32; 3],
-    envelope: Vec<f32>,
-}
-
-fn decode_mono_for_audit(path: &Path) -> Result<(Vec<f32>, u32), String> {
-    let mut dec = open_decoded(path)?;
-    let ch = dec.channels.max(1) as usize;
-    let sr = dec.sample_rate;
-    let reserve = (dec.total_samples / ch as u64).min(44_100 * 180) as usize;
-    let mut mono = Vec::with_capacity(reserve);
-    loop {
-        let mut acc = 0.0f32;
-        let mut got = 0usize;
-        for _ in 0..ch {
-            match read_one_sample(&mut dec) {
-                Some(v) => {
-                    acc += v;
-                    got += 1;
-                }
-                None => break,
-            }
-        }
-        if got == 0 {
-            break;
-        }
-        mono.push(acc / got as f32);
-        if got < ch {
-            break;
-        }
-    }
-    Ok((mono, sr))
-}
-
-fn build_audio_audit(track_label: &str, path: &Path) -> Result<AudioAuditSnapshot, String> {
-    let (samples, sr) = decode_mono_for_audit(path)?;
-    if samples.is_empty() || sr == 0 {
-        return Err("decoded audio was empty".to_string());
-    }
-    let silences = audio_audit::silence_intervals(&samples, sr, -52.0, 180);
-    let longest_silence_sec = silences
-        .iter()
-        .map(|s| s.duration_sec)
-        .fold(0.0f32, f32::max);
-    let spectral = audio_audit::spectral_envelope(&samples, sr, 9);
-    let low: f32 = spectral.bands.iter().take(3).sum();
-    let mid: f32 = spectral.bands.iter().skip(3).take(3).sum();
-    let high: f32 = spectral.bands.iter().skip(6).take(3).sum();
-    let max_band = low.max(mid).max(high).max(1e-6);
-    let envelope_raw = audio_audit::rms_envelope(&samples, sr, 300);
-    let max_env = envelope_raw
-        .iter()
-        .copied()
-        .fold(0.0f32, f32::max)
-        .max(1e-6);
-    let envelope = envelope_raw.into_iter().map(|v| v / max_env).collect();
-    Ok(AudioAuditSnapshot {
-        track_label: track_label.to_string(),
-        playable_path: path.to_path_buf(),
-        duration_sec: samples.len() as f32 / sr as f32,
-        peak_dbfs: audio_audit::peak_dbfs(&samples),
-        rms_dbfs: audio_audit::rms_dbfs(&samples),
-        crest_factor_db: audio_audit::crest_factor_db(&samples),
-        silence_count: silences.len(),
-        longest_silence_sec,
-        dominant: audio_audit::dominant_frequencies(&samples, sr, 3),
-        tone_balance: [low / max_band, mid / max_band, high / max_band],
-        envelope,
-    })
-}
-
-struct PendingRender {
-    track_label: String,
-    voice_id: String,
-    started: Instant,
-    rx: std::sync::mpsc::Receiver<Result<PathBuf, String>>,
-    _handle: std::thread::JoinHandle<()>,
-}
-
-struct PendingAudit {
-    track_label: String,
-    rx: std::sync::mpsc::Receiver<Result<AudioAuditSnapshot, String>>,
-    _handle: std::thread::JoinHandle<()>,
-}
-
-#[derive(Clone, Default)]
-struct PlaybackSnapshot {
-    loaded_label: Option<String>,
-    is_playing: bool,
-    cursor_frames: u64,
-    total_frames: u64,
-    volume: f32,
 }
 
 struct JukeboxLiteC {
-    tracks: Vec<Track>,
-    song_index: HashMap<String, Song>,
-    db_voice_count: usize,
-    play_log: Option<PlayLogDb>,
-    favorites: HashSet<String>,
-    recent_ids: HashSet<String>,
-    recent_entries: Vec<PlayEntry>,
-    play_counts: HashMap<String, i64>,
+    sort_col: SortColumn,
+    sort_asc: bool,
+}
 
-    mixer: Mixer,
-    sample_rate_for_progress: u32,
-    pending_render: Option<PendingRender>,
-    pending_audit: Option<PendingAudit>,
-    audio_audit: Option<AudioAuditSnapshot>,
-    audio_audit_error: Option<String>,
-    loaded_voice: Option<String>,
-
-    tile: Tile,
-    search: String,
-    selected_label: Option<String>,
-    refresh_dirs: Vec<PathBuf>,
-
-    cp_state: gui_cp::State<CpSnapshot, CpCommand>,
-    _cp_handle: Option<gui_cp::Handle>,
-    cp_frame_id: u64,
+impl Default for JukeboxLiteC {
+    fn default() -> Self {
+        Self {
+            sort_col: SortColumn::Composer,
+            sort_asc: true,
+        }
+    }
 }
 
 impl JukeboxLiteC {
-    fn new(dirs: Vec<PathBuf>) -> Result<Self, String> {
-        let (song_index, db_voice_count) = load_library_index();
-        let dir_refs: Vec<&Path> = dirs.iter().map(|p| p.as_path()).collect();
-        let tracks = scan_dirs(&dir_refs);
-        println!(
-            "jukebox_lite_c: library_db catalog -> {} songs / {} voices ({} files on disk)",
-            song_index.len(),
-            db_voice_count,
-            tracks.len(),
-        );
-        let play_log = load_play_log();
-        let (favorites, recent_ids, recent_entries, play_counts) =
-            snapshot_history(play_log.as_ref());
-
-        let audio = Arc::new(Mutex::new(AudioState::new()));
-        let mixer = build_mixer_stream(audio).map_err(|e| format!("audio: {e}"))?;
-        let sample_rate_for_progress = 44_100;
-
-        let cp_state: gui_cp::State<CpSnapshot, CpCommand> = gui_cp::State::new();
-        let cp_handle = match spawn_cp_server(cp_state.clone()) {
-            Ok(h) => Some(h),
-            Err(e) => {
-                eprintln!("jukebox_lite_c: CP server failed: {e}");
-                None
-            }
-        };
-
-        let initial_label = recent_entries
-            .first()
-            .map(|e| e.song_id.clone())
-            .or_else(|| favorites.iter().next().cloned())
-            .or_else(|| tracks.first().map(|t| t.label.clone()));
-
-        Ok(Self {
-            tracks,
-            song_index,
-            db_voice_count,
-            play_log,
-            favorites,
-            recent_ids,
-            recent_entries,
-            play_counts,
-            mixer,
-            sample_rate_for_progress,
-            pending_render: None,
-            pending_audit: None,
-            audio_audit: None,
-            audio_audit_error: None,
-            loaded_voice: None,
-            tile: Tile::All,
-            search: String::new(),
-            selected_label: initial_label,
-            refresh_dirs: dirs,
-            cp_state,
-            _cp_handle: cp_handle,
-            cp_frame_id: 0,
-        })
-    }
-
-    fn rescan(&mut self) {
-        let dir_refs: Vec<&Path> = self.refresh_dirs.iter().map(|p| p.as_path()).collect();
-        self.tracks = scan_dirs(&dir_refs);
-        let (idx, vc) = load_library_index();
-        self.song_index = idx;
-        self.db_voice_count = vc;
-        self.refresh_history();
-    }
-
-    fn refresh_history(&mut self) {
-        let (f, r, re, counts) = snapshot_history(self.play_log.as_ref());
-        self.favorites = f;
-        self.recent_ids = r;
-        self.recent_entries = re;
-        self.play_counts = counts;
-    }
-
-    fn playback_snapshot(&self) -> PlaybackSnapshot {
-        let st = match self.mixer.state.lock() {
-            Ok(g) => g,
-            Err(_) => return PlaybackSnapshot::default(),
-        };
-        PlaybackSnapshot {
-            loaded_label: if st.label.is_empty() {
-                None
-            } else {
-                Some(st.label.clone())
-            },
-            is_playing: st.is_playing,
-            cursor_frames: st.cursor_frames,
-            total_frames: st
-                .decoded
-                .as_ref()
-                .map(|d| d.total_samples / d.channels.max(1) as u64)
-                .unwrap_or(0),
-            volume: st.volume,
+    fn toggle_sort(&mut self, col: SortColumn) {
+        if self.sort_col == col {
+            self.sort_asc = !self.sort_asc;
+        } else {
+            self.sort_col = col;
+            self.sort_asc = true;
         }
     }
 
-    fn visible_tracks(&self) -> Vec<Track> {
-        let needle = self.search.trim().to_ascii_lowercase();
-        let mut out: Vec<Track> = self
-            .tracks
-            .iter()
-            .filter(|t| {
-                let song = self.song_index.get(&t.label);
-                if !track_matches_tile(self.tile, t, song, &self.favorites, &self.recent_ids) {
-                    return false;
-                }
-                if needle.is_empty() {
-                    return true;
-                }
-                let title = song.map(|s| s.title.as_str()).unwrap_or("");
-                let composer = song.map(|s| s.composer.as_str()).unwrap_or("");
-                t.label.to_ascii_lowercase().contains(&needle)
-                    || title.to_ascii_lowercase().contains(&needle)
-                    || composer.to_ascii_lowercase().contains(&needle)
-            })
-            .cloned()
-            .collect();
-        if self.tile == Tile::Recent {
-            let order: HashMap<&str, usize> = self
-                .recent_entries
-                .iter()
-                .enumerate()
-                .map(|(i, e)| (e.song_id.as_str(), i))
-                .collect();
-            out.sort_by_key(|t| order.get(t.label.as_str()).copied().unwrap_or(usize::MAX));
-        } else if !self.song_index.is_empty() {
-            out.sort_by(|a, b| {
-                let ka = self
-                    .song_index
-                    .get(&a.label)
-                    .map(|s| s.composer_key.clone());
-                let kb = self
-                    .song_index
-                    .get(&b.label)
-                    .map(|s| s.composer_key.clone());
-                match (ka, kb) {
-                    (Some(x), Some(y)) => x.cmp(&y).then_with(|| a.label.cmp(&b.label)),
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                    (None, None) => a.label.cmp(&b.label),
-                }
-            });
-        }
-        out
-    }
-
-    fn ensure_selection(&mut self, visible: &[Track]) {
-        if self
-            .selected_label
-            .as_ref()
-            .map(|label| self.tracks.iter().any(|t| &t.label == label))
-            .unwrap_or(false)
-        {
-            return;
-        }
-        self.selected_label = visible.first().map(|t| t.label.clone());
-    }
-
-    fn selected_track(&self) -> Option<Track> {
-        let label = self.selected_label.as_ref()?;
-        self.tracks.iter().find(|t| &t.label == label).cloned()
-    }
-
-    fn toggle_favorite(&mut self, label: &str) {
-        let Some(db) = self.play_log.as_mut() else {
-            return;
-        };
-        if let Err(e) = db.toggle_favorite(label) {
-            eprintln!("jukebox_lite_c: toggle_favorite({label}): {e}");
-        }
-        self.refresh_history();
-    }
-
-    fn resume_loaded(&mut self) {
-        if let Ok(mut st) = self.mixer.state.lock() {
-            if st.decoded.is_some() {
-                st.is_playing = true;
-            }
-        }
-    }
-
-    fn set_volume(&mut self, volume: f32) {
-        if let Ok(mut st) = self.mixer.state.lock() {
-            st.volume = volume.clamp(0.0, 1.5);
-        }
-    }
-
-    fn activate_track(&mut self, track: Track, playback: &PlaybackSnapshot) {
-        if playback.loaded_label.as_deref() == Some(track.label.as_str()) {
-            if playback.is_playing {
-                self.stop();
-            } else {
-                self.resume_loaded();
-            }
-            self.selected_label = Some(track.label);
-            return;
-        }
-        self.play_track(track);
-    }
-
-    fn play_track(&mut self, track: Track) {
-        let song = self.song_index.get(&track.label).cloned();
-        let voice = pick_voice(self.tile, song.as_ref(), &track).to_string();
-        self.selected_label = Some(track.label.clone());
-
-        let playable = match track.format {
-            Format::Mid => match lookup_in_cache(&track.path, &voice) {
-                Ok(Some(p)) => p,
-                Ok(None) => {
-                    self.spawn_render(&track, &voice);
-                    return;
-                }
-                Err(e) => {
-                    eprintln!("jukebox_lite_c: cache lookup {}: {e}", track.path.display());
-                    return;
-                }
-            },
-            Format::Wav | Format::Mp3 => track.path.clone(),
-        };
-        self.load_resolved(track.label.clone(), playable, &voice);
-    }
-
-    fn spawn_render(&mut self, track: &Track, voice: &str) {
-        let path = track.path.clone();
-        let voice_for_thread = voice.to_string();
-        let label = track.label.clone();
-        let (tx, rx) = std::sync::mpsc::channel();
-        let handle = std::thread::Builder::new()
-            .name("jukebox-lite-c-render".into())
-            .spawn(move || {
-                let result = render_midi_blocking(&path, &voice_for_thread);
-                let _ = tx.send(result);
-            })
-            .expect("spawn render thread");
-        eprintln!(
-            "jukebox_lite_c: render queued ({}) — voice={voice}",
-            track.path.display(),
-        );
-        self.pending_render = Some(PendingRender {
-            track_label: label,
-            voice_id: voice.to_string(),
-            started: Instant::now(),
-            rx,
-            _handle: handle,
-        });
-    }
-
-    fn poll_pending_render(&mut self) {
-        let pending = match self.pending_render.as_ref() {
-            Some(p) => p,
-            None => return,
-        };
-        let result = match pending.rx.try_recv() {
-            Ok(r) => r,
-            Err(std::sync::mpsc::TryRecvError::Empty) => return,
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                self.pending_render = None;
-                return;
-            }
-        };
-        let pending = self.pending_render.take().expect("guarded");
-        let elapsed = pending.started.elapsed().as_millis();
-        match result {
-            Ok(wav) => {
-                eprintln!(
-                    "jukebox_lite_c: render done ({}) in {} ms",
-                    wav.display(),
-                    elapsed,
-                );
-                self.load_resolved(pending.track_label, wav, &pending.voice_id);
-            }
-            Err(e) => {
-                eprintln!("jukebox_lite_c: render failed: {e}");
-            }
-        }
-    }
-
-    fn spawn_audio_audit(&mut self, label: &str, playable: &Path) {
-        let label = label.to_string();
-        let label_for_thread = label.clone();
-        let path = playable.to_path_buf();
-        let (tx, rx) = std::sync::mpsc::channel();
-        let handle = std::thread::Builder::new()
-            .name("jukebox-lite-c-audit".into())
-            .spawn(move || {
-                let result = build_audio_audit(&label_for_thread, &path);
-                let _ = tx.send(result);
-            })
-            .expect("spawn audit thread");
-        self.pending_audit = Some(PendingAudit {
-            track_label: label,
-            rx,
-            _handle: handle,
-        });
-    }
-
-    fn poll_pending_audit(&mut self) {
-        let pending = match self.pending_audit.as_ref() {
-            Some(p) => p,
-            None => return,
-        };
-        let result = match pending.rx.try_recv() {
-            Ok(r) => r,
-            Err(std::sync::mpsc::TryRecvError::Empty) => return,
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                self.pending_audit = None;
-                return;
-            }
-        };
-        let pending = self.pending_audit.take().expect("guarded");
-        match result {
-            Ok(report) => {
-                if report.track_label == pending.track_label {
-                    self.audio_audit_error = None;
-                    self.audio_audit = Some(report);
-                }
-            }
-            Err(e) => {
-                self.audio_audit = None;
-                self.audio_audit_error = Some(e);
-            }
-        }
-    }
-
-    fn load_resolved(&mut self, label: String, playable: PathBuf, voice: &str) {
-        let dec = match open_decoded(&playable) {
-            Ok(d) => d,
-            Err(e) => {
-                eprintln!("jukebox_lite_c: open {}: {e}", playable.display());
-                return;
-            }
-        };
-        let sr = dec.sample_rate;
-        {
-            let mut st = match self.mixer.state.lock() {
-                Ok(g) => g,
-                Err(_) => return,
+    fn sort_tracks(&self, core: &JukeboxCore, tracks: &mut Vec<Track>) {
+        let lib = &core.library;
+        tracks.sort_by(|a, b| {
+            let sa = lib.song(&a.label);
+            let sb = lib.song(&b.label);
+            let ord = match self.sort_col {
+                SortColumn::Title => song_title(sa, a).cmp(&song_title(sb, b)),
+                SortColumn::Composer => song_composer_key(sa).cmp(&song_composer_key(sb)),
+                SortColumn::Era => song_era(sa).cmp(&song_era(sb)),
+                SortColumn::Format => format_label(a.format).cmp(format_label(b.format)),
             };
-            st.decoded = Some(dec);
-            st.is_playing = true;
-            st.cursor_frames = 0;
-            st.label = label.clone();
-        }
-        self.sample_rate_for_progress = sr;
-        self.selected_label = Some(label.clone());
-        self.loaded_voice = Some(voice.to_string());
-        self.audio_audit = None;
-        self.audio_audit_error = None;
-        self.spawn_audio_audit(&label, &playable);
-
-        if let Some(db) = self.play_log.as_mut() {
-            let stored_voice = if voice == "direct" { None } else { Some(voice) };
-            if let Err(e) = db.record_play(&label, stored_voice, None) {
-                eprintln!("jukebox_lite_c: record_play({label}): {e}");
-            }
-        }
-        self.refresh_history();
-    }
-
-    fn stop(&mut self) {
-        if let Ok(mut st) = self.mixer.state.lock() {
-            st.is_playing = false;
-        }
-    }
-
-    fn drain_cp_commands(&mut self) {
-        for cmd in self.cp_state.drain_commands() {
-            match cmd {
-                CpCommand::LoadTrack { label } => {
-                    if let Some(t) = self.tracks.iter().find(|t| t.label == label).cloned() {
-                        self.play_track(t);
-                    } else {
-                        eprintln!("jukebox_lite_c: CP load_track unknown label={label}");
-                    }
-                }
-                CpCommand::Play => self.resume_loaded(),
-                CpCommand::Stop => self.stop(),
-                CpCommand::SelectTile { tile } => {
-                    if let Some(t) = tile_from_str(&tile) {
-                        self.tile = t;
-                    }
-                }
-                CpCommand::Rescan => self.rescan(),
-            }
-        }
-    }
-
-    fn publish_cp_snapshot(&mut self, visible: &[Track], playback: &PlaybackSnapshot) {
-        self.cp_frame_id = self.cp_frame_id.saturating_add(1);
-        let snap = CpSnapshot {
-            frame_id: self.cp_frame_id,
-            track_count: self.tracks.len(),
-            db_song_count: self.song_index.len(),
-            db_voice_count: self.db_voice_count,
-            selected_label: self.selected_label.clone(),
-            selected_tile: self.tile.label().to_string(),
-            any_playing: playback.is_playing,
-            loaded_label: playback.loaded_label.clone(),
-            cursor_frames: playback.cursor_frames,
-            total_frames: playback.total_frames,
-            sample_rate: self.sample_rate_for_progress,
-            visible_labels: visible.iter().map(|t| t.label.clone()).collect(),
-            all_labels: self.tracks.iter().map(|t| t.label.clone()).collect(),
-        };
-        self.cp_state.publish(snap);
-    }
-
-    fn show_header(&mut self, ui: &mut egui::Ui, visible_count: usize) {
-        ui.add_space(4.0);
-        ui.horizontal(|ui| {
-            ui.heading("keysynth / jukebox lite c");
-            ui.add_space(8.0);
-            ui.label(
-                egui::RichText::new("list browser")
-                    .small()
-                    .color(egui::Color32::from_rgb(96, 100, 93)),
-            );
-            ui.add_space(16.0);
-            stat_chip(
-                ui,
-                "View",
-                format!("{} rows", visible_count),
-                egui::Color32::from_rgb(225, 229, 218),
-            );
-            stat_chip(
-                ui,
-                "Catalog",
-                format!("{} songs", self.song_index.len()),
-                egui::Color32::from_rgb(225, 222, 214),
-            );
-            stat_chip(
-                ui,
-                "Voices",
-                self.db_voice_count.to_string(),
-                egui::Color32::from_rgb(220, 229, 228),
-            );
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                if ui.button("Rescan").clicked() {
-                    self.rescan();
-                }
-                if ui.button("Clear").clicked() {
-                    self.search.clear();
-                }
-            });
-        });
-        ui.add_space(6.0);
-        ui.horizontal(|ui| {
-            ui.label(
-                egui::RichText::new("Find")
-                    .strong()
-                    .color(egui::Color32::from_rgb(48, 53, 49)),
-            );
-            ui.add_sized(
-                [300.0, 30.0],
-                egui::TextEdit::singleline(&mut self.search)
-                    .hint_text("title, composer, stem, or catalog metadata"),
-            );
-            ui.add_space(10.0);
-            ui.label(
-                egui::RichText::new(format!("{} view", self.tile.label()))
-                    .color(egui::Color32::from_rgb(83, 98, 88)),
-            );
-            if let Some(pending) = self.pending_render.as_ref() {
-                ui.add_space(14.0);
-                ui.spinner();
-                ui.label(
-                    egui::RichText::new(format!("rendering {}", pending.track_label))
-                        .color(egui::Color32::from_rgb(69, 111, 103)),
-                );
-            } else if let Some(pending) = self.pending_audit.as_ref() {
-                ui.add_space(14.0);
-                ui.spinner();
-                ui.label(
-                    egui::RichText::new(format!("auditing {}", pending.track_label))
-                        .color(egui::Color32::from_rgb(92, 93, 131)),
-                );
+            let tie = a.label.cmp(&b.label);
+            let combined = ord.then(tie);
+            if self.sort_asc {
+                combined
+            } else {
+                combined.reverse()
             }
         });
     }
+}
 
-    fn show_sidebar(&mut self, ui: &mut egui::Ui) {
-        ui.add_space(8.0);
-        ui.label(
-            egui::RichText::new("Filters")
-                .small()
-                .color(egui::Color32::from_rgb(96, 100, 93)),
-        );
-        ui.add_space(4.0);
-        for &tile in Tile::all() {
-            let count = self
-                .tracks
-                .iter()
-                .filter(|t| {
-                    track_matches_tile(
-                        tile,
-                        t,
-                        self.song_index.get(&t.label),
-                        &self.favorites,
-                        &self.recent_ids,
-                    )
-                })
-                .count();
-            let selected = self.tile == tile;
-            let fill = if selected {
-                egui::Color32::from_rgb(80, 115, 103)
-            } else {
-                egui::Color32::from_rgb(229, 226, 218)
-            };
-            let text = if selected {
-                egui::Color32::from_rgb(247, 245, 240)
-            } else {
-                egui::Color32::from_rgb(44, 47, 45)
-            };
-            let button = egui::Button::new(
-                egui::RichText::new(format!("{:<10} {:>4}", tile.label(), count)).color(text),
-            )
-            .fill(fill);
-            if ui.add_sized([170.0, 30.0], button).clicked() {
-                self.tile = tile;
-            }
-            ui.add_space(4.0);
-        }
+fn song_title(song: Option<&Song>, track: &Track) -> String {
+    song.map(|s| s.title.clone())
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| track.label.clone())
+        .to_ascii_lowercase()
+}
 
-        ui.add_space(10.0);
-        ui.separator();
-        ui.add_space(10.0);
-        ui.label(
-            egui::RichText::new("Routing")
-                .small()
-                .color(egui::Color32::from_rgb(96, 100, 93)),
-        );
-        ui.add_space(4.0);
-        routing_row(ui, "Classical", "piano-modal");
-        routing_row(ui, "Game", "square");
-        routing_row(ui, "Folk", "guitar-stk");
-        routing_row(ui, "Audio files", "direct");
+fn song_composer_key(song: Option<&Song>) -> String {
+    song.map(|s| s.composer_key.clone())
+        .unwrap_or_else(|| "~".to_string())
+}
 
-        ui.add_space(10.0);
-        ui.separator();
-        ui.add_space(10.0);
-        ui.label(
-            egui::RichText::new("Recent")
-                .small()
-                .color(egui::Color32::from_rgb(96, 100, 93)),
-        );
-        ui.add_space(4.0);
-        let mut to_select = None;
-        let mut shown = 0usize;
-        for entry in &self.recent_entries {
-            if shown >= 5 {
-                break;
-            }
-            let Some(track) = self.tracks.iter().find(|t| t.label == entry.song_id) else {
-                continue;
-            };
-            let song = self.song_index.get(&track.label);
-            let title = display_title(song, track);
-            let subtitle = display_composer(song);
-            let button = egui::Button::new(
-                egui::RichText::new(title).color(egui::Color32::from_rgb(44, 47, 45)),
-            )
-            .fill(egui::Color32::from_rgb(240, 236, 228));
-            if ui.add_sized([170.0, 26.0], button).clicked() {
-                to_select = Some(track.label.clone());
-            }
-            ui.label(
-                egui::RichText::new(subtitle)
-                    .small()
-                    .color(egui::Color32::from_rgb(108, 111, 108)),
-            );
-            ui.add_space(4.0);
-            shown += 1;
-        }
-        if let Some(label) = to_select {
-            self.selected_label = Some(label);
-        }
+fn song_era(song: Option<&Song>) -> String {
+    song.and_then(|s| s.era.clone())
+        .unwrap_or_else(|| "~".to_string())
+}
+
+fn format_label(f: Format) -> &'static str {
+    match f {
+        Format::Wav => "WAV",
+        Format::Mp3 => "MP3",
+        Format::Mid => "MID",
     }
+}
 
-    fn show_transport(&mut self, ui: &mut egui::Ui, playback: &PlaybackSnapshot) {
-        egui::Frame::none()
-            .fill(egui::Color32::from_rgb(57, 69, 63))
-            .inner_margin(egui::Margin::symmetric(14.0, 12.0))
-            .rounding(8.0)
-            .show(ui, |ui| {
-                let label = playback.loaded_label.clone();
-                let song = label.as_ref().and_then(|l| self.song_index.get(l));
-                let title = match (label.as_ref(), song) {
-                    (Some(_), Some(s)) => s.title.clone(),
-                    (Some(l), None) => l.clone(),
-                    (None, _) => "No track loaded".to_string(),
-                };
-                let subtitle = match (label.as_ref(), song) {
-                    (Some(_), Some(s)) => {
-                        let mut out = compact_composer(&s.composer);
-                        if let Some(era) = s.era.as_deref() {
-                            out.push_str("  /  ");
-                            out.push_str(era);
-                        }
-                        out
-                    }
-                    (Some(l), None) => l.clone(),
-                    (None, _) => "Select a row and hit Play.".to_string(),
-                };
+fn fmt_duration(frames: u64, sample_rate: u32) -> String {
+    if sample_rate == 0 || frames == 0 {
+        return String::from("--:--");
+    }
+    let total = frames as f64 / sample_rate as f64;
+    let mins = (total / 60.0).floor() as u64;
+    let secs = (total - (mins as f64) * 60.0).floor() as u64;
+    format!("{:02}:{:02}", mins, secs)
+}
+
+impl JukeboxApp for JukeboxLiteC {
+    fn render(&mut self, ctx: &egui::Context, core: &mut JukeboxCore, visible: &[Track]) {
+        // Build sorted snapshot for this paint.
+        let mut sorted: Vec<Track> = visible.to_vec();
+        self.sort_tracks(core, &mut sorted);
+
+        let snap = core.audio.snapshot();
+        let sample_rate = core.audio.sample_rate_for_progress;
+        let active_tile = core.selection.tile;
+        let selected_label = core.selection.selected_label.clone();
+
+        // Top: search bar + tile tabs.
+        egui::TopBottomPanel::top("ui_c_top")
+            .exact_height(TILE_BAR_H * 2.0 + 6.0)
+            .show(ctx, |ui| {
+                ui.add_space(2.0);
                 ui.horizontal(|ui| {
-                    ui.vertical(|ui| {
-                        ui.label(
-                            egui::RichText::new(title)
-                                .size(17.0)
-                                .strong()
-                                .color(egui::Color32::from_rgb(246, 244, 240)),
-                        );
-                        ui.label(
-                            egui::RichText::new(subtitle)
-                                .small()
-                                .color(egui::Color32::from_rgb(205, 213, 204)),
-                        );
-                    });
-                    ui.add_space(14.0);
-                    let mut vol = playback.volume;
-                    let progress = if playback.total_frames > 0 {
-                        (playback.cursor_frames as f32 / playback.total_frames as f32)
-                            .clamp(0.0, 1.0)
-                    } else {
-                        0.0
-                    };
-                    ui.add(egui::ProgressBar::new(progress).desired_width(340.0).text(
-                        if playback.total_frames > 0 {
-                            let secs = playback.cursor_frames as u32
-                                / self.sample_rate_for_progress.max(1);
-                            let total_secs =
-                                playback.total_frames as u32 / self.sample_rate_for_progress.max(1);
-                            format!(
-                                "{:01}:{:02} / {:01}:{:02}",
-                                secs / 60,
-                                secs % 60,
-                                total_secs / 60,
-                                total_secs % 60
-                            )
-                        } else {
-                            "--:--".to_string()
-                        },
-                    ));
-                    ui.add_space(14.0);
+                    ui.label(egui::RichText::new("filter").small().weak());
+                    let resp = ui.add(
+                        egui::TextEdit::singleline(&mut core.selection.search)
+                            .desired_width(260.0)
+                            .hint_text("title / composer / label")
+                            .font(egui::TextStyle::Small),
+                    );
+                    if resp.changed() {
+                        ctx.request_repaint();
+                    }
+                    ui.separator();
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "{} / {} tracks",
+                            sorted.len(),
+                            core.library.tracks.len()
+                        ))
+                        .small()
+                        .weak(),
+                    );
+                });
+                ui.add_space(2.0);
+                ui.horizontal(|ui| {
+                    for &tile in Tile::all() {
+                        let active = tile == active_tile;
+                        let txt = egui::RichText::new(tile.label()).small();
+                        let txt = if active { txt.strong() } else { txt.weak() };
+                        if ui
+                            .selectable_label(active, txt)
+                            .on_hover_text(tile.label())
+                            .clicked()
+                        {
+                            core.select_tile(tile);
+                        }
+                    }
+                });
+            });
+
+        // Bottom: transport + progress.
+        egui::TopBottomPanel::bottom("ui_c_bottom")
+            .exact_height(TRANSPORT_H + PROGRESS_H + 8.0)
+            .show(ctx, |ui| {
+                let now_label = snap
+                    .label
+                    .clone()
+                    .or_else(|| selected_label.clone())
+                    .unwrap_or_else(|| String::from("(no track)"));
+                let composer_text = core
+                    .library
+                    .song(&now_label)
+                    .map(|s| s.composer.clone())
+                    .filter(|c| !c.is_empty());
+                let now_text = match composer_text {
+                    Some(c) => format!("{}  -  {}", now_label, c),
+                    None => now_label.clone(),
+                };
+                ui.add_space(2.0);
+                ui.horizontal(|ui| {
+                    let playing = snap.is_playing;
+                    let play_label = if playing { "II" } else { ">" };
                     if ui
-                        .add_sized(
-                            [62.0, 28.0],
-                            egui::Button::new(if playback.is_playing { "Stop" } else { "Play" })
-                                .fill(egui::Color32::from_rgb(208, 224, 216)),
-                        )
+                        .add_sized([28.0, 22.0], egui::Button::new(play_label))
                         .clicked()
                     {
-                        if playback.is_playing {
-                            self.stop();
-                        } else {
-                            self.resume_loaded();
+                        if playing {
+                            core.audio.stop();
+                        } else if let Some(label) = selected_label.clone() {
+                            core.play_label(&label);
                         }
                     }
-                    ui.add_space(8.0);
-                    ui.label(
-                        egui::RichText::new(display_voice_label(self.loaded_voice.as_deref()))
-                            .small()
-                            .color(egui::Color32::from_rgb(219, 223, 216)),
-                    );
-                    ui.add_space(8.0);
                     if ui
-                        .add_sized(
-                            [110.0, 24.0],
-                            egui::Slider::new(&mut vol, 0.0..=1.25).show_value(false),
-                        )
-                        .changed()
+                        .add_sized([28.0, 22.0], egui::Button::new("[]"))
+                        .clicked()
                     {
-                        self.set_volume(vol);
+                        core.stop();
                     }
-                    ui.label(
-                        egui::RichText::new(format!("{:>3.0}%", vol * 100.0))
-                            .small()
-                            .color(egui::Color32::from_rgb(219, 223, 216)),
-                    );
-                });
-            });
-    }
-
-    fn show_inspector(&mut self, ui: &mut egui::Ui, playback: &PlaybackSnapshot) {
-        ui.add_space(8.0);
-        let Some(track) = self.selected_track() else {
-            ui.label("No selection.");
-            return;
-        };
-        let song = self.song_index.get(&track.label).cloned();
-        let title = display_title(song.as_ref(), &track);
-        let composer = display_composer(song.as_ref());
-        ui.label(
-            egui::RichText::new(title)
-                .heading()
-                .color(egui::Color32::from_rgb(36, 40, 37)),
-        );
-        ui.label(
-            egui::RichText::new(composer)
-                .color(egui::Color32::from_rgb(93, 96, 91))
-                .small(),
-        );
-        ui.add_space(10.0);
-
-        let is_fav = self.favorites.contains(&track.label);
-        ui.horizontal(|ui| {
-            if ui
-                .add_sized(
-                    [76.0, 28.0],
-                    egui::Button::new("Play").fill(egui::Color32::from_rgb(211, 224, 215)),
-                )
-                .clicked()
-            {
-                self.activate_track(track.clone(), playback);
-            }
-            if ui
-                .add_sized(
-                    [76.0, 28.0],
-                    egui::Button::new(if is_fav { "Unsave" } else { "Save" })
-                        .fill(egui::Color32::from_rgb(229, 224, 214)),
-                )
-                .clicked()
-            {
-                self.toggle_favorite(&track.label);
-            }
-        });
-
-        ui.add_space(10.0);
-        egui::Grid::new("jukebox_lite_c_meta")
-            .num_columns(2)
-            .spacing([12.0, 8.0])
-            .show(ui, |ui| {
-                inspector_key(ui, "Label");
-                ui.label(egui::RichText::new(&track.label).monospace());
-                ui.end_row();
-
-                inspector_key(ui, "Format");
-                ui.label(track.format.label());
-                ui.end_row();
-
-                inspector_key(ui, "Route");
-                ui.label(display_voice_label(Some(pick_voice(
-                    self.tile,
-                    song.as_ref(),
-                    &track,
-                ))));
-                ui.end_row();
-
-                inspector_key(ui, "Era");
-                ui.label(song.as_ref().and_then(|s| s.era.as_deref()).unwrap_or("-"));
-                ui.end_row();
-
-                inspector_key(ui, "Instrument");
-                ui.label(song.as_ref().map(|s| s.instrument.as_str()).unwrap_or("-"));
-                ui.end_row();
-
-                inspector_key(ui, "License");
-                ui.label(song.as_ref().map(|s| s.license.as_str()).unwrap_or("-"));
-                ui.end_row();
-
-                inspector_key(ui, "Plays");
-                ui.label(
-                    self.play_counts
-                        .get(&track.label)
-                        .copied()
-                        .unwrap_or(0)
-                        .to_string(),
-                );
-                ui.end_row();
-
-                inspector_key(ui, "Last heard");
-                let last_heard = self
-                    .play_log
-                    .as_ref()
-                    .and_then(|db| db.last_played_at(&track.label).ok().flatten())
-                    .map(|ts| humanize_ago(unix_now().saturating_sub(ts)))
-                    .unwrap_or_else(|| "never".to_string());
-                ui.label(last_heard);
-                ui.end_row();
-
-                inspector_key(ui, "Path");
-                ui.label(
-                    egui::RichText::new(track.path.display().to_string())
-                        .small()
-                        .monospace(),
-                );
-                ui.end_row();
-            });
-
-        if let Some(song) = song.as_ref() {
-            if !song.tags.is_empty() {
-                ui.add_space(10.0);
-                ui.label(
-                    egui::RichText::new("Tags")
-                        .small()
-                        .color(egui::Color32::from_rgb(96, 100, 93)),
-                );
-                ui.add_space(4.0);
-                ui.horizontal_wrapped(|ui| {
-                    for tag in &song.tags {
-                        detail_chip(ui, tag, egui::Color32::from_rgb(232, 228, 219));
-                    }
-                });
-            }
-
-            if let Some(context) = song.context.as_deref() {
-                ui.add_space(10.0);
-                ui.label(
-                    egui::RichText::new("Context")
-                        .small()
-                        .color(egui::Color32::from_rgb(96, 100, 93)),
-                );
-                ui.add_space(4.0);
-                egui::Frame::none()
-                    .fill(egui::Color32::from_rgb(240, 236, 228))
-                    .inner_margin(egui::Margin::symmetric(10.0, 8.0))
-                    .rounding(6.0)
-                    .show(ui, |ui| {
-                        ui.label(context);
+                    ui.separator();
+                    ui.label(egui::RichText::new(now_text).small());
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let dur = fmt_duration(snap.total_frames, sample_rate);
+                        let pos = fmt_duration(snap.cursor_frames, sample_rate);
+                        ui.label(
+                            egui::RichText::new(format!("{} / {}", pos, dur))
+                                .small()
+                                .monospace(),
+                        );
                     });
-            }
-
-            if let Some(url) = song.source_url.as_deref() {
-                ui.add_space(8.0);
-                ui.hyperlink_to("Source link", url);
-            }
-        }
-
-        ui.add_space(12.0);
-        ui.separator();
-        ui.add_space(12.0);
-        ui.label(
-            egui::RichText::new("Audio audit")
-                .small()
-                .color(egui::Color32::from_rgb(96, 100, 93)),
-        );
-        ui.add_space(6.0);
-
-        let audit_matches = self
-            .audio_audit
-            .as_ref()
-            .map(|a| a.track_label == track.label)
-            .unwrap_or(false);
-        let audit_pending = self
-            .pending_audit
-            .as_ref()
-            .map(|p| p.track_label == track.label)
-            .unwrap_or(false);
-
-        if audit_pending {
-            ui.spinner();
-            ui.label("Computing audio metrics...");
-            return;
-        }
-
-        if !audit_matches {
-            if self
-                .pending_render
-                .as_ref()
-                .map(|p| p.track_label == track.label)
-                .unwrap_or(false)
-            {
-                ui.label("This row is waiting on preview render before audio audit can run.");
-            } else {
-                ui.label("Play this row to populate the audio audit panel.");
-            }
-            return;
-        }
-
-        let Some(report) = self.audio_audit.as_ref() else {
-            if let Some(err) = self.audio_audit_error.as_deref() {
-                ui.label(err);
-            }
-            return;
-        };
-
-        ui.label(
-            egui::RichText::new(report.playable_path.display().to_string())
-                .small()
-                .monospace()
-                .color(egui::Color32::from_rgb(103, 107, 103)),
-        );
-        ui.add_space(8.0);
-        draw_envelope(ui, &report.envelope);
-        ui.add_space(8.0);
-        egui::Grid::new("jukebox_lite_c_audit_metrics")
-            .num_columns(2)
-            .spacing([12.0, 6.0])
-            .show(ui, |ui| {
-                inspector_key(ui, "Duration");
-                ui.label(format!("{:.1}s", report.duration_sec));
-                ui.end_row();
-
-                inspector_key(ui, "Peak");
-                ui.label(format!("{:.1} dBFS", report.peak_dbfs));
-                ui.end_row();
-
-                inspector_key(ui, "RMS");
-                ui.label(format!("{:.1} dBFS", report.rms_dbfs));
-                ui.end_row();
-
-                inspector_key(ui, "Crest");
-                ui.label(format!("{:.1} dB", report.crest_factor_db));
-                ui.end_row();
-
-                inspector_key(ui, "Silence");
-                ui.label(format!(
-                    "{} spans / {:.2}s longest",
-                    report.silence_count, report.longest_silence_sec
-                ));
-                ui.end_row();
-            });
-        ui.add_space(8.0);
-        meter_row(
-            ui,
-            "Body",
-            report.tone_balance[0],
-            egui::Color32::from_rgb(182, 196, 160),
-        );
-        meter_row(
-            ui,
-            "Presence",
-            report.tone_balance[1],
-            egui::Color32::from_rgb(123, 167, 151),
-        );
-        meter_row(
-            ui,
-            "Air",
-            report.tone_balance[2],
-            egui::Color32::from_rgb(144, 171, 201),
-        );
-
-        if !report.dominant.is_empty() {
-            ui.add_space(10.0);
-            ui.label(
-                egui::RichText::new("Dominant frequencies")
-                    .small()
-                    .color(egui::Color32::from_rgb(96, 100, 93)),
-            );
-            for dom in &report.dominant {
-                ui.label(format!(
-                    "{:>6.1} Hz   {:>5.1} dB",
-                    dom.freq_hz, dom.magnitude_db
-                ));
-            }
-        }
-    }
-
-    fn show_table(&mut self, ui: &mut egui::Ui, visible: &[Track], playback: &PlaybackSnapshot) {
-        if visible.is_empty() {
-            ui.add_space(50.0);
-            ui.vertical_centered(|ui| {
-                ui.label(
-                    egui::RichText::new("No rows in this view.")
-                        .heading()
-                        .color(egui::Color32::from_rgb(104, 108, 102)),
-                );
-                ui.label("Change the filter or clear the search box.");
-            });
-            return;
-        }
-
-        const ROW_H: f32 = 34.0;
-        const STATUS_W: f32 = 54.0;
-        const COMPOSER_W: f32 = 180.0;
-        const ERA_W: f32 = 90.0;
-        const INSTR_W: f32 = 92.0;
-        const SOURCE_W: f32 = 56.0;
-        const PLAYS_W: f32 = 42.0;
-        const ACTION_W: f32 = 56.0;
-        const FAV_W: f32 = 44.0;
-
-        let title_w = (ui.available_width()
-            - STATUS_W
-            - COMPOSER_W
-            - ERA_W
-            - INSTR_W
-            - SOURCE_W
-            - PLAYS_W
-            - ACTION_W
-            - FAV_W
-            - 48.0)
-            .max(220.0);
-
-        egui::Frame::none()
-            .fill(egui::Color32::from_rgb(214, 221, 210))
-            .rounding(6.0)
-            .inner_margin(egui::Margin::symmetric(10.0, 8.0))
-            .show(ui, |ui| {
-                ui.horizontal(|ui| {
-                    header_cell(ui, STATUS_W, "State");
-                    header_cell(ui, title_w, "Title");
-                    header_cell(ui, COMPOSER_W, "Composer");
-                    header_cell(ui, ERA_W, "Era");
-                    header_cell(ui, INSTR_W, "Inst");
-                    header_cell(ui, SOURCE_W, "Src");
-                    header_cell(ui, PLAYS_W, "P");
-                    header_cell(ui, FAV_W, "Save");
-                    header_cell(ui, ACTION_W, "Go");
                 });
-            });
-
-        ui.add_space(6.0);
-
-        let mut select_label: Option<String> = None;
-        let mut toggle_fav: Option<String> = None;
-        let mut to_activate: Option<Track> = None;
-
-        egui::ScrollArea::vertical()
-            .auto_shrink([false; 2])
-            .show_rows(ui, ROW_H + 4.0, visible.len(), |ui, range| {
-                for row in range {
-                    let track = &visible[row];
-                    let song = self.song_index.get(&track.label);
-                    let is_selected = self
-                        .selected_label
-                        .as_ref()
-                        .map(|l| l == &track.label)
-                        .unwrap_or(false);
-                    let is_loaded = playback
-                        .loaded_label
-                        .as_ref()
-                        .map(|l| l == &track.label)
-                        .unwrap_or(false);
-                    let is_pending = self
-                        .pending_render
-                        .as_ref()
-                        .map(|p| p.track_label == track.label)
-                        .unwrap_or(false);
-                    let is_fav = self.favorites.contains(&track.label);
-                    let plays = self.play_counts.get(&track.label).copied().unwrap_or(0);
-
-                    let fill = if is_loaded && playback.is_playing {
-                        egui::Color32::from_rgb(213, 229, 220)
-                    } else if is_selected {
-                        egui::Color32::from_rgb(225, 231, 223)
-                    } else if row % 2 == 0 {
-                        egui::Color32::from_rgb(248, 245, 239)
-                    } else {
-                        egui::Color32::from_rgb(241, 237, 229)
-                    };
-
-                    let (rect, row_resp) = ui.allocate_exact_size(
-                        egui::vec2(ui.available_width(), ROW_H),
-                        egui::Sense::click(),
-                    );
-                    ui.painter().rect_filled(rect, 6.0, fill);
-                    let mut clicked_fav = false;
-                    let mut clicked_play = false;
-                    ui.allocate_new_ui(
-                        egui::UiBuilder::new()
-                            .max_rect(rect.shrink2(egui::vec2(10.0, 6.0)))
-                            .layout(egui::Layout::left_to_right(egui::Align::Center)),
-                        |ui| {
-                            let state_text = if is_pending {
-                                "Render"
-                            } else if is_loaded && playback.is_playing {
-                                "Live"
-                            } else if is_loaded {
-                                "Ready"
-                            } else if self.recent_ids.contains(&track.label) {
-                                "Recent"
-                            } else {
-                                "-"
-                            };
-                            cell_text(
-                                ui,
-                                STATUS_W,
-                                egui::RichText::new(state_text)
-                                    .small()
-                                    .color(egui::Color32::from_rgb(79, 94, 86)),
-                            );
-
-                            let title = display_title(song, track);
-                            let title_resp = ui.add_sized(
-                                [title_w, 20.0],
-                                egui::SelectableLabel::new(
-                                    is_selected,
-                                    egui::RichText::new(title)
-                                        .strong()
-                                        .color(egui::Color32::from_rgb(34, 38, 35)),
-                                ),
-                            );
-                            if title_resp.clicked() {
-                                select_label = Some(track.label.clone());
-                            }
-                            if title_resp.double_clicked() {
-                                to_activate = Some(track.clone());
-                            }
-
-                            cell_text(
-                                ui,
-                                COMPOSER_W,
-                                egui::RichText::new(display_composer(song))
-                                    .color(egui::Color32::from_rgb(83, 87, 82)),
-                            );
-                            badge_cell(
-                                ui,
-                                ERA_W,
-                                song.and_then(|s| s.era.as_deref()).unwrap_or("-"),
-                                era_badge_color(song.and_then(|s| s.era.as_deref())),
-                            );
-                            cell_text(
-                                ui,
-                                INSTR_W,
-                                egui::RichText::new(
-                                    song.map(|s| s.instrument.as_str()).unwrap_or("-"),
-                                )
-                                .color(egui::Color32::from_rgb(83, 87, 82)),
-                            );
-                            cell_text(
-                                ui,
-                                SOURCE_W,
-                                egui::RichText::new(source_bucket(track, song))
-                                    .monospace()
-                                    .color(egui::Color32::from_rgb(86, 90, 99)),
-                            );
-                            cell_text(
-                                ui,
-                                PLAYS_W,
-                                egui::RichText::new(plays.to_string())
-                                    .monospace()
-                                    .color(egui::Color32::from_rgb(83, 87, 82)),
-                            );
-
-                            let fav_resp = ui.add_sized(
-                                [FAV_W, 20.0],
-                                egui::Button::new(if is_fav { "On" } else { "Save" })
-                                    .fill(egui::Color32::from_rgb(232, 226, 215)),
-                            );
-                            if fav_resp.clicked() {
-                                clicked_fav = true;
-                                toggle_fav = Some(track.label.clone());
-                            }
-
-                            let play_label = if is_loaded && playback.is_playing {
-                                "Stop"
-                            } else {
-                                "Play"
-                            };
-                            let play_resp = ui.add_sized(
-                                [ACTION_W, 20.0],
-                                egui::Button::new(play_label)
-                                    .fill(egui::Color32::from_rgb(206, 221, 212)),
-                            );
-                            if play_resp.clicked() {
-                                clicked_play = true;
-                                to_activate = Some(track.clone());
-                            }
-                        },
-                    );
-                    if row_resp.clicked() && !clicked_fav && !clicked_play {
-                        select_label = Some(track.label.clone());
-                    }
-                    if row_resp.double_clicked() && !clicked_fav && !clicked_play {
-                        to_activate = Some(track.clone());
-                    }
-                    ui.add_space(4.0);
+                let frac = if snap.total_frames > 0 {
+                    (snap.cursor_frames as f32 / snap.total_frames as f32).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
+                let (rect, _) = ui.allocate_exact_size(
+                    egui::vec2(ui.available_width(), PROGRESS_H),
+                    egui::Sense::hover(),
+                );
+                let painter = ui.painter_at(rect);
+                painter.rect_filled(rect, 0.0, egui::Color32::from_gray(30));
+                if frac > 0.0 {
+                    let mut filled = rect;
+                    filled.set_width(rect.width() * frac);
+                    painter.rect_filled(filled, 0.0, egui::Color32::from_rgb(110, 150, 200));
                 }
             });
 
-        if let Some(label) = select_label {
-            self.selected_label = Some(label);
-        }
-        if let Some(label) = toggle_fav {
-            self.toggle_favorite(&label);
-        }
-        if let Some(track) = to_activate {
-            self.activate_track(track, playback);
-        }
-    }
-}
-
-impl eframe::App for JukeboxLiteC {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        self.drain_cp_commands();
-        self.poll_pending_render();
-        self.poll_pending_audit();
-
-        let visible = self.visible_tracks();
-        self.ensure_selection(&visible);
-        let playback = self.playback_snapshot();
-
-        egui::TopBottomPanel::top("jukebox_lite_c_header")
-            .exact_height(78.0)
-            .show(ctx, |ui| self.show_header(ui, visible.len()));
-
-        egui::TopBottomPanel::bottom("jukebox_lite_c_transport")
-            .exact_height(92.0)
-            .show(ctx, |ui| self.show_transport(ui, &playback));
-
-        egui::SidePanel::left("jukebox_lite_c_sidebar")
-            .resizable(false)
-            .exact_width(190.0)
-            .show(ctx, |ui| self.show_sidebar(ui));
-
-        egui::SidePanel::right("jukebox_lite_c_inspector")
-            .resizable(false)
-            .exact_width(320.0)
-            .show(ctx, |ui| self.show_inspector(ui, &playback));
-
+        // Central: dense table.
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.add_space(8.0);
-            self.show_table(ui, &visible, &playback);
-        });
-
-        self.publish_cp_snapshot(&visible, &playback);
-
-        if playback.is_playing || self.pending_render.is_some() || self.pending_audit.is_some() {
-            ctx.request_repaint_after(std::time::Duration::from_millis(120));
-        }
-    }
-}
-
-fn stat_chip(ui: &mut egui::Ui, label: &str, value: String, fill: egui::Color32) {
-    egui::Frame::none()
-        .fill(fill)
-        .rounding(6.0)
-        .inner_margin(egui::Margin::symmetric(8.0, 4.0))
-        .show(ui, |ui| {
+            // Header row.
+            let cols: [(SortColumn, f32); 4] = [
+                (SortColumn::Title, 320.0),
+                (SortColumn::Composer, 220.0),
+                (SortColumn::Era, 110.0),
+                (SortColumn::Format, 70.0),
+            ];
             ui.horizontal(|ui| {
+                ui.set_min_height(ROW_H);
+                for (col, w) in cols.iter().copied() {
+                    let arrow = if col == self.sort_col {
+                        if self.sort_asc {
+                            " ^"
+                        } else {
+                            " v"
+                        }
+                    } else {
+                        "  "
+                    };
+                    let text = format!("{}{}", col.label(), arrow);
+                    let resp = ui.add_sized(
+                        [w, ROW_H],
+                        egui::Button::new(egui::RichText::new(text).small().strong())
+                            .frame(false),
+                    );
+                    if resp.clicked() {
+                        self.toggle_sort(col);
+                    }
+                }
                 ui.label(
-                    egui::RichText::new(label)
+                    egui::RichText::new("voice")
                         .small()
-                        .color(egui::Color32::from_rgb(96, 100, 93)),
-                );
-                ui.label(
-                    egui::RichText::new(value)
                         .strong()
-                        .color(egui::Color32::from_rgb(45, 48, 45)),
+                        .color(egui::Color32::from_gray(160)),
                 );
             });
-        });
-}
+            ui.separator();
 
-fn routing_row(ui: &mut egui::Ui, label: &str, value: &str) {
-    ui.horizontal(|ui| {
-        ui.label(
-            egui::RichText::new(label)
-                .small()
-                .color(egui::Color32::from_rgb(72, 76, 74)),
-        );
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            ui.label(
-                egui::RichText::new(value)
-                    .small()
-                    .monospace()
-                    .color(egui::Color32::from_rgb(108, 111, 108)),
-            );
-        });
-    });
-}
+            let row_count = sorted.len();
+            let mut to_play: Option<String> = None;
+            let mut to_select: Option<String> = None;
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show_rows(ui, ROW_H, row_count, |ui, range| {
+                    for idx in range {
+                        let track = &sorted[idx];
+                        let song = core.library.song(&track.label);
+                        let title = song
+                            .map(|s| s.title.clone())
+                            .filter(|t| !t.is_empty())
+                            .unwrap_or_else(|| track.label.clone());
+                        let composer =
+                            song.map(|s| s.composer.clone()).unwrap_or_default();
+                        let era = song
+                            .and_then(|s| s.era.clone())
+                            .unwrap_or_default();
+                        let voice = song
+                            .and_then(|s| s.suggested_voice.clone())
+                            .unwrap_or_else(|| match track.format {
+                                Format::Wav | Format::Mp3 => String::from("-"),
+                                Format::Mid => String::from("?"),
+                            });
+                        let is_selected =
+                            selected_label.as_deref() == Some(track.label.as_str());
 
-fn inspector_key(ui: &mut egui::Ui, text: &str) {
-    ui.label(
-        egui::RichText::new(text)
-            .small()
-            .color(egui::Color32::from_rgb(96, 100, 93)),
-    );
-}
+                        let row_resp = ui
+                            .horizontal(|ui| {
+                                ui.set_min_height(ROW_H);
+                                let title_color = if is_selected {
+                                    egui::Color32::from_rgb(220, 230, 250)
+                                } else {
+                                    egui::Color32::from_gray(210)
+                                };
+                                ui.add_sized(
+                                    [320.0, ROW_H],
+                                    egui::Label::new(
+                                        egui::RichText::new(title)
+                                            .small()
+                                            .color(title_color),
+                                    )
+                                    .truncate(),
+                                );
+                                ui.add_sized(
+                                    [220.0, ROW_H],
+                                    egui::Label::new(
+                                        egui::RichText::new(composer)
+                                            .small()
+                                            .color(egui::Color32::from_gray(170)),
+                                    )
+                                    .truncate(),
+                                );
+                                ui.add_sized(
+                                    [110.0, ROW_H],
+                                    egui::Label::new(
+                                        egui::RichText::new(era)
+                                            .small()
+                                            .color(egui::Color32::from_gray(150)),
+                                    )
+                                    .truncate(),
+                                );
+                                ui.add_sized(
+                                    [70.0, ROW_H],
+                                    egui::Label::new(
+                                        egui::RichText::new(format_label(track.format))
+                                            .small()
+                                            .monospace()
+                                            .color(egui::Color32::from_gray(160)),
+                                    ),
+                                );
+                                ui.add(
+                                    egui::Label::new(
+                                        egui::RichText::new(voice)
+                                            .small()
+                                            .color(egui::Color32::from_gray(140)),
+                                    )
+                                    .truncate(),
+                                );
+                            })
+                            .response
+                            .interact(egui::Sense::click());
 
-fn detail_chip(ui: &mut egui::Ui, text: &str, fill: egui::Color32) {
-    egui::Frame::none()
-        .fill(fill)
-        .rounding(6.0)
-        .inner_margin(egui::Margin::symmetric(8.0, 4.0))
-        .show(ui, |ui| {
-            ui.label(
-                egui::RichText::new(text)
-                    .small()
-                    .color(egui::Color32::from_rgb(56, 58, 55)),
-            );
-        });
-}
+                        if is_selected {
+                            let painter = ui.painter();
+                            painter.rect_filled(
+                                row_resp.rect,
+                                0.0,
+                                egui::Color32::from_rgba_unmultiplied(80, 110, 160, 50),
+                            );
+                        }
 
-fn meter_row(ui: &mut egui::Ui, label: &str, value: f32, fill: egui::Color32) {
-    ui.horizontal(|ui| {
-        ui.add_sized(
-            [62.0, 18.0],
-            egui::Label::new(
-                egui::RichText::new(label)
-                    .small()
-                    .color(egui::Color32::from_rgb(96, 100, 93)),
-            ),
-        );
-        ui.add(
-            egui::ProgressBar::new(value.clamp(0.0, 1.0))
-                .desired_width(ui.available_width() - 10.0)
-                .fill(fill),
-        );
-    });
-}
-
-fn draw_envelope(ui: &mut egui::Ui, values: &[f32]) {
-    let desired = egui::vec2(ui.available_width(), 44.0);
-    let (rect, _) = ui.allocate_exact_size(desired, egui::Sense::hover());
-    let painter = ui.painter();
-    painter.rect_filled(rect, 6.0, egui::Color32::from_rgb(240, 236, 228));
-    if values.len() < 2 {
-        return;
-    }
-    let mut points = Vec::with_capacity(values.len());
-    for (i, value) in values.iter().enumerate() {
-        let t = i as f32 / (values.len() - 1) as f32;
-        let x = egui::lerp(rect.left()..=rect.right(), t);
-        let y = egui::lerp(rect.bottom()..=rect.top(), value.clamp(0.0, 1.0));
-        points.push(egui::pos2(x, y));
-    }
-    painter.add(egui::Shape::line(
-        points,
-        egui::Stroke::new(1.6, egui::Color32::from_rgb(74, 116, 104)),
-    ));
-}
-
-fn header_cell(ui: &mut egui::Ui, width: f32, text: &str) {
-    ui.add_sized(
-        [width, 18.0],
-        egui::Label::new(
-            egui::RichText::new(text)
-                .small()
-                .strong()
-                .color(egui::Color32::from_rgb(52, 58, 54)),
-        ),
-    );
-}
-
-fn cell_text(ui: &mut egui::Ui, width: f32, text: egui::RichText) {
-    ui.add_sized([width, 18.0], egui::Label::new(text));
-}
-
-fn badge_cell(ui: &mut egui::Ui, width: f32, text: &str, fill: egui::Color32) {
-    ui.allocate_ui_with_layout(
-        egui::vec2(width, 20.0),
-        egui::Layout::left_to_right(egui::Align::Center),
-        |ui| {
-            egui::Frame::none()
-                .fill(fill)
-                .rounding(6.0)
-                .inner_margin(egui::Margin::symmetric(6.0, 2.0))
-                .show(ui, |ui| {
-                    ui.label(
-                        egui::RichText::new(text)
-                            .small()
-                            .color(egui::Color32::from_rgb(31, 34, 31)),
-                    );
+                        if row_resp.clicked() {
+                            to_select = Some(track.label.clone());
+                        }
+                        if row_resp.double_clicked() {
+                            to_play = Some(track.label.clone());
+                        }
+                    }
                 });
-        },
-    );
-}
 
-fn apply_visual_style(ctx: &egui::Context) {
-    ctx.set_theme(egui::ThemePreference::Light);
-
-    let mut style = (*ctx.style()).clone();
-    style.spacing.item_spacing = egui::vec2(8.0, 6.0);
-    style.spacing.button_padding = egui::vec2(10.0, 5.0);
-    style.spacing.interact_size.y = 24.0;
-    style.text_styles.insert(
-        egui::TextStyle::Heading,
-        egui::FontId::new(24.0, egui::FontFamily::Proportional),
-    );
-    style.text_styles.insert(
-        egui::TextStyle::Body,
-        egui::FontId::new(14.5, egui::FontFamily::Proportional),
-    );
-    style.text_styles.insert(
-        egui::TextStyle::Button,
-        egui::FontId::new(13.5, egui::FontFamily::Proportional),
-    );
-    style.text_styles.insert(
-        egui::TextStyle::Small,
-        egui::FontId::new(11.5, egui::FontFamily::Proportional),
-    );
-    ctx.set_style(style);
-
-    let mut visuals = egui::Visuals::light();
-    visuals.override_text_color = Some(egui::Color32::from_rgb(37, 40, 37));
-    visuals.panel_fill = egui::Color32::from_rgb(236, 232, 224);
-    visuals.window_fill = egui::Color32::from_rgb(246, 243, 237);
-    visuals.extreme_bg_color = egui::Color32::from_rgb(228, 224, 214);
-    visuals.selection.bg_fill = egui::Color32::from_rgb(91, 126, 112);
-    visuals.selection.stroke = egui::Stroke::new(1.0, egui::Color32::from_rgb(246, 244, 240));
-    visuals.widgets.noninteractive.bg_fill = egui::Color32::from_rgb(240, 236, 228);
-    visuals.widgets.inactive.bg_fill = egui::Color32::from_rgb(239, 235, 226);
-    visuals.widgets.hovered.bg_fill = egui::Color32::from_rgb(231, 227, 217);
-    visuals.widgets.active.bg_fill = egui::Color32::from_rgb(221, 229, 220);
-    ctx.set_visuals(visuals);
+            if let Some(label) = to_select {
+                core.selection.selected_label = Some(label);
+            }
+            if let Some(label) = to_play {
+                core.play_label(&label);
+            }
+        });
+    }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -2466,170 +397,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         PathBuf::from("bench-out/CHIPTUNE"),
         PathBuf::from("bench-out/iterH"),
     ];
-    let app = JukeboxLiteC::new(dirs)?;
-    let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default()
-            .with_inner_size([1380.0, 840.0])
-            .with_title("keysynth jukebox lite c"),
-        ..Default::default()
-    };
+    let app = JukeboxLiteC::default();
     eframe::run_native(
         "keysynth jukebox lite c",
-        options,
+        eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default()
+                .with_inner_size([1380.0, 840.0])
+                .with_title("keysynth jukebox lite c")
+                .with_visible(true),
+            ..Default::default()
+        },
         Box::new(|cc| {
             keysynth::ui::setup_japanese_fonts(&cc.egui_ctx);
-            apply_visual_style(&cc.egui_ctx);
-            Ok(Box::new(app))
+            cc.egui_ctx.set_visuals(egui::Visuals::dark());
+            let core = JukeboxCore::new(dirs, "jukebox_lite_c", cc.egui_ctx.clone())
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
+            Ok(Box::new(JukeboxRunner::new(core, app)))
         }),
     )
-    .map_err(|e| -> Box<dyn std::error::Error> { format!("eframe: {e}").into() })?;
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn format_from_extension() {
-        assert_eq!(Format::from_ext("mid"), Some(Format::Mid));
-        assert_eq!(Format::from_ext("MIDI"), Some(Format::Mid));
-        assert_eq!(Format::from_ext("wav"), Some(Format::Wav));
-        assert_eq!(Format::from_ext("mp3"), Some(Format::Mp3));
-        assert_eq!(Format::from_ext("flac"), None);
-    }
-
-    #[test]
-    fn tile_label_round_trip() {
-        for &t in Tile::all() {
-            assert_eq!(tile_from_str(t.label()), Some(t));
-        }
-    }
-
-    #[test]
-    fn pick_voice_uses_active_tile_first() {
-        let track = Track {
-            path: PathBuf::from("dummy.mid"),
-            label: "dummy".into(),
-            format: Format::Mid,
-        };
-        assert_eq!(pick_voice(Tile::Classical, None, &track), "piano-modal");
-        assert_eq!(pick_voice(Tile::Game, None, &track), "square");
-        assert_eq!(pick_voice(Tile::Folk, None, &track), "guitar-stk");
-    }
-
-    #[test]
-    fn pick_voice_falls_back_to_song_metadata() {
-        let track = Track {
-            path: PathBuf::from("x.mid"),
-            label: "x".into(),
-            format: Format::Mid,
-        };
-        let song = Song {
-            id: "x".into(),
-            title: "T".into(),
-            composer: "C".into(),
-            composer_key: "c".into(),
-            era: Some("Baroque".into()),
-            instrument: "guitar".into(),
-            license: "PD".into(),
-            source: None,
-            source_url: None,
-            suggested_voice: None,
-            midi_path: PathBuf::from("x.mid"),
-            context: None,
-            tags: vec![],
-        };
-        assert_eq!(pick_voice(Tile::All, Some(&song), &track), "guitar-stk");
-    }
-
-    #[test]
-    fn rendered_audio_uses_direct_route() {
-        let track = Track {
-            path: PathBuf::from("foo.wav"),
-            label: "foo".into(),
-            format: Format::Wav,
-        };
-        assert_eq!(pick_voice(Tile::All, None, &track), "direct");
-    }
-
-    #[test]
-    fn classical_tile_includes_baroque_classical_romantic_modern() {
-        let mk = |era: Option<&str>, ins: &str| Song {
-            id: "x".into(),
-            title: "T".into(),
-            composer: "C".into(),
-            composer_key: "c".into(),
-            era: era.map(String::from),
-            instrument: ins.into(),
-            license: "PD".into(),
-            source: None,
-            source_url: None,
-            suggested_voice: None,
-            midi_path: PathBuf::from("x.mid"),
-            context: None,
-            tags: vec![],
-        };
-        let t = Track {
-            path: PathBuf::from("x.mid"),
-            label: "x".into(),
-            format: Format::Mid,
-        };
-        let favs = HashSet::new();
-        let recent = HashSet::new();
-        for era in ["Baroque", "Classical", "Romantic", "Modern"] {
-            let s = mk(Some(era), "piano");
-            assert!(track_matches_tile(
-                Tile::Classical,
-                &t,
-                Some(&s),
-                &favs,
-                &recent
-            ));
-        }
-        let s = mk(Some("Traditional"), "guitar");
-        assert!(!track_matches_tile(
-            Tile::Classical,
-            &t,
-            Some(&s),
-            &favs,
-            &recent
-        ));
-        assert!(track_matches_tile(Tile::Folk, &t, Some(&s), &favs, &recent));
-    }
-
-    #[test]
-    fn game_tile_catches_metadata_less_tracks() {
-        let t = Track {
-            path: PathBuf::from("v01_chip.mid"),
-            label: "v01_chip".into(),
-            format: Format::Mid,
-        };
-        let favs = HashSet::new();
-        let recent = HashSet::new();
-        assert!(track_matches_tile(Tile::Game, &t, None, &favs, &recent));
-    }
-
-    #[test]
-    fn scan_dirs_dedups_mp3_over_same_stem_wav() {
-        let dir = std::env::temp_dir().join("keysynth_jukebox_lite_c_dedup_test");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("a.wav"), b"RIFF").unwrap();
-        std::fs::write(dir.join("a.mp3"), b"ID3").unwrap();
-        std::fs::write(dir.join("b.wav"), b"RIFF").unwrap();
-        let tracks = scan_dirs(&[dir.as_path()]);
-        assert_eq!(tracks.len(), 2);
-        let a = tracks.iter().find(|t| t.label == "a").unwrap();
-        assert_eq!(a.format, Format::Mp3);
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn humanize_ago_picks_natural_unit() {
-        assert_eq!(humanize_ago(15), "15s ago");
-        assert_eq!(humanize_ago(90), "1m ago");
-        assert_eq!(humanize_ago(7_200), "2h ago");
-        assert_eq!(humanize_ago(172_800), "2d ago");
-    }
+    .map_err(|e| format!("eframe: {e}").into())
 }

--- a/src/bin/jukebox_lite_g.rs
+++ b/src/bin/jukebox_lite_g.rs
@@ -1,710 +1,38 @@
-//! jukebox_lite_g — Gemini version of the music browser.
+//! jukebox_lite_g — Gemini variant of the music browser.
 //!
-//! A sibling to `jukebox_lite` with a custom list-style UI.
-//! Reuses the backend from `jukebox_lite.rs` but implements a denser,
-//! table-focused interface inspired by foobar2000 and Spotify.
+//! Spotify-style sidebar + table built on the shared [`jukebox_core`].
+//! The variant only owns UI-local state (sort column / direction). Audio,
+//! library scan, history, and the CP server all live in `JukeboxCore`.
+//!
+//! ## Why this rewrite exists
+//!
+//! The original 1263-line bin re-implemented every backend service in the
+//! file: cpal mixer, library_db loading, play_log, CP server, MIDI render
+//! pump. Two of those open-coded paths broke in the same way:
+//!
+//! 1. `eframe::App::update` only requested a repaint **while playing**.
+//!    Construction → first frame depended on a paint event that never
+//!    arrived because no input had occurred yet, so eframe never flipped
+//!    `WS_VISIBLE` and the OS window stayed hidden.
+//! 2. The CP server callbacks pushed commands but did not call
+//!    `egui::Context::request_repaint`, so a `dispatch load_track` from a
+//!    verifier sat in the queue until something else woke the GUI.
+//!
+//! Both invariants now live in `JukeboxRunner` / `JukeboxControl::spawn`,
+//! so this file deliberately does not call either repaint API.
 
-use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
 
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{SampleFormat, StreamConfig};
 use eframe::egui;
-use hound::{SampleFormat as WavSampleFormat, WavReader};
-use serde::Serialize;
-use serde_json::json;
-use symphonia::core::audio::{AudioBufferRef, Signal};
-use symphonia::core::codecs::{Decoder, DecoderOptions, CODEC_TYPE_NULL};
-use symphonia::core::errors::Error as SymphoniaError;
-use symphonia::core::formats::{FormatOptions, FormatReader};
-use symphonia::core::io::MediaSourceStream;
-use symphonia::core::meta::MetadataOptions;
-use symphonia::core::probe::Hint;
 
-use keysynth::gui_cp;
-use keysynth::library_db::{LibraryDb, Song, SongFilter, VoiceFilter};
-use keysynth::play_log::{PlayEntry, PlayLogDb};
+use keysynth::jukebox_core::{
+    AudioSnapshot, Format, JukeboxApp, JukeboxCore, JukeboxRunner, Tile, Track,
+};
+use keysynth::library_db::Song;
 
 // ---------------------------------------------------------------------------
-// Source files
+// Sort column (UI-only state)
 // ---------------------------------------------------------------------------
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Format {
-    Wav,
-    Mp3,
-    Mid,
-}
-
-impl Format {
-    fn from_ext(ext: &str) -> Option<Self> {
-        match ext.to_ascii_lowercase().as_str() {
-            "wav" => Some(Format::Wav),
-            "mp3" => Some(Format::Mp3),
-            "mid" | "midi" => Some(Format::Mid),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct Track {
-    path: PathBuf,
-    /// Stable id (file stem) — joins to `Song::id` and `play_log` keys.
-    label: String,
-    format: Format,
-}
-
-fn scan_dirs(dirs: &[&Path]) -> Vec<Track> {
-    let mut out: Vec<Track> = Vec::new();
-    for d in dirs {
-        let read = match std::fs::read_dir(d) {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
-        let mut dir_tracks: Vec<Track> = Vec::new();
-        for ent in read.flatten() {
-            let p = ent.path();
-            let ext = match p.extension().and_then(|s| s.to_str()) {
-                Some(e) => e.to_ascii_lowercase(),
-                None => continue,
-            };
-            let fmt = match Format::from_ext(&ext) {
-                Some(f) => f,
-                None => continue,
-            };
-            let stem = match p.file_stem().and_then(|s| s.to_str()) {
-                Some(s) => s.to_string(),
-                None => continue,
-            };
-            dir_tracks.push(Track {
-                path: p,
-                label: stem,
-                format: fmt,
-            });
-        }
-        let mp3_stems: HashSet<String> = dir_tracks
-            .iter()
-            .filter(|t| t.format == Format::Mp3)
-            .map(|t| t.label.clone())
-            .collect();
-        for t in dir_tracks {
-            if t.format == Format::Wav && mp3_stems.contains(&t.label) {
-                continue;
-            }
-            out.push(t);
-        }
-    }
-    out.sort_by(|a, b| a.label.cmp(&b.label));
-    out
-}
-
-// ---------------------------------------------------------------------------
-// Decoder (reused from jukebox_lite)
-// ---------------------------------------------------------------------------
-
-struct Mp3State {
-    #[allow(dead_code)]
-    path: PathBuf,
-    format: Box<dyn FormatReader>,
-    decoder: Box<dyn Decoder>,
-    track_id: u32,
-    scratch: Vec<f32>,
-    scratch_pos: usize,
-    eof: bool,
-}
-
-enum DecoderState {
-    Wav {
-        reader: WavReader<BufReader<File>>,
-        sample_format: WavSampleFormat,
-        bits_per_sample: u16,
-    },
-    Mp3(Mp3State),
-}
-
-struct DecodedTrack {
-    state: DecoderState,
-    sample_rate: u32,
-    channels: u16,
-    total_samples: u64,
-}
-
-fn open_wav(path: &Path) -> Result<DecodedTrack, String> {
-    let reader = WavReader::open(path).map_err(|e| format!("hound open: {e}"))?;
-    let spec = reader.spec();
-    let total = reader.duration() as u64 * spec.channels as u64;
-    Ok(DecodedTrack {
-        sample_rate: spec.sample_rate,
-        channels: spec.channels,
-        total_samples: total,
-        state: DecoderState::Wav {
-            reader,
-            sample_format: spec.sample_format,
-            bits_per_sample: spec.bits_per_sample,
-        },
-    })
-}
-
-fn open_mp3(path: &Path) -> Result<DecodedTrack, String> {
-    let file = File::open(path).map_err(|e| format!("mp3 open: {e}"))?;
-    let mss = MediaSourceStream::new(Box::new(file), Default::default());
-    let mut hint = Hint::new();
-    if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-        hint.with_extension(ext);
-    }
-    let probed = symphonia::default::get_probe()
-        .format(
-            &hint,
-            mss,
-            &FormatOptions::default(),
-            &MetadataOptions::default(),
-        )
-        .map_err(|e| format!("mp3 probe: {e}"))?;
-    let format = probed.format;
-    let track = format
-        .tracks()
-        .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
-        .ok_or_else(|| "mp3: no decodable track".to_string())?;
-    let track_id = track.id;
-    let cp = track.codec_params.clone();
-    let sr = cp
-        .sample_rate
-        .ok_or_else(|| "mp3: missing sample rate".to_string())?;
-    let ch = cp.channels.map(|c| c.count() as u16).unwrap_or(2);
-    let total = cp.n_frames.map(|n| n * ch as u64).unwrap_or(0);
-    let decoder = symphonia::default::get_codecs()
-        .make(&cp, &DecoderOptions::default())
-        .map_err(|e| format!("mp3 codec: {e}"))?;
-    Ok(DecodedTrack {
-        sample_rate: sr,
-        channels: ch,
-        total_samples: total,
-        state: DecoderState::Mp3(Mp3State {
-            path: path.to_path_buf(),
-            format,
-            decoder,
-            track_id,
-            scratch: Vec::new(),
-            scratch_pos: 0,
-            eof: false,
-        }),
-    })
-}
-
-fn open_decoded(path: &Path) -> Result<DecodedTrack, String> {
-    let ext = path
-        .extension()
-        .and_then(|s| s.to_str())
-        .map(|s| s.to_ascii_lowercase())
-        .unwrap_or_default();
-    match ext.as_str() {
-        "wav" => open_wav(path),
-        "mp3" => open_mp3(path),
-        other => Err(format!("unsupported format: {other}")),
-    }
-}
-
-fn mp3_decode_next(state: &mut Mp3State) -> Result<(), String> {
-    if state.eof {
-        return Ok(());
-    }
-    loop {
-        let packet = match state.format.next_packet() {
-            Ok(p) => p,
-            Err(SymphoniaError::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(SymphoniaError::ResetRequired) => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(e) => return Err(format!("mp3 next_packet: {e}")),
-        };
-        if packet.track_id() != state.track_id {
-            continue;
-        }
-        let decoded = match state.decoder.decode(&packet) {
-            Ok(d) => d,
-            Err(SymphoniaError::DecodeError(_)) => continue,
-            Err(SymphoniaError::IoError(_)) => {
-                state.eof = true;
-                return Ok(());
-            }
-            Err(e) => return Err(format!("mp3 decode: {e}")),
-        };
-        let frames = decoded.frames();
-        let spec = *decoded.spec();
-        let ch = spec.channels.count();
-        state.scratch.clear();
-        state.scratch_pos = 0;
-        state.scratch.reserve(frames * ch);
-        match decoded {
-            AudioBufferRef::F32(buf) => {
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f]);
-                    }
-                }
-            }
-            AudioBufferRef::S16(buf) => {
-                let inv = 1.0f32 / i16::MAX as f32;
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32 * inv);
-                    }
-                }
-            }
-            AudioBufferRef::S32(buf) => {
-                let inv = 1.0f32 / i32::MAX as f32;
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32 * inv);
-                    }
-                }
-            }
-            AudioBufferRef::F64(buf) => {
-                for f in 0..frames {
-                    for c in 0..ch {
-                        state.scratch.push(buf.chan(c)[f] as f32);
-                    }
-                }
-            }
-            _ => continue,
-        }
-        if state.scratch.is_empty() {
-            continue;
-        }
-        return Ok(());
-    }
-}
-
-fn read_one_sample(dec: &mut DecodedTrack) -> Option<f32> {
-    match &mut dec.state {
-        DecoderState::Wav {
-            reader,
-            sample_format,
-            bits_per_sample,
-        } => match *sample_format {
-            WavSampleFormat::Int => {
-                let s: i32 = reader.samples::<i32>().next()?.ok()?;
-                let max = ((1u32 << (*bits_per_sample as u32 - 1)) - 1) as f32;
-                Some(s as f32 / max)
-            }
-            WavSampleFormat::Float => {
-                let s: f32 = reader.samples::<f32>().next()?.ok()?;
-                Some(s)
-            }
-        },
-        DecoderState::Mp3(state) => {
-            if state.scratch_pos >= state.scratch.len() {
-                if state.eof {
-                    return None;
-                }
-                if mp3_decode_next(state).is_err() {
-                    state.eof = true;
-                    return None;
-                }
-                if state.scratch_pos >= state.scratch.len() {
-                    return None;
-                }
-            }
-            let s = state.scratch[state.scratch_pos];
-            state.scratch_pos += 1;
-            Some(s)
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Audio mixer (single slot)
-// ---------------------------------------------------------------------------
-
-struct AudioState {
-    decoded: Option<DecodedTrack>,
-    is_playing: bool,
-    cursor_frames: u64,
-    label: String,
-    volume: f32,
-}
-
-impl AudioState {
-    fn new() -> Self {
-        Self {
-            decoded: None,
-            is_playing: false,
-            cursor_frames: 0,
-            label: String::new(),
-            volume: 0.85,
-        }
-    }
-}
-
-struct Mixer {
-    state: Arc<Mutex<AudioState>>,
-    _stream: cpal::Stream,
-}
-
-fn fill_callback(out: &mut [f32], channels: u16, state: &Arc<Mutex<AudioState>>) {
-    for s in out.iter_mut() {
-        *s = 0.0;
-    }
-    let mut st = match state.lock() {
-        Ok(g) => g,
-        Err(_) => return,
-    };
-    if !st.is_playing {
-        return;
-    }
-    let vol = st.volume.clamp(0.0, 1.5);
-    let dec = match st.decoded.as_mut() {
-        Some(d) => d,
-        None => {
-            st.is_playing = false;
-            return;
-        }
-    };
-    let dec_ch = dec.channels;
-    let frames = out.len() / channels.max(1) as usize;
-    let mut cursor_advanced: u64 = 0;
-    let mut hit_eof = false;
-    for f in 0..frames {
-        let (l, r) = match dec_ch {
-            1 => {
-                let s = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                (s, s)
-            }
-            2 => {
-                let l = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                let r = read_one_sample(dec).unwrap_or(l);
-                (l, r)
-            }
-            n => {
-                let l = match read_one_sample(dec) {
-                    Some(v) => v,
-                    None => {
-                        hit_eof = true;
-                        break;
-                    }
-                };
-                let r = read_one_sample(dec).unwrap_or(l);
-                for _ in 2..n {
-                    let _ = read_one_sample(dec);
-                }
-                (l, r)
-            }
-        };
-        cursor_advanced += 1;
-        let bus_l = (l * vol).tanh();
-        let bus_r = (r * vol).tanh();
-        let base = f * channels as usize;
-        match channels {
-            1 => out[base] = (bus_l + bus_r) * 0.5,
-            2 => {
-                out[base] = bus_l;
-                out[base + 1] = bus_r;
-            }
-            n => {
-                out[base] = bus_l;
-                out[base + 1] = bus_r;
-                for c in 2..n as usize {
-                    out[base + c] = 0.0;
-                }
-            }
-        }
-    }
-    st.cursor_frames = st.cursor_frames.saturating_add(cursor_advanced);
-    if hit_eof {
-        st.is_playing = false;
-    }
-}
-
-fn build_mixer_stream(state: Arc<Mutex<AudioState>>) -> Result<Mixer, String> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or_else(|| "no default output device".to_string())?;
-    let supported = device
-        .default_output_config()
-        .map_err(|e| format!("default_output_config: {e}"))?;
-    let sample_format = supported.sample_format();
-    let channels = supported.channels();
-    let stream_cfg: StreamConfig = supported.into();
-    let err_fn = |err| eprintln!("jukebox_lite_g audio stream error: {err}");
-    let stream = match sample_format {
-        SampleFormat::F32 => {
-            let st = state.clone();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [f32], _| fill_callback(out, channels, &st),
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build f32: {e}"))?
-        }
-        SampleFormat::I16 => {
-            let st = state.clone();
-            let mut scratch: Vec<f32> = Vec::new();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [i16], _| {
-                        if scratch.len() != out.len() {
-                            scratch.resize(out.len(), 0.0);
-                        }
-                        for s in scratch.iter_mut() {
-                            *s = 0.0;
-                        }
-                        fill_callback(&mut scratch, channels, &st);
-                        for (dst, src) in out.iter_mut().zip(scratch.iter()) {
-                            let c = src.clamp(-1.0, 1.0);
-                            *dst = (c * i16::MAX as f32) as i16;
-                        }
-                    },
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build i16: {e}"))?
-        }
-        SampleFormat::U16 => {
-            let st = state.clone();
-            let mut scratch: Vec<f32> = Vec::new();
-            device
-                .build_output_stream(
-                    &stream_cfg,
-                    move |out: &mut [u16], _| {
-                        if scratch.len() != out.len() {
-                            scratch.resize(out.len(), 0.0);
-                        }
-                        for s in scratch.iter_mut() {
-                            *s = 0.0;
-                        }
-                        fill_callback(&mut scratch, channels, &st);
-                        for (dst, src) in out.iter_mut().zip(scratch.iter()) {
-                            let c = src.clamp(-1.0, 1.0);
-                            *dst = (((c + 1.0) * 0.5) * u16::MAX as f32) as u16;
-                        }
-                    },
-                    err_fn,
-                    None,
-                )
-                .map_err(|e| format!("build u16: {e}"))?
-        }
-        other => return Err(format!("unsupported sample format: {other:?}")),
-    };
-    stream.play().map_err(|e| format!("stream.play: {e}"))?;
-    Ok(Mixer {
-        state,
-        _stream: stream,
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Preview cache
-// ---------------------------------------------------------------------------
-
-fn render_midi_binary_path() -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    let dir = exe.parent()?;
-    let candidates = if cfg!(windows) {
-        vec!["render_midi.exe"]
-    } else {
-        vec!["render_midi"]
-    };
-    candidates
-        .into_iter()
-        .map(|name| dir.join(name))
-        .find(|p| p.is_file())
-}
-
-fn cache_key(track_path: &Path, voice_id: &str) -> keysynth::preview_cache::CacheKey {
-    keysynth::preview_cache::CacheKey {
-        song_path: track_path.to_path_buf(),
-        voice_id: voice_id.to_string(),
-        voice_dll: None,
-        render_params: keysynth::preview_cache::RenderParams::default(),
-    }
-}
-
-fn open_preview_cache() -> Result<keysynth::preview_cache::Cache, String> {
-    let cache_dir = PathBuf::from("bench-out/cache");
-    keysynth::preview_cache::Cache::new(&cache_dir, 1_073_741_824)
-        .map_err(|e| format!("Cache::new: {e}"))
-}
-
-fn lookup_in_cache(track_path: &Path, voice_id: &str) -> Result<Option<PathBuf>, String> {
-    let cache = open_preview_cache()?;
-    let key = cache_key(track_path, voice_id);
-    cache.lookup(&key).map_err(|e| format!("lookup: {e}"))
-}
-
-fn render_midi_blocking(midi_path: &Path, voice_id: &str) -> Result<PathBuf, String> {
-    let cache = open_preview_cache()?;
-    let key = cache_key(midi_path, voice_id);
-    let bin = render_midi_binary_path()
-        .ok_or_else(|| "render_midi binary not found alongside jukebox_lite_g".to_string())?;
-    keysynth::preview_cache::render_to_cache(&cache, &key, voice_id, &bin)
-        .map_err(|e| format!("render_to_cache: {e}"))
-}
-
-// ---------------------------------------------------------------------------
-// Sidebar / Filter logic
-// ---------------------------------------------------------------------------
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Tile {
-    All,
-    Favorites,
-    Recent,
-    Classical,
-    Game,
-    Folk,
-}
-
-impl Tile {
-    fn label(self) -> &'static str {
-        match self {
-            Tile::All => "All Songs",
-            Tile::Favorites => "Favorites",
-            Tile::Recent => "Recently Played",
-            Tile::Classical => "Classical",
-            Tile::Game => "Game / Synth",
-            Tile::Folk => "Folk / Guitar",
-        }
-    }
-    fn icon(self) -> &'static str {
-        match self {
-            Tile::All => "\u{2630}",
-            Tile::Favorites => "\u{2605}",
-            Tile::Recent => "\u{21BB}",
-            Tile::Classical => "\u{1F3B9}",
-            Tile::Game => "\u{1F3AE}",
-            Tile::Folk => "\u{1F3B8}",
-        }
-    }
-    fn all() -> &'static [Tile] {
-        &[
-            Tile::All,
-            Tile::Favorites,
-            Tile::Recent,
-            Tile::Classical,
-            Tile::Game,
-            Tile::Folk,
-        ]
-    }
-}
-
-fn pick_voice(tile: Tile, song: Option<&Song>, track: &Track) -> &'static str {
-    if matches!(track.format, Format::Wav | Format::Mp3) {
-        return "—";
-    }
-    match tile {
-        Tile::Classical => return "piano-modal",
-        Tile::Game => return "square",
-        Tile::Folk => return "guitar-stk",
-        _ => {}
-    }
-    if let Some(s) = song {
-        let ins = s.instrument.to_ascii_lowercase();
-        if ins.contains("guitar") {
-            return "guitar-stk";
-        }
-        if ins.contains("piano") {
-            return "piano-modal";
-        }
-    }
-    let stem = track.label.to_ascii_lowercase();
-    if stem.starts_with("cc0_") || stem.contains("chiptune") {
-        return "square";
-    }
-    "piano-modal"
-}
-
-fn track_matches_tile(
-    tile: Tile,
-    track: &Track,
-    song: Option<&Song>,
-    favorites: &HashSet<String>,
-    recent: &HashSet<String>,
-) -> bool {
-    match tile {
-        Tile::All => true,
-        Tile::Favorites => favorites.contains(&track.label),
-        Tile::Recent => recent.contains(&track.label),
-        Tile::Classical => song
-            .and_then(|s| s.era.as_deref())
-            .map(|e| matches!(e, "Baroque" | "Classical" | "Romantic" | "Modern"))
-            .unwrap_or(false),
-        Tile::Folk => song
-            .map(|s| {
-                s.instrument.to_ascii_lowercase().contains("guitar")
-                    || s.era.as_deref() == Some("Traditional")
-            })
-            .unwrap_or(false),
-        Tile::Game => {
-            if song.is_none() {
-                return track.label.to_ascii_lowercase().contains("cc0");
-            }
-            let s = song.unwrap();
-            let ins = s.instrument.to_ascii_lowercase();
-            ins.contains("synth") || ins.contains("game") || ins.contains("chip")
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// CP types
-// ---------------------------------------------------------------------------
-
-#[derive(Clone, Debug, Default, Serialize)]
-struct CpSnapshot {
-    frame_id: u64,
-    any_playing: bool,
-    loaded_label: Option<String>,
-    cursor_frames: u64,
-    total_frames: u64,
-    visible_labels: Vec<String>,
-    track_count: usize,
-    db_song_count: usize,
-    db_voice_count: usize,
-}
-
-#[derive(Clone, Debug, serde::Deserialize)]
-enum CpCommand {
-    LoadTrack { label: String },
-    Play,
-    Stop,
-    SelectTile { tile: String },
-    Rescan,
-}
-
-// ---------------------------------------------------------------------------
-// App State
-// ---------------------------------------------------------------------------
-
-struct PendingRender {
-    track_label: String,
-    voice_id: String,
-    rx: std::sync::mpsc::Receiver<Result<PathBuf, String>>,
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SortColumn {
@@ -714,336 +42,113 @@ enum SortColumn {
     Format,
 }
 
+fn tile_icon(tile: Tile) -> &'static str {
+    match tile {
+        Tile::All => "\u{2630}",
+        Tile::Favorites => "\u{2605}",
+        Tile::Recent => "\u{21BB}",
+        Tile::Classical => "\u{1F3B9}",
+        Tile::Game => "\u{1F3AE}",
+        Tile::Folk => "\u{1F3B8}",
+    }
+}
+
+fn format_label(fmt: Format) -> &'static str {
+    match fmt {
+        Format::Wav => "WAV",
+        Format::Mp3 => "MP3",
+        Format::Mid => "MID",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JukeboxLiteG — UI-only state
+// ---------------------------------------------------------------------------
+
 struct JukeboxLiteG {
-    tracks: Vec<Track>,
-    song_index: HashMap<String, Song>,
-    db_voice_count: usize,
-    play_log: Option<PlayLogDb>,
-    favorites: HashSet<String>,
-    recent_ids: HashSet<String>,
-    recent_entries: Vec<PlayEntry>,
-
-    mixer: Mixer,
-    sample_rate: u32,
-    pending_render: Option<PendingRender>,
-
-    tile: Tile,
-    search: String,
-    selected_label: Option<String>,
-
     sort_col: SortColumn,
     sort_asc: bool,
+}
 
-    cp_state: gui_cp::State<CpSnapshot, CpCommand>,
-    _cp_handle: Option<gui_cp::Handle>,
-    cp_frame_id: u64,
+impl Default for JukeboxLiteG {
+    fn default() -> Self {
+        Self {
+            sort_col: SortColumn::Composer,
+            sort_asc: true,
+        }
+    }
 }
 
 impl JukeboxLiteG {
-    fn new() -> Result<Self, String> {
-        let db_path = PathBuf::from("bench-out/library.db");
-        let mut db = LibraryDb::open(&db_path).map_err(|e| e.to_string())?;
-        let _ = db.migrate();
-        let songs = db.query_songs(&SongFilter::default()).unwrap_or_default();
-        let voice_count = db.query_voices(&VoiceFilter::default()).map(|v| v.len()).unwrap_or(0);
-        let mut song_index = HashMap::new();
-        for s in songs {
-            song_index.insert(s.id.clone(), s);
+    /// Sort `tracks` according to the user-selected column. Done as a
+    /// pure operation on the borrowed slice so we never mutate the
+    /// caller-owned `visible` vector.
+    fn sorted(&self, tracks: &[Track], core: &JukeboxCore) -> Vec<Track> {
+        let mut out = tracks.to_vec();
+        let asc = self.sort_asc;
+        let key_str = |t: &Track, k: fn(&Song) -> &str| -> String {
+            core.library
+                .song(&t.label)
+                .map(k)
+                .unwrap_or("")
+                .to_ascii_lowercase()
+        };
+        match self.sort_col {
+            SortColumn::Title => out.sort_by(|a, b| {
+                let ka = key_str(a, |s| s.title.as_str());
+                let kb = key_str(b, |s| s.title.as_str());
+                let ka = if ka.is_empty() { a.label.to_ascii_lowercase() } else { ka };
+                let kb = if kb.is_empty() { b.label.to_ascii_lowercase() } else { kb };
+                if asc { ka.cmp(&kb) } else { kb.cmp(&ka) }
+            }),
+            SortColumn::Composer => out.sort_by(|a, b| {
+                let ka = key_str(a, |s| s.composer.as_str());
+                let kb = key_str(b, |s| s.composer.as_str());
+                if asc { ka.cmp(&kb) } else { kb.cmp(&ka) }
+            }),
+            SortColumn::Era => out.sort_by(|a, b| {
+                let ka = core
+                    .library
+                    .song(&a.label)
+                    .and_then(|s| s.era.clone())
+                    .unwrap_or_default();
+                let kb = core
+                    .library
+                    .song(&b.label)
+                    .and_then(|s| s.era.clone())
+                    .unwrap_or_default();
+                if asc { ka.cmp(&kb) } else { kb.cmp(&ka) }
+            }),
+            SortColumn::Format => out.sort_by(|a, b| {
+                let ka = format_label(a.format);
+                let kb = format_label(b.format);
+                if asc { ka.cmp(kb) } else { kb.cmp(ka) }
+            }),
         }
-
-        let dirs = vec![
-            PathBuf::from("bench-out/songs"),
-            PathBuf::from("bench-out/CHIPTUNE"),
-        ];
-        let dir_refs: Vec<&Path> = dirs.iter().map(|p| p.as_path()).collect();
-        let tracks = scan_dirs(&dir_refs);
-
-        let play_log = PlayLogDb::open(&PathBuf::from("bench-out/play_log.db")).ok();
-        let mut favs = HashSet::new();
-        let mut recent_ids = HashSet::new();
-        let mut recent_entries = Vec::new();
-        if let Some(ref db) = play_log {
-            if let Ok(f) = db.favorites() {
-                favs = f.into_iter().collect();
-            }
-            if let Ok(r) = db.recent_plays(100) {
-                recent_ids = r.iter().map(|e| e.song_id.clone()).collect();
-                recent_entries = r;
-            }
-        }
-
-        let audio = Arc::new(Mutex::new(AudioState::new()));
-        let mixer = build_mixer_stream(audio).map_err(|e| format!("audio: {e}"))?;
-
-        let cp_state: gui_cp::State<CpSnapshot, CpCommand> = gui_cp::State::new();
-        let st_get = cp_state.clone();
-        let st_load = cp_state.clone();
-        let st_play = cp_state.clone();
-        let st_stop = cp_state.clone();
-        let st_tile = cp_state.clone();
-        let st_rescan = cp_state.clone();
-        
-        let endpoint = gui_cp::resolve_endpoint("jukebox_lite_g", None);
-        let cp_handle = gui_cp::Builder::new("jukebox_lite_g", &endpoint)
-            .register("get_state", move |_p| match st_get.read_snapshot() {
-                Some(snap) => Ok(json!(snap)),
-                None => Ok(json!({"warming_up": true})),
-            })
-            .register("load_track", move |p| {
-                #[derive(serde::Deserialize)]
-                struct Args { label: String }
-                let a: Args = serde_json::from_value(p).map_err(|e| cp_core::RpcError::invalid_params(e.to_string()))?;
-                st_load.push_command(CpCommand::LoadTrack { label: a.label });
-                Ok(json!({"status": "ok"}))
-            })
-            .register("play", move |_p| {
-                st_play.push_command(CpCommand::Play);
-                Ok(json!({"status": "ok"}))
-            })
-            .register("stop", move |_p| {
-                st_stop.push_command(CpCommand::Stop);
-                Ok(json!({"status": "ok"}))
-            })
-            .register("select_tile", move |p| {
-                #[derive(serde::Deserialize)]
-                struct Args { tile: String }
-                let a: Args = serde_json::from_value(p).map_err(|e| cp_core::RpcError::invalid_params(e.to_string()))?;
-                st_tile.push_command(CpCommand::SelectTile { tile: a.tile });
-                Ok(json!({"status": "ok"}))
-            })
-            .register("rescan", move |_p| {
-                st_rescan.push_command(CpCommand::Rescan);
-                Ok(json!({"status": "ok"}))
-            })
-            .serve()
-            .ok();
-
-        Ok(Self {
-            tracks,
-            song_index,
-            db_voice_count: voice_count,
-            play_log,
-            favorites: favs,
-            recent_ids,
-            recent_entries,
-            mixer,
-            sample_rate: 44100,
-            pending_render: None,
-            tile: Tile::All,
-            search: String::new(),
-            selected_label: None,
-            sort_col: SortColumn::Composer,
-            sort_asc: true,
-            cp_state,
-            _cp_handle: cp_handle,
-            cp_frame_id: 0,
-        })
-    }
-
-    fn rescan(&mut self) {
-        let db_path = PathBuf::from("bench-out/library.db");
-        if let Ok(mut db) = LibraryDb::open(&db_path) {
-            let _ = db.migrate();
-            let songs = db.query_songs(&SongFilter::default()).unwrap_or_default();
-            self.db_voice_count = db.query_voices(&VoiceFilter::default()).map(|v| v.len()).unwrap_or(0);
-            self.song_index.clear();
-            for s in songs {
-                self.song_index.insert(s.id.clone(), s);
-            }
-        }
-
-        let dirs = vec![
-            PathBuf::from("bench-out/songs"),
-            PathBuf::from("bench-out/CHIPTUNE"),
-        ];
-        let dir_refs: Vec<&Path> = dirs.iter().map(|p| p.as_path()).collect();
-        self.tracks = scan_dirs(&dir_refs);
-
-        if let Some(ref db) = self.play_log {
-            if let Ok(f) = db.favorites() {
-                self.favorites = f.into_iter().collect();
-            }
-            if let Ok(r) = db.recent_plays(100) {
-                self.recent_ids = r.iter().map(|e| e.song_id.clone()).collect();
-                self.recent_entries = r;
-            }
-        }
-    }
-
-    fn play_track(&mut self, track: Track) {
-        let song = self.song_index.get(&track.label);
-        let voice = pick_voice(self.tile, song, &track).to_string();
-        self.selected_label = Some(track.label.clone());
-
-        match track.format {
-            Format::Mid => {
-                if let Ok(Some(cached)) = lookup_in_cache(&track.path, &voice) {
-                    self.load_resolved(track.label.clone(), cached, &voice);
-                } else {
-                    let path = track.path.clone();
-                    let v = voice.clone();
-                    let (tx, rx) = std::sync::mpsc::channel();
-                    std::thread::spawn(move || {
-                        let res = render_midi_blocking(&path, &v);
-                        let _ = tx.send(res);
-                    });
-                    self.pending_render = Some(PendingRender {
-                        track_label: track.label.clone(),
-                        voice_id: voice,
-                        rx,
-                    });
-                }
-            }
-            _ => self.load_resolved(track.label.clone(), track.path.clone(), &voice),
-        }
-    }
-
-    fn load_resolved(&mut self, label: String, path: PathBuf, voice: &str) {
-        if let Ok(dec) = open_decoded(&path) {
-            self.sample_rate = dec.sample_rate;
-            if let Ok(mut st) = self.mixer.state.lock() {
-                st.decoded = Some(dec);
-                st.is_playing = true;
-                st.cursor_frames = 0;
-                st.label = label.clone();
-            }
-            if let Some(ref mut db) = self.play_log {
-                let v = if voice == "—" { None } else { Some(voice) };
-                let _ = db.record_play(&label, v, None);
-            }
-        }
-    }
-
-    fn visible_tracks(&self) -> Vec<Track> {
-        let needle = self.search.trim().to_lowercase();
-        let mut out: Vec<Track> = self.tracks.iter()
-            .filter(|t| {
-                let song = self.song_index.get(&t.label);
-                if !track_matches_tile(self.tile, t, song, &self.favorites, &self.recent_ids) {
-                    return false;
-                }
-                if needle.is_empty() { return true; }
-                let title = song.map(|s| s.title.as_str()).unwrap_or("");
-                let composer = song.map(|s| s.composer.as_str()).unwrap_or("");
-                t.label.to_lowercase().contains(&needle) ||
-                title.to_lowercase().contains(&needle) ||
-                composer.to_lowercase().contains(&needle)
-            })
-            .cloned()
-            .collect();
-
-        out.sort_by(|a, b| {
-            let sa = self.song_index.get(&a.label);
-            let sb = self.song_index.get(&b.label);
-            let ord = match self.sort_col {
-                SortColumn::Title => {
-                    let ta = sa.map(|s| s.title.as_str()).unwrap_or(&a.label);
-                    let tb = sb.map(|s| s.title.as_str()).unwrap_or(&b.label);
-                    ta.cmp(tb)
-                }
-                SortColumn::Composer => {
-                    let ca = sa.map(|s| s.composer_key.as_str()).unwrap_or("");
-                    let cb = sb.map(|s| s.composer_key.as_str()).unwrap_or("");
-                    ca.cmp(cb).then(a.label.cmp(&b.label))
-                }
-                SortColumn::Era => {
-                    let ea = sa.and_then(|s| s.era.as_deref()).unwrap_or("");
-                    let eb = sb.and_then(|s| s.era.as_deref()).unwrap_or("");
-                    ea.cmp(eb)
-                }
-                SortColumn::Format => format!("{:?}", a.format).cmp(&format!("{:?}", b.format)),
-            };
-            if self.sort_asc { ord } else { ord.reverse() }
-        });
         out
     }
 
-    fn drain_cp_commands(&mut self) {
-        for cmd in self.cp_state.drain_commands() {
-            match cmd {
-                CpCommand::LoadTrack { label } => {
-                    if let Some(t) = self.tracks.iter().find(|t| t.label == label).cloned() {
-                        self.play_track(t);
-                    }
-                }
-                CpCommand::Play => {
-                    if let Ok(mut st) = self.mixer.state.lock() {
-                        if st.decoded.is_some() { st.is_playing = true; }
-                    }
-                }
-                CpCommand::Stop => {
-                    if let Ok(mut st) = self.mixer.state.lock() { st.is_playing = false; }
-                }
-                CpCommand::SelectTile { tile } => {
-                    if let Some(t) = tile_from_str(&tile) {
-                        self.tile = t;
-                    }
-                }
-                CpCommand::Rescan => self.rescan(),
+    fn header_cell(&mut self, ui: &mut egui::Ui, text: &str, width: f32, col: SortColumn) {
+        let selected = self.sort_col == col;
+        let mut label = text.to_string();
+        if selected {
+            label.push(' ');
+            label.push(if self.sort_asc { '\u{25B4}' } else { '\u{25BE}' });
+        }
+        let button = egui::Button::new(egui::RichText::new(label).small().strong())
+            .frame(false)
+            .min_size(egui::vec2(width, 20.0));
+        if ui.add(button).clicked() {
+            if self.sort_col == col {
+                self.sort_asc = !self.sort_asc;
+            } else {
+                self.sort_col = col;
+                self.sort_asc = true;
             }
         }
     }
 
-    fn publish_cp_snapshot(&mut self, visible: &[Track]) {
-        self.cp_frame_id = self.cp_frame_id.saturating_add(1);
-        let (any_playing, loaded_label, cursor_frames, total_frames) = {
-            let st = self.mixer.state.lock().ok();
-            match st {
-                Some(g) => (
-                    g.is_playing,
-                    if g.label.is_empty() { None } else { Some(g.label.clone()) },
-                    g.cursor_frames,
-                    g.decoded.as_ref().map(|d| d.total_samples / d.channels.max(1) as u64).unwrap_or(0),
-                ),
-                None => (false, None, 0, 0),
-            }
-        };
-        let snap = CpSnapshot {
-            frame_id: self.cp_frame_id,
-            any_playing,
-            loaded_label,
-            cursor_frames,
-            total_frames,
-            visible_labels: visible.iter().map(|t| t.label.clone()).collect(),
-            track_count: self.tracks.len(),
-            db_song_count: self.song_index.len(),
-            db_voice_count: self.db_voice_count,
-        };
-        self.cp_state.publish(snap);
-    }
-}
-
-fn tile_from_str(s: &str) -> Option<Tile> {
-    match s.to_lowercase().as_str() {
-        "all" => Some(Tile::All),
-        "favorites" | "favs" => Some(Tile::Favorites),
-        "recent" => Some(Tile::Recent),
-        "classical" => Some(Tile::Classical),
-        "game" => Some(Tile::Game),
-        "folk" => Some(Tile::Folk),
-        _ => None,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// UI implementation
-// ---------------------------------------------------------------------------
-
-impl eframe::App for JukeboxLiteG {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        self.drain_cp_commands();
-        if let Some(pending) = self.pending_render.take() {
-            match pending.rx.try_recv() {
-                Ok(Ok(path)) => self.load_resolved(pending.track_label, path, &pending.voice_id),
-                Ok(Err(_)) => {},
-                Err(std::sync::mpsc::TryRecvError::Empty) => self.pending_render = Some(pending),
-                Err(_) => {},
-            }
-        }
-
-        let visible = self.visible_tracks();
-        self.publish_cp_snapshot(&visible);
-
+    fn render_sidebar(&mut self, ctx: &egui::Context, core: &mut JukeboxCore) {
         egui::SidePanel::left("sidebar")
             .resizable(false)
             .default_width(180.0)
@@ -1057,206 +162,291 @@ impl eframe::App for JukeboxLiteG {
                     ui.label(text);
                 });
                 ui.add_space(20.0);
-                
+
                 for &tile in Tile::all() {
-                    let selected = self.tile == tile;
-                    let text = format!("{}  {}", tile.icon(), tile.label());
+                    let selected = core.selection.tile == tile;
+                    let text = format!("{}  {}", tile_icon(tile), tile.label());
                     if ui.selectable_label(selected, text).clicked() {
-                        self.tile = tile;
+                        core.select_tile(tile);
                     }
                     ui.add_space(4.0);
                 }
 
                 ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
                     ui.add_space(10.0);
-                    let stats = format!("{} tracks / {} voices", self.tracks.len(), self.db_voice_count);
+                    let stats = format!(
+                        "{} tracks / {} voices",
+                        core.library.tracks.len(),
+                        core.library.db_voice_count
+                    );
                     ui.label(egui::RichText::new(stats).small().color(egui::Color32::GRAY));
                     if ui.button("\u{21BB} Rescan").clicked() {
-                        self.rescan();
+                        core.rescan();
                     }
                     ui.separator();
                 });
             });
+    }
 
+    fn render_search(&mut self, ctx: &egui::Context, core: &mut JukeboxCore, visible_count: usize) {
         egui::TopBottomPanel::top("header").show(ctx, |ui| {
             ui.add_space(8.0);
             ui.horizontal(|ui| {
                 ui.add_space(8.0);
                 ui.label(egui::RichText::new("\u{1F50D}").color(egui::Color32::GRAY));
-                ui.add(egui::TextEdit::singleline(&mut self.search)
-                    .hint_text("Search library...")
-                    .desired_width(240.0));
-                if !self.search.is_empty() {
-                    if ui.button("\u{2715}").clicked() { self.search.clear(); }
+                ui.add(
+                    egui::TextEdit::singleline(&mut core.selection.search)
+                        .hint_text("Search library...")
+                        .desired_width(240.0),
+                );
+                if !core.selection.search.is_empty() && ui.button("\u{2715}").clicked() {
+                    core.selection.search.clear();
                 }
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.add_space(8.0);
-                    ui.label(egui::RichText::new(format!("{} results", visible.len())).small());
+                    ui.label(
+                        egui::RichText::new(format!("{} results", visible_count)).small(),
+                    );
                 });
             });
             ui.add_space(8.0);
         });
+    }
 
+    fn render_player(&mut self, ctx: &egui::Context, core: &mut JukeboxCore) {
         egui::TopBottomPanel::bottom("player")
             .exact_height(80.0)
             .show(ctx, |ui| {
-                let st_lock = self.mixer.state.lock();
-                let (playing, label, cursor, total) = if let Ok(ref st) = st_lock {
-                    (st.is_playing, 
-                     st.label.clone(), 
-                     st.cursor_frames, 
-                     st.decoded.as_ref().map(|d| d.total_samples / d.channels.max(1) as u64).unwrap_or(0))
-                } else {
-                    (false, String::new(), 0, 0)
-                };
+                let snap: AudioSnapshot = core.audio.snapshot();
+                let label = snap.label.clone().unwrap_or_default();
+                let title = core
+                    .library
+                    .song(&label)
+                    .map(|s| s.title.clone())
+                    .unwrap_or_else(|| {
+                        if label.is_empty() {
+                            "—".into()
+                        } else {
+                            label.clone()
+                        }
+                    });
+                let composer = core
+                    .library
+                    .song(&label)
+                    .map(|s| s.composer.clone())
+                    .unwrap_or_else(|| "—".into());
 
                 ui.add_space(10.0);
                 ui.horizontal(|ui| {
                     ui.add_space(20.0);
-                    if playing {
-                        if ui.button(egui::RichText::new("\u{23F8}").size(24.0)).clicked() {
-                            if let Ok(mut st) = self.mixer.state.lock() { st.is_playing = false; }
+                    if snap.is_playing {
+                        if ui
+                            .button(egui::RichText::new("\u{23F8}").size(24.0))
+                            .clicked()
+                        {
+                            core.audio.stop();
                         }
                     } else {
-                        let play_btn = ui.button(egui::RichText::new("\u{25B6}").size(24.0));
-                        if play_btn.clicked() {
-                            if let Ok(mut st) = self.mixer.state.lock() { st.is_playing = true; }
+                        if ui
+                            .button(egui::RichText::new("\u{25B6}").size(24.0))
+                            .clicked()
+                        {
+                            if !label.is_empty() {
+                                core.audio.resume();
+                            } else if let Some(sel) = core.selection.selected_label.clone() {
+                                core.play_label(&sel);
+                            }
                         }
                     }
-                    if ui.button(egui::RichText::new("\u{25A0}").size(24.0)).clicked() {
-                        if let Ok(mut st) = self.mixer.state.lock() { st.is_playing = false; }
+                    if ui
+                        .button(egui::RichText::new("\u{25A0}").size(24.0))
+                        .clicked()
+                    {
+                        core.audio.stop();
                     }
 
                     ui.add_space(20.0);
                     ui.vertical(|ui| {
-                        let title = self.song_index.get(&label).map(|s| s.title.as_str()).unwrap_or(&label);
                         ui.label(egui::RichText::new(title).strong());
-                        let composer = self.song_index.get(&label).map(|s| s.composer.as_str()).unwrap_or("—");
-                        ui.label(egui::RichText::new(composer).small().color(egui::Color32::GRAY));
+                        ui.label(
+                            egui::RichText::new(composer)
+                                .small()
+                                .color(egui::Color32::GRAY),
+                        );
                     });
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.add_space(20.0);
-                        let mut vol = if let Ok(st) = self.mixer.state.lock() { st.volume } else { 0.85 };
-                        if ui.add(egui::Slider::new(&mut vol, 0.0..=1.5).show_value(false).text("\u{1F50A}")).changed() {
-                            if let Ok(mut st) = self.mixer.state.lock() { st.volume = vol; }
+                        let mut vol = core
+                            .audio
+                            .mixer
+                            .state
+                            .lock()
+                            .map(|s| s.volume)
+                            .unwrap_or(0.85);
+                        if ui
+                            .add(
+                                egui::Slider::new(&mut vol, 0.0..=1.5)
+                                    .show_value(false)
+                                    .text("\u{1F50A}"),
+                            )
+                            .changed()
+                        {
+                            if let Ok(mut st) = core.audio.mixer.state.lock() {
+                                st.volume = vol;
+                            }
                         }
                     });
                 });
 
                 ui.add_space(8.0);
-                let progress = if total > 0 { cursor as f32 / total as f32 } else { 0.0 };
-                ui.add(egui::ProgressBar::new(progress).desired_height(4.0));
+                let progress = if snap.total_frames > 0 {
+                    snap.cursor_frames as f32 / snap.total_frames as f32
+                } else {
+                    0.0
+                };
+                ui.add(egui::ProgressBar::new(progress.clamp(0.0, 1.0)).desired_height(4.0));
             });
+    }
 
+    fn render_table(
+        &mut self,
+        ctx: &egui::Context,
+        core: &mut JukeboxCore,
+        rows: &[Track],
+    ) {
         egui::CentralPanel::default().show(ctx, |ui| {
-            egui::ScrollArea::vertical().auto_shrink([false; 2]).show(ui, |ui| {
-                ui.spacing_mut().item_spacing.y = 0.0;
-                
-                ui.horizontal(|ui| {
-                    let w = ui.available_width();
-                    let cols = [w * 0.4, w * 0.3, w * 0.15, w * 0.1];
-                    
-                    self.header_cell(ui, "TITLE", cols[0], SortColumn::Title);
-                    self.header_cell(ui, "COMPOSER", cols[1], SortColumn::Composer);
-                    self.header_cell(ui, "ERA", cols[2], SortColumn::Era);
-                    self.header_cell(ui, "FMT", cols[3], SortColumn::Format);
-                });
-                ui.separator();
+            egui::ScrollArea::vertical()
+                .auto_shrink([false; 2])
+                .show(ui, |ui| {
+                    ui.spacing_mut().item_spacing.y = 0.0;
 
-                for (idx, track) in visible.iter().enumerate() {
-                    let song = self.song_index.get(&track.label);
-                    let is_selected = self.selected_label.as_ref() == Some(&track.label);
-                    
-                    let bg = if is_selected {
-                        ui.visuals().selection.bg_fill
-                    } else if idx % 2 == 0 {
-                        ui.visuals().faint_bg_color
-                    } else {
-                        ui.visuals().window_fill()
-                    };
-
-                    let frame = egui::Frame::none()
-                        .fill(bg)
-                        .inner_margin(egui::Margin::symmetric(8.0, 6.0));
-                    
-                    let response = frame.show(ui, |ui| {
+                    ui.horizontal(|ui| {
                         let w = ui.available_width();
                         let cols = [w * 0.4, w * 0.3, w * 0.15, w * 0.1];
-                        
-                        ui.horizontal(|ui| {
-                            let title = song.map(|s| s.title.as_str()).unwrap_or(&track.label);
-                            let text_color = if is_selected { ui.visuals().selection.stroke.color } else { ui.visuals().text_color() };
-                            ui.add_sized([cols[0], 20.0], egui::Label::new(egui::RichText::new(title).strong().color(text_color)));
-                            
-                            let composer = song.map(|s| s.composer.as_str()).unwrap_or("—");
-                            ui.add_sized([cols[1], 20.0], egui::Label::new(composer));
-                            
-                            let era = song.and_then(|s| s.era.as_deref()).unwrap_or("");
-                            ui.add_sized([cols[2], 20.0], egui::Label::new(era));
-                            
-                            ui.add_sized([cols[3], 20.0], egui::Label::new(format!("{:?}", track.format).to_uppercase()));
-                        });
-                    }).response;
+                        self.header_cell(ui, "TITLE", cols[0], SortColumn::Title);
+                        self.header_cell(ui, "COMPOSER", cols[1], SortColumn::Composer);
+                        self.header_cell(ui, "ERA", cols[2], SortColumn::Era);
+                        self.header_cell(ui, "FMT", cols[3], SortColumn::Format);
+                    });
+                    ui.separator();
 
-                    let response = ui.interact(response.rect, ui.id().with(idx), egui::Sense::click());
-                    if response.clicked() {
-                        self.play_track(track.clone());
+                    let selected_label = core.selection.selected_label.clone();
+                    let mut click_label: Option<String> = None;
+                    for (idx, track) in rows.iter().enumerate() {
+                        let song = core.library.song(&track.label);
+                        let is_selected = selected_label.as_deref() == Some(track.label.as_str());
+
+                        let bg = if is_selected {
+                            ui.visuals().selection.bg_fill
+                        } else if idx % 2 == 0 {
+                            ui.visuals().faint_bg_color
+                        } else {
+                            ui.visuals().window_fill()
+                        };
+
+                        let frame = egui::Frame::none()
+                            .fill(bg)
+                            .inner_margin(egui::Margin::symmetric(8.0, 6.0));
+
+                        let response = frame
+                            .show(ui, |ui| {
+                                let w = ui.available_width();
+                                let cols = [w * 0.4, w * 0.3, w * 0.15, w * 0.1];
+                                ui.horizontal(|ui| {
+                                    let title =
+                                        song.map(|s| s.title.as_str()).unwrap_or(&track.label);
+                                    let text_color = if is_selected {
+                                        ui.visuals().selection.stroke.color
+                                    } else {
+                                        ui.visuals().text_color()
+                                    };
+                                    ui.add_sized(
+                                        [cols[0], 20.0],
+                                        egui::Label::new(
+                                            egui::RichText::new(title).strong().color(text_color),
+                                        ),
+                                    );
+                                    let composer =
+                                        song.map(|s| s.composer.as_str()).unwrap_or("—");
+                                    ui.add_sized(
+                                        [cols[1], 20.0],
+                                        egui::Label::new(composer),
+                                    );
+                                    let era = song.and_then(|s| s.era.as_deref()).unwrap_or("");
+                                    ui.add_sized([cols[2], 20.0], egui::Label::new(era));
+                                    ui.add_sized(
+                                        [cols[3], 20.0],
+                                        egui::Label::new(format_label(track.format)),
+                                    );
+                                });
+                            })
+                            .response;
+
+                        let response = ui.interact(
+                            response.rect,
+                            ui.id().with(("row", idx)),
+                            egui::Sense::click(),
+                        );
+                        if response.clicked() {
+                            click_label = Some(track.label.clone());
+                        }
+                        if response.hovered() && !is_selected {
+                            ui.painter().rect_filled(
+                                response.rect,
+                                0.0,
+                                ui.visuals().widgets.hovered.bg_fill.gamma_multiply(0.2),
+                            );
+                        }
                     }
-                    if response.hovered() && !is_selected {
-                        ui.painter().rect_filled(response.rect, 0.0, ui.visuals().widgets.hovered.bg_fill.gamma_multiply(0.2));
+                    if let Some(l) = click_label {
+                        core.play_label(&l);
                     }
-                }
-            });
+                });
         });
-
-        if let Ok(st) = self.mixer.state.lock() {
-            if st.is_playing || self.pending_render.is_some() {
-                ctx.request_repaint_after(std::time::Duration::from_millis(100));
-            }
-        }
     }
 }
 
-impl JukeboxLiteG {
-    fn header_cell(&mut self, ui: &mut egui::Ui, text: &str, width: f32, col: SortColumn) {
-        let selected = self.sort_col == col;
-        let mut text = text.to_string();
-        if selected {
-            text.push(' ');
-            text.push(if self.sort_asc { '\u{25B4}' } else { '\u{25BE}' });
-        }
-        
-        let button = egui::Button::new(egui::RichText::new(text).small().strong())
-            .frame(false)
-            .min_size(egui::vec2(width, 20.0));
-        
-        if ui.add(button).clicked() {
-            if self.sort_col == col {
-                self.sort_asc = !self.sort_asc;
-            } else {
-                self.sort_col = col;
-                self.sort_asc = true;
-            }
-        }
+impl JukeboxApp for JukeboxLiteG {
+    fn render(&mut self, ctx: &egui::Context, core: &mut JukeboxCore, visible: &[Track]) {
+        let rows = self.sorted(visible, core);
+        self.render_sidebar(ctx, core);
+        self.render_search(ctx, core, rows.len());
+        self.render_player(ctx, core);
+        self.render_table(ctx, core, &rows);
     }
 }
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app = JukeboxLiteG::new()?;
-    let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default()
-            .with_inner_size([1100.0, 700.0])
-            .with_title("JUKEBOX G"),
-        ..Default::default()
-    };
+    let dirs = vec![
+        PathBuf::from("bench-out/songs"),
+        PathBuf::from("bench-out/CHIPTUNE"),
+    ];
+    let app = JukeboxLiteG::default();
     eframe::run_native(
         "JUKEBOX G",
-        options,
+        eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default()
+                .with_inner_size([1100.0, 700.0])
+                .with_title("JUKEBOX G")
+                .with_visible(true),
+            ..Default::default()
+        },
         Box::new(|cc| {
             keysynth::ui::setup_japanese_fonts(&cc.egui_ctx);
             cc.egui_ctx.set_visuals(egui::Visuals::dark());
-            Ok(Box::new(app))
+            let core = match JukeboxCore::new(dirs, "jukebox_lite_g", cc.egui_ctx.clone()) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("jukebox_lite_g: core init failed: {e}");
+                    return Err(format!("core init: {e}").into());
+                }
+            };
+            Ok(Box::new(JukeboxRunner::new(core, app)))
         }),
     )
     .map_err(|e| format!("eframe: {e}").into())

--- a/src/jukebox_core.rs
+++ b/src/jukebox_core.rs
@@ -1,0 +1,1666 @@
+//! jukebox_core — shared substrate for the `jukebox_lite{,_c,_g}` UI
+//! variants.
+//!
+//! ## Why
+//!
+//! The three `jukebox_lite*` bins each grew 1200–2600 lines of
+//! independently-written audio + library + CP-server scaffolding. They
+//! shared the *concept* but not the code, so each variant re-invented
+//! (and re-broke) the same egui first-paint discipline, the same
+//! cpal mixer plumbing, and the same play_log/library_db wiring.
+//!
+//! `JukeboxCore` collects those fixed parts into one place so a UI
+//! variant only needs to implement [`JukeboxApp::render`]. The runner
+//! ([`JukeboxRunner`]) provides the `eframe::App` impl with the two
+//! invariants that previously had to be re-discovered per bin:
+//!
+//! 1. **First-paint backstop.** `JukeboxRunner::update` unconditionally
+//!    calls `ctx.request_repaint_after(500ms)` at the end of every
+//!    frame. eframe needs the GUI to paint at least once before it
+//!    flips `WS_VISIBLE` on the OS window; if the variant code only
+//!    requests repaints "while playing", the very first frame after
+//!    construction can stall and the window stays invisible. The
+//!    backstop means we always come back within 500ms regardless of
+//!    play state.
+//!
+//! 2. **CP-driven repaint.** Every CP server callback registered via
+//!    [`JukeboxControl`] captures an `egui::Context` clone and calls
+//!    `request_repaint()` after queuing the command. Without that, a
+//!    `dispatch load_track` from a verifier would sit in the queue
+//!    until the user happened to wiggle the mouse.
+//!
+//! ## Layering
+//!
+//! ```text
+//!  UI variant (jukebox_lite, jukebox_lite_c, jukebox_lite_g)
+//!     impl JukeboxApp
+//!         ↓ &mut JukeboxCore
+//!  JukeboxCore (this file)
+//!     ├── JukeboxLibrary    — track scan + library_db
+//!     ├── JukeboxAudio      — cpal stream + AudioState + pending_render
+//!     ├── JukeboxSelection  — tile/search/sort/selected_label
+//!     ├── JukeboxHistory    — play_log + favorites + recent
+//!     └── JukeboxControl    — CP server (egui_ctx-aware)
+//!         ↓
+//!  keysynth lib (gui_cp / library_db / play_log / preview_cache)
+//! ```
+//!
+//! ## Non-goals
+//!
+//! * No UI rendering. `JukeboxCore` never touches `egui::Ui`. The UI
+//!   layer reads visible tracks / selection / playing state and calls
+//!   into `play_track` / `stop` / `select_tile`.
+//! * No music-knowledge heuristics (mood→voice mapping). That stays in
+//!   the UI variant because each one wants slightly different defaults.
+
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use cp_core::RpcError;
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{SampleFormat, StreamConfig};
+use eframe::egui;
+use hound::{SampleFormat as WavSampleFormat, WavReader};
+use serde::Serialize;
+use serde_json::json;
+use symphonia::core::audio::{AudioBufferRef, Signal};
+use symphonia::core::codecs::{Decoder, DecoderOptions, CODEC_TYPE_NULL};
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::{FormatOptions, FormatReader};
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+use crate::gui_cp;
+use crate::library_db::{LibraryDb, Song, SongFilter, SongSort, VoiceFilter};
+use crate::play_log::{PlayEntry, PlayLogDb};
+
+// ---------------------------------------------------------------------------
+// Track + format
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Format {
+    Wav,
+    Mp3,
+    Mid,
+}
+
+impl Format {
+    pub fn from_ext(ext: &str) -> Option<Self> {
+        match ext.to_ascii_lowercase().as_str() {
+            "wav" => Some(Format::Wav),
+            "mp3" => Some(Format::Mp3),
+            "mid" | "midi" => Some(Format::Mid),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Track {
+    pub path: PathBuf,
+    /// Stable id (file stem) — joins to `Song::id` and `play_log` keys.
+    pub label: String,
+    pub format: Format,
+}
+
+/// Walk each directory and collect playable files. Within a single
+/// directory, MP3 wins over a same-stem WAV (matches the production
+/// transition strategy: rendered MP3s shipped alongside legacy WAVs).
+pub fn scan_dirs(dirs: &[&Path]) -> Vec<Track> {
+    let mut out: Vec<Track> = Vec::new();
+    for d in dirs {
+        let read = match std::fs::read_dir(d) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let mut dir_tracks: Vec<Track> = Vec::new();
+        for ent in read.flatten() {
+            let p = ent.path();
+            let ext = match p.extension().and_then(|s| s.to_str()) {
+                Some(e) => e.to_ascii_lowercase(),
+                None => continue,
+            };
+            let fmt = match Format::from_ext(&ext) {
+                Some(f) => f,
+                None => continue,
+            };
+            let stem = match p.file_stem().and_then(|s| s.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            dir_tracks.push(Track {
+                path: p,
+                label: stem,
+                format: fmt,
+            });
+        }
+        let mp3_stems: HashSet<String> = dir_tracks
+            .iter()
+            .filter(|t| t.format == Format::Mp3)
+            .map(|t| t.label.clone())
+            .collect();
+        for t in dir_tracks {
+            if t.format == Format::Wav && mp3_stems.contains(&t.label) {
+                continue;
+            }
+            out.push(t);
+        }
+    }
+    out.sort_by(|a, b| a.label.cmp(&b.label));
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Decoder (WAV via hound, MP3 via symphonia)
+// ---------------------------------------------------------------------------
+
+pub struct Mp3State {
+    #[allow(dead_code)]
+    path: PathBuf,
+    format: Box<dyn FormatReader>,
+    decoder: Box<dyn Decoder>,
+    track_id: u32,
+    scratch: Vec<f32>,
+    scratch_pos: usize,
+    eof: bool,
+}
+
+pub enum DecoderState {
+    Wav {
+        reader: WavReader<BufReader<File>>,
+        sample_format: WavSampleFormat,
+        bits_per_sample: u16,
+    },
+    Mp3(Mp3State),
+}
+
+pub struct DecodedTrack {
+    pub state: DecoderState,
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub total_samples: u64,
+}
+
+fn open_wav(path: &Path) -> Result<DecodedTrack, String> {
+    let reader = WavReader::open(path).map_err(|e| format!("hound open: {e}"))?;
+    let spec = reader.spec();
+    let total = reader.duration() as u64 * spec.channels as u64;
+    Ok(DecodedTrack {
+        sample_rate: spec.sample_rate,
+        channels: spec.channels,
+        total_samples: total,
+        state: DecoderState::Wav {
+            reader,
+            sample_format: spec.sample_format,
+            bits_per_sample: spec.bits_per_sample,
+        },
+    })
+}
+
+fn open_mp3(path: &Path) -> Result<DecodedTrack, String> {
+    let file = File::open(path).map_err(|e| format!("mp3 open: {e}"))?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+        hint.with_extension(ext);
+    }
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            mss,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .map_err(|e| format!("mp3 probe: {e}"))?;
+    let format = probed.format;
+    let track = format
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .ok_or_else(|| "mp3: no decodable track".to_string())?;
+    let track_id = track.id;
+    let cp = track.codec_params.clone();
+    let sr = cp
+        .sample_rate
+        .ok_or_else(|| "mp3: missing sample rate".to_string())?;
+    let ch = cp.channels.map(|c| c.count() as u16).unwrap_or(2);
+    let total = cp.n_frames.map(|n| n * ch as u64).unwrap_or(0);
+    let decoder = symphonia::default::get_codecs()
+        .make(&cp, &DecoderOptions::default())
+        .map_err(|e| format!("mp3 codec: {e}"))?;
+    Ok(DecodedTrack {
+        sample_rate: sr,
+        channels: ch,
+        total_samples: total,
+        state: DecoderState::Mp3(Mp3State {
+            path: path.to_path_buf(),
+            format,
+            decoder,
+            track_id,
+            scratch: Vec::new(),
+            scratch_pos: 0,
+            eof: false,
+        }),
+    })
+}
+
+pub fn open_decoded(path: &Path) -> Result<DecodedTrack, String> {
+    let ext = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    match ext.as_str() {
+        "wav" => open_wav(path),
+        "mp3" => open_mp3(path),
+        other => Err(format!("unsupported format: {other}")),
+    }
+}
+
+fn mp3_decode_next(state: &mut Mp3State) -> Result<(), String> {
+    if state.eof {
+        return Ok(());
+    }
+    loop {
+        let packet = match state.format.next_packet() {
+            Ok(p) => p,
+            Err(SymphoniaError::IoError(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                state.eof = true;
+                return Ok(());
+            }
+            Err(SymphoniaError::ResetRequired) => {
+                state.eof = true;
+                return Ok(());
+            }
+            Err(e) => return Err(format!("mp3 next_packet: {e}")),
+        };
+        if packet.track_id() != state.track_id {
+            continue;
+        }
+        let decoded = match state.decoder.decode(&packet) {
+            Ok(d) => d,
+            Err(SymphoniaError::DecodeError(_)) => continue,
+            Err(SymphoniaError::IoError(_)) => {
+                state.eof = true;
+                return Ok(());
+            }
+            Err(e) => return Err(format!("mp3 decode: {e}")),
+        };
+        let frames = decoded.frames();
+        let spec = *decoded.spec();
+        let ch = spec.channels.count();
+        state.scratch.clear();
+        state.scratch_pos = 0;
+        state.scratch.reserve(frames * ch);
+        match decoded {
+            AudioBufferRef::F32(buf) => {
+                for f in 0..frames {
+                    for c in 0..ch {
+                        state.scratch.push(buf.chan(c)[f]);
+                    }
+                }
+            }
+            AudioBufferRef::S16(buf) => {
+                let inv = 1.0f32 / i16::MAX as f32;
+                for f in 0..frames {
+                    for c in 0..ch {
+                        state.scratch.push(buf.chan(c)[f] as f32 * inv);
+                    }
+                }
+            }
+            AudioBufferRef::S32(buf) => {
+                let inv = 1.0f32 / i32::MAX as f32;
+                for f in 0..frames {
+                    for c in 0..ch {
+                        state.scratch.push(buf.chan(c)[f] as f32 * inv);
+                    }
+                }
+            }
+            AudioBufferRef::F64(buf) => {
+                for f in 0..frames {
+                    for c in 0..ch {
+                        state.scratch.push(buf.chan(c)[f] as f32);
+                    }
+                }
+            }
+            _ => continue,
+        }
+        if state.scratch.is_empty() {
+            continue;
+        }
+        return Ok(());
+    }
+}
+
+fn read_one_sample(dec: &mut DecodedTrack) -> Option<f32> {
+    match &mut dec.state {
+        DecoderState::Wav {
+            reader,
+            sample_format,
+            bits_per_sample,
+        } => match *sample_format {
+            WavSampleFormat::Int => {
+                let s: i32 = reader.samples::<i32>().next()?.ok()?;
+                let max = ((1u32 << (*bits_per_sample as u32 - 1)) - 1) as f32;
+                Some(s as f32 / max)
+            }
+            WavSampleFormat::Float => {
+                let s: f32 = reader.samples::<f32>().next()?.ok()?;
+                Some(s)
+            }
+        },
+        DecoderState::Mp3(state) => {
+            if state.scratch_pos >= state.scratch.len() {
+                if state.eof {
+                    return None;
+                }
+                if mp3_decode_next(state).is_err() {
+                    state.eof = true;
+                    return None;
+                }
+                if state.scratch_pos >= state.scratch.len() {
+                    return None;
+                }
+            }
+            let s = state.scratch[state.scratch_pos];
+            state.scratch_pos += 1;
+            Some(s)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JukeboxAudio — single-slot mixer + decoded source
+// ---------------------------------------------------------------------------
+
+/// Audio state shared between the egui thread and the cpal callback.
+/// The cpal callback only ever flips `is_playing` to false on EOF and
+/// advances `cursor_frames`; everything else is written from the egui
+/// thread under the mutex.
+pub struct AudioState {
+    pub decoded: Option<DecodedTrack>,
+    pub is_playing: bool,
+    pub cursor_frames: u64,
+    pub label: String,
+    pub volume: f32,
+}
+
+impl AudioState {
+    fn new() -> Self {
+        Self {
+            decoded: None,
+            is_playing: false,
+            cursor_frames: 0,
+            label: String::new(),
+            volume: 0.85,
+        }
+    }
+}
+
+pub struct MixerStream {
+    pub state: Arc<Mutex<AudioState>>,
+    _stream: cpal::Stream,
+}
+
+fn fill_callback(out: &mut [f32], channels: u16, state: &Arc<Mutex<AudioState>>) {
+    for s in out.iter_mut() {
+        *s = 0.0;
+    }
+    let mut st = match state.lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    if !st.is_playing {
+        return;
+    }
+    let vol = st.volume.clamp(0.0, 1.5);
+    let dec = match st.decoded.as_mut() {
+        Some(d) => d,
+        None => {
+            st.is_playing = false;
+            return;
+        }
+    };
+    let dec_ch = dec.channels;
+    let frames = out.len() / channels.max(1) as usize;
+    let mut cursor_advanced: u64 = 0;
+    let mut hit_eof = false;
+    for f in 0..frames {
+        let (l, r) = match dec_ch {
+            1 => {
+                let s = match read_one_sample(dec) {
+                    Some(v) => v,
+                    None => {
+                        hit_eof = true;
+                        break;
+                    }
+                };
+                (s, s)
+            }
+            2 => {
+                let l = match read_one_sample(dec) {
+                    Some(v) => v,
+                    None => {
+                        hit_eof = true;
+                        break;
+                    }
+                };
+                let r = read_one_sample(dec).unwrap_or(l);
+                (l, r)
+            }
+            n => {
+                let l = match read_one_sample(dec) {
+                    Some(v) => v,
+                    None => {
+                        hit_eof = true;
+                        break;
+                    }
+                };
+                let r = read_one_sample(dec).unwrap_or(l);
+                for _ in 2..n {
+                    let _ = read_one_sample(dec);
+                }
+                (l, r)
+            }
+        };
+        cursor_advanced += 1;
+        let bus_l = (l * vol).tanh();
+        let bus_r = (r * vol).tanh();
+        let base = f * channels as usize;
+        match channels {
+            1 => out[base] = (bus_l + bus_r) * 0.5,
+            2 => {
+                out[base] = bus_l;
+                out[base + 1] = bus_r;
+            }
+            n => {
+                out[base] = bus_l;
+                out[base + 1] = bus_r;
+                for c in 2..n as usize {
+                    out[base + c] = 0.0;
+                }
+            }
+        }
+    }
+    st.cursor_frames = st.cursor_frames.saturating_add(cursor_advanced);
+    if hit_eof {
+        st.is_playing = false;
+    }
+}
+
+pub fn build_mixer_stream(state: Arc<Mutex<AudioState>>) -> Result<MixerStream, String> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or_else(|| "no default output device".to_string())?;
+    let supported = device
+        .default_output_config()
+        .map_err(|e| format!("default_output_config: {e}"))?;
+    let sample_format = supported.sample_format();
+    let channels = supported.channels();
+    let stream_cfg: StreamConfig = supported.into();
+    let err_fn = |err| eprintln!("jukebox_core audio stream error: {err}");
+    let stream = match sample_format {
+        SampleFormat::F32 => {
+            let st = state.clone();
+            device
+                .build_output_stream(
+                    &stream_cfg,
+                    move |out: &mut [f32], _| fill_callback(out, channels, &st),
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| format!("build f32: {e}"))?
+        }
+        SampleFormat::I16 => {
+            let st = state.clone();
+            let mut scratch: Vec<f32> = Vec::new();
+            device
+                .build_output_stream(
+                    &stream_cfg,
+                    move |out: &mut [i16], _| {
+                        if scratch.len() != out.len() {
+                            scratch.resize(out.len(), 0.0);
+                        }
+                        for s in scratch.iter_mut() {
+                            *s = 0.0;
+                        }
+                        fill_callback(&mut scratch, channels, &st);
+                        for (dst, src) in out.iter_mut().zip(scratch.iter()) {
+                            let c = src.clamp(-1.0, 1.0);
+                            *dst = (c * i16::MAX as f32) as i16;
+                        }
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| format!("build i16: {e}"))?
+        }
+        SampleFormat::U16 => {
+            let st = state.clone();
+            let mut scratch: Vec<f32> = Vec::new();
+            device
+                .build_output_stream(
+                    &stream_cfg,
+                    move |out: &mut [u16], _| {
+                        if scratch.len() != out.len() {
+                            scratch.resize(out.len(), 0.0);
+                        }
+                        for s in scratch.iter_mut() {
+                            *s = 0.0;
+                        }
+                        fill_callback(&mut scratch, channels, &st);
+                        for (dst, src) in out.iter_mut().zip(scratch.iter()) {
+                            let c = src.clamp(-1.0, 1.0);
+                            *dst = (((c + 1.0) * 0.5) * u16::MAX as f32) as u16;
+                        }
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| format!("build u16: {e}"))?
+        }
+        other => return Err(format!("unsupported sample format: {other:?}")),
+    };
+    stream.play().map_err(|e| format!("stream.play: {e}"))?;
+    Ok(MixerStream {
+        state,
+        _stream: stream,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Preview cache integration
+// ---------------------------------------------------------------------------
+
+fn render_midi_binary_path() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    let candidates = if cfg!(windows) {
+        vec!["render_midi.exe"]
+    } else {
+        vec!["render_midi"]
+    };
+    candidates
+        .into_iter()
+        .map(|name| dir.join(name))
+        .find(|p| p.is_file())
+}
+
+fn cache_key(track_path: &Path, voice_id: &str) -> crate::preview_cache::CacheKey {
+    crate::preview_cache::CacheKey {
+        song_path: track_path.to_path_buf(),
+        voice_id: voice_id.to_string(),
+        voice_dll: None,
+        render_params: crate::preview_cache::RenderParams::default(),
+    }
+}
+
+fn open_preview_cache() -> Result<crate::preview_cache::Cache, String> {
+    let cache_dir = PathBuf::from("bench-out/cache");
+    crate::preview_cache::Cache::new(&cache_dir, 1_073_741_824)
+        .map_err(|e| format!("Cache::new: {e}"))
+}
+
+pub fn lookup_in_cache(track_path: &Path, voice_id: &str) -> Result<Option<PathBuf>, String> {
+    let cache = open_preview_cache()?;
+    let key = cache_key(track_path, voice_id);
+    cache.lookup(&key).map_err(|e| format!("lookup: {e}"))
+}
+
+pub fn render_midi_blocking(midi_path: &Path, voice_id: &str) -> Result<PathBuf, String> {
+    let cache = open_preview_cache()?;
+    let key = cache_key(midi_path, voice_id);
+    let bin = render_midi_binary_path()
+        .ok_or_else(|| "render_midi binary not found alongside jukebox binary".to_string())?;
+    crate::preview_cache::render_to_cache(&cache, &key, voice_id, &bin)
+        .map_err(|e| format!("render_to_cache: {e}"))
+}
+
+pub struct PendingRender {
+    pub track_label: String,
+    pub voice_id: String,
+    pub started: Instant,
+    pub rx: std::sync::mpsc::Receiver<Result<PathBuf, String>>,
+    pub _handle: std::thread::JoinHandle<()>,
+}
+
+// ---------------------------------------------------------------------------
+// Tile semantics
+// ---------------------------------------------------------------------------
+
+/// Sidebar tile / category. Variants share a common vocabulary so the
+/// CP `select_tile` command works against any UI.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Tile {
+    All,
+    Favorites,
+    Recent,
+    Classical,
+    Game,
+    Folk,
+}
+
+impl Tile {
+    pub fn label(self) -> &'static str {
+        match self {
+            Tile::All => "All",
+            Tile::Favorites => "Favorites",
+            Tile::Recent => "Recent",
+            Tile::Classical => "Classical",
+            Tile::Game => "Game",
+            Tile::Folk => "Folk",
+        }
+    }
+    pub fn all() -> &'static [Tile] {
+        &[
+            Tile::All,
+            Tile::Favorites,
+            Tile::Recent,
+            Tile::Classical,
+            Tile::Game,
+            Tile::Folk,
+        ]
+    }
+    pub fn from_str(s: &str) -> Option<Tile> {
+        match s.to_ascii_lowercase().as_str() {
+            "all" => Some(Tile::All),
+            "favorites" | "favs" | "fav" => Some(Tile::Favorites),
+            "recent" => Some(Tile::Recent),
+            "classical" => Some(Tile::Classical),
+            "game" => Some(Tile::Game),
+            "folk" => Some(Tile::Folk),
+            _ => None,
+        }
+    }
+}
+
+/// Decide whether `track` belongs in `tile`. Tracks without DB
+/// metadata fall through to `Game` (catch-all for filename-only entries
+/// like `cc0_*` chiptune dumps).
+pub fn track_matches_tile(
+    tile: Tile,
+    track: &Track,
+    song: Option<&Song>,
+    favorites: &HashSet<String>,
+    recent: &HashSet<String>,
+) -> bool {
+    match tile {
+        Tile::All => true,
+        Tile::Favorites => favorites.contains(&track.label),
+        Tile::Recent => recent.contains(&track.label),
+        Tile::Classical => song
+            .and_then(|s| s.era.as_deref())
+            .map(|e| matches!(e, "Baroque" | "Classical" | "Romantic" | "Modern"))
+            .unwrap_or(false),
+        Tile::Folk => song
+            .map(|s| {
+                s.instrument.to_ascii_lowercase().contains("guitar")
+                    || s.era.as_deref() == Some("Traditional")
+            })
+            .unwrap_or(false),
+        Tile::Game => {
+            if song.is_none() {
+                return true;
+            }
+            let s = song.unwrap();
+            let ins = s.instrument.to_ascii_lowercase();
+            ins.contains("synth") || ins.contains("game") || ins.contains("chip")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JukeboxLibrary — track scan + library_db lookup
+// ---------------------------------------------------------------------------
+
+pub const RECENT_WINDOW: usize = 24;
+
+pub struct JukeboxLibrary {
+    /// Files discovered by `scan_dirs`.
+    pub tracks: Vec<Track>,
+    /// `Song` rows from `library_db`, keyed by `Song::id` (= file stem).
+    pub song_index: HashMap<String, Song>,
+    /// Number of voice rows in the DB, reported by the stats popover.
+    pub db_voice_count: usize,
+    /// Source directories, retained so `rescan` can re-walk them.
+    pub source_dirs: Vec<PathBuf>,
+}
+
+impl JukeboxLibrary {
+    fn load(dirs: Vec<PathBuf>) -> Self {
+        let dir_refs: Vec<&Path> = dirs.iter().map(|p| p.as_path()).collect();
+        let tracks = scan_dirs(&dir_refs);
+        let (song_index, db_voice_count) = load_library_index();
+        Self {
+            tracks,
+            song_index,
+            db_voice_count,
+            source_dirs: dirs,
+        }
+    }
+
+    pub fn rescan(&mut self) {
+        let dir_refs: Vec<&Path> = self.source_dirs.iter().map(|p| p.as_path()).collect();
+        self.tracks = scan_dirs(&dir_refs);
+        let (idx, vc) = load_library_index();
+        self.song_index = idx;
+        self.db_voice_count = vc;
+    }
+
+    pub fn find_track(&self, label: &str) -> Option<Track> {
+        self.tracks.iter().find(|t| t.label == label).cloned()
+    }
+
+    pub fn song(&self, label: &str) -> Option<&Song> {
+        self.song_index.get(label)
+    }
+}
+
+fn load_library_index() -> (HashMap<String, Song>, usize) {
+    let db_path = PathBuf::from("bench-out/library.db");
+    let manifest = PathBuf::from("bench-out/songs/manifest.json");
+    let voices_live = PathBuf::from("voices_live");
+    let mut db = match LibraryDb::open(&db_path) {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!(
+                "jukebox_core: library_db open failed ({}): {e} — running without DB metadata",
+                db_path.display()
+            );
+            return (HashMap::new(), 0);
+        }
+    };
+    if let Err(e) = db.migrate() {
+        eprintln!("jukebox_core: library_db migrate failed: {e}");
+        return (HashMap::new(), 0);
+    }
+    if manifest.is_file() {
+        if let Err(e) = db.import_songs(&manifest) {
+            eprintln!("jukebox_core: library_db import_songs failed: {e}");
+        }
+    }
+    if voices_live.is_dir() {
+        if let Err(e) = db.import_voices(&voices_live) {
+            eprintln!("jukebox_core: library_db import_voices failed: {e}");
+        }
+    }
+    let songs = db
+        .query_songs(&SongFilter {
+            sort: SongSort::ByComposer,
+            ..Default::default()
+        })
+        .unwrap_or_default();
+    let voice_count = db
+        .query_voices(&VoiceFilter::default())
+        .map(|v| v.len())
+        .unwrap_or(0);
+    let mut idx = HashMap::new();
+    for s in songs {
+        idx.insert(s.id.clone(), s);
+    }
+    (idx, voice_count)
+}
+
+// ---------------------------------------------------------------------------
+// JukeboxHistory — play_log + favorites + recent
+// ---------------------------------------------------------------------------
+
+pub struct JukeboxHistory {
+    pub play_log: Option<PlayLogDb>,
+    pub favorites: HashSet<String>,
+    pub recent_ids: HashSet<String>,
+    pub recent_entries: Vec<PlayEntry>,
+}
+
+impl JukeboxHistory {
+    fn load() -> Self {
+        let play_log = load_play_log();
+        let (favorites, recent_ids, recent_entries) = snapshot_history(play_log.as_ref());
+        Self {
+            play_log,
+            favorites,
+            recent_ids,
+            recent_entries,
+        }
+    }
+
+    pub fn refresh(&mut self) {
+        let (f, r, re) = snapshot_history(self.play_log.as_ref());
+        self.favorites = f;
+        self.recent_ids = r;
+        self.recent_entries = re;
+    }
+
+    pub fn record_play(&mut self, label: &str, voice: Option<&str>) {
+        if let Some(db) = self.play_log.as_mut() {
+            if let Err(e) = db.record_play(label, voice, None) {
+                eprintln!("jukebox_core: record_play({label}): {e}");
+            }
+        }
+    }
+}
+
+fn load_play_log() -> Option<PlayLogDb> {
+    let db_path = PathBuf::from("bench-out/play_log.db");
+    let mut db = match PlayLogDb::open(&db_path) {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("jukebox_core: play_log open failed: {e}");
+            return None;
+        }
+    };
+    if let Err(e) = db.migrate() {
+        eprintln!("jukebox_core: play_log migrate failed: {e}");
+        return None;
+    }
+    Some(db)
+}
+
+fn snapshot_history(
+    log: Option<&PlayLogDb>,
+) -> (HashSet<String>, HashSet<String>, Vec<PlayEntry>) {
+    let mut favs: HashSet<String> = HashSet::new();
+    let mut recent_ids: HashSet<String> = HashSet::new();
+    let mut recent_entries: Vec<PlayEntry> = Vec::new();
+    if let Some(db) = log {
+        if let Ok(f) = db.favorites() {
+            favs = f.into_iter().collect();
+        }
+        if let Ok(r) = db.recent_plays(RECENT_WINDOW) {
+            for e in &r {
+                recent_ids.insert(e.song_id.clone());
+            }
+            recent_entries = r;
+        }
+    }
+    (favs, recent_ids, recent_entries)
+}
+
+// ---------------------------------------------------------------------------
+// JukeboxAudio — audio state + mixer + pending render queue
+// ---------------------------------------------------------------------------
+
+pub struct JukeboxAudio {
+    pub mixer: MixerStream,
+    /// Sample-rate of the most recently loaded track. Used by progress
+    /// bars (cursor_frames / sample_rate → seconds).
+    pub sample_rate_for_progress: u32,
+    pub pending_render: Option<PendingRender>,
+}
+
+impl JukeboxAudio {
+    fn build() -> Result<Self, String> {
+        let state = Arc::new(Mutex::new(AudioState::new()));
+        let mixer = build_mixer_stream(state).map_err(|e| format!("audio: {e}"))?;
+        Ok(Self {
+            mixer,
+            sample_rate_for_progress: 44_100,
+            pending_render: None,
+        })
+    }
+
+    /// Snapshot of the audio state suitable for CP / UI consumption.
+    /// Releases the lock immediately — never hold the audio mutex
+    /// across an egui paint.
+    pub fn snapshot(&self) -> AudioSnapshot {
+        let st = match self.mixer.state.lock() {
+            Ok(g) => g,
+            Err(_) => {
+                return AudioSnapshot::default();
+            }
+        };
+        AudioSnapshot {
+            is_playing: st.is_playing,
+            label: if st.label.is_empty() {
+                None
+            } else {
+                Some(st.label.clone())
+            },
+            cursor_frames: st.cursor_frames,
+            total_frames: st
+                .decoded
+                .as_ref()
+                .map(|d| d.total_samples / d.channels.max(1) as u64)
+                .unwrap_or(0),
+        }
+    }
+
+    pub fn is_playing(&self) -> bool {
+        self.mixer
+            .state
+            .lock()
+            .map(|s| s.is_playing)
+            .unwrap_or(false)
+    }
+
+    pub fn stop(&self) {
+        if let Ok(mut st) = self.mixer.state.lock() {
+            st.is_playing = false;
+        }
+    }
+
+    /// Resume playback if a track is loaded.
+    pub fn resume(&self) {
+        if let Ok(mut st) = self.mixer.state.lock() {
+            if st.decoded.is_some() {
+                st.is_playing = true;
+            }
+        }
+    }
+
+    /// Replace the current decoded track and start playing it. Returns
+    /// the file's sample-rate so the caller can update the progress bar
+    /// reference.
+    fn load(&mut self, label: String, dec: DecodedTrack) -> u32 {
+        let sr = dec.sample_rate;
+        if let Ok(mut st) = self.mixer.state.lock() {
+            st.decoded = Some(dec);
+            st.is_playing = true;
+            st.cursor_frames = 0;
+            st.label = label;
+        }
+        self.sample_rate_for_progress = sr;
+        sr
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct AudioSnapshot {
+    pub is_playing: bool,
+    pub label: Option<String>,
+    pub cursor_frames: u64,
+    pub total_frames: u64,
+}
+
+// ---------------------------------------------------------------------------
+// JukeboxSelection — tile/search/sort/selected_label
+// ---------------------------------------------------------------------------
+
+pub struct JukeboxSelection {
+    pub tile: Tile,
+    pub search: String,
+    pub selected_label: Option<String>,
+}
+
+impl JukeboxSelection {
+    fn new(initial: Option<String>) -> Self {
+        Self {
+            tile: Tile::All,
+            search: String::new(),
+            selected_label: initial,
+        }
+    }
+
+    /// Compute the visible tracks given current tile + search + history.
+    /// Returns clones so the UI can mutate `JukeboxCore` (e.g. start
+    /// playback) while iterating.
+    pub fn visible(&self, library: &JukeboxLibrary, history: &JukeboxHistory) -> Vec<Track> {
+        let needle = self.search.trim().to_ascii_lowercase();
+        let mut out: Vec<Track> = library
+            .tracks
+            .iter()
+            .filter(|t| {
+                let song = library.song_index.get(&t.label);
+                if !track_matches_tile(self.tile, t, song, &history.favorites, &history.recent_ids)
+                {
+                    return false;
+                }
+                if needle.is_empty() {
+                    return true;
+                }
+                let title = song.map(|s| s.title.as_str()).unwrap_or("");
+                let composer = song.map(|s| s.composer.as_str()).unwrap_or("");
+                t.label.to_ascii_lowercase().contains(&needle)
+                    || title.to_ascii_lowercase().contains(&needle)
+                    || composer.to_ascii_lowercase().contains(&needle)
+            })
+            .cloned()
+            .collect();
+        if self.tile == Tile::Recent {
+            let order: HashMap<&str, usize> = history
+                .recent_entries
+                .iter()
+                .enumerate()
+                .map(|(i, e)| (e.song_id.as_str(), i))
+                .collect();
+            out.sort_by_key(|t| order.get(t.label.as_str()).copied().unwrap_or(usize::MAX));
+        } else if !library.song_index.is_empty() {
+            out.sort_by(|a, b| {
+                let ka = library.song_index.get(&a.label).map(|s| s.composer_key.clone());
+                let kb = library.song_index.get(&b.label).map(|s| s.composer_key.clone());
+                match (ka, kb) {
+                    (Some(x), Some(y)) => x.cmp(&y).then_with(|| a.label.cmp(&b.label)),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => a.label.cmp(&b.label),
+                }
+            });
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CP server — snapshot, command, and the egui-aware spawn
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CpSnapshot {
+    pub frame_id: u64,
+    pub track_count: usize,
+    pub db_song_count: usize,
+    pub db_voice_count: usize,
+    pub selected_label: Option<String>,
+    pub selected_tile: String,
+    pub any_playing: bool,
+    pub loaded_label: Option<String>,
+    pub cursor_frames: u64,
+    pub total_frames: u64,
+    pub sample_rate: u32,
+    /// Catalog rows visible after current tile + filter, in display order.
+    pub visible_labels: Vec<String>,
+    /// Every catalog row label, regardless of filter.
+    pub all_labels: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CpCommand {
+    LoadTrack { label: String },
+    Play,
+    Stop,
+    SelectTile { tile: String },
+    Rescan,
+}
+
+pub struct JukeboxControl {
+    pub state: gui_cp::State<CpSnapshot, CpCommand>,
+    /// Held only to keep the CP listener alive — drop = shutdown.
+    _handle: Option<gui_cp::Handle>,
+    pub frame_id: u64,
+}
+
+impl JukeboxControl {
+    /// Start the CP server. The `egui_ctx` clone is captured by every
+    /// command-pushing callback; each callback calls
+    /// `egui_ctx.request_repaint()` after queuing so the egui main
+    /// thread wakes up and drains the command on the next tick.
+    fn spawn(app_name: &'static str, egui_ctx: egui::Context) -> Self {
+        let state: gui_cp::State<CpSnapshot, CpCommand> = gui_cp::State::new();
+        let endpoint = gui_cp::resolve_endpoint(app_name, None);
+        let st_get = state.clone();
+        let st_load = state.clone();
+        let st_play = state.clone();
+        let st_stop = state.clone();
+        let st_tile = state.clone();
+        let st_rescan = state.clone();
+        let st_list = state.clone();
+        let ctx_load = egui_ctx.clone();
+        let ctx_play = egui_ctx.clone();
+        let ctx_stop = egui_ctx.clone();
+        let ctx_tile = egui_ctx.clone();
+        let ctx_rescan = egui_ctx.clone();
+        let builder = gui_cp::Builder::new(app_name, &endpoint)
+            .register("get_state", move |_p| match st_get.read_snapshot() {
+                Some(snap) => gui_cp::encode_result(snap),
+                None => Ok(json!({"frame_id": 0, "warming_up": true})),
+            })
+            .register("load_track", move |p| {
+                #[derive(serde::Deserialize)]
+                struct Args {
+                    label: String,
+                }
+                let a: Args = gui_cp::decode_params(p)?;
+                st_load.push_command(CpCommand::LoadTrack {
+                    label: a.label.clone(),
+                });
+                ctx_load.request_repaint();
+                Ok(json!({"queued": "load_track", "label": a.label}))
+            })
+            .register("play", move |_p| {
+                st_play.push_command(CpCommand::Play);
+                ctx_play.request_repaint();
+                Ok(json!({"queued": "play"}))
+            })
+            .register("stop", move |_p| {
+                st_stop.push_command(CpCommand::Stop);
+                ctx_stop.request_repaint();
+                Ok(json!({"queued": "stop"}))
+            })
+            .register("select_tile", move |p| {
+                #[derive(serde::Deserialize)]
+                struct Args {
+                    tile: String,
+                }
+                let a: Args = gui_cp::decode_params(p)?;
+                st_tile.push_command(CpCommand::SelectTile {
+                    tile: a.tile.clone(),
+                });
+                ctx_tile.request_repaint();
+                Ok(json!({"queued": "select_tile", "tile": a.tile}))
+            })
+            .register("rescan", move |_p| {
+                st_rescan.push_command(CpCommand::Rescan);
+                ctx_rescan.request_repaint();
+                Ok(json!({"queued": "rescan"}))
+            })
+            .register("list_tracks", move |p| {
+                #[derive(serde::Deserialize, Default)]
+                #[serde(default)]
+                struct Args {
+                    limit: Option<usize>,
+                    contains: Option<String>,
+                }
+                let a: Args = serde_json::from_value(p)
+                    .map_err(|e| RpcError::invalid_params(format!("param parse: {e}")))?;
+                let snap = match st_list.read_snapshot() {
+                    Some(s) => s,
+                    None => return Ok(json!({"warming_up": true, "tracks": []})),
+                };
+                let needle = a.contains.unwrap_or_default().to_ascii_lowercase();
+                let limit = a.limit.unwrap_or(usize::MAX);
+                let tracks: Vec<&str> = snap
+                    .all_labels
+                    .iter()
+                    .filter(|l| needle.is_empty() || l.to_ascii_lowercase().contains(&needle))
+                    .take(limit)
+                    .map(|s| s.as_str())
+                    .collect();
+                Ok(json!({
+                    "tracks": tracks,
+                    "track_count": snap.track_count,
+                }))
+            });
+        let handle = match builder.serve() {
+            Ok(h) => Some(h),
+            Err(e) => {
+                eprintln!("jukebox_core: CP server failed: {e}");
+                None
+            }
+        };
+        Self {
+            state,
+            _handle: handle,
+            frame_id: 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JukeboxCore — composes the five sub-components above
+// ---------------------------------------------------------------------------
+
+/// Hook the UI variant uses to pick a voice for a given track + tile.
+/// The UI variant supplies its own logic at construction time so each
+/// variant can keep its preferred mood→voice mapping local.
+pub type VoicePicker =
+    Box<dyn Fn(Tile, Option<&Song>, &Track) -> &'static str + Send + Sync + 'static>;
+
+/// Default voice picker. Mirrors `jukebox_lite`'s heuristic:
+/// already-rendered audio uses the `"—"` sentinel; tile mood overrides
+/// metadata; metadata era + instrument fall through last.
+pub fn default_voice_picker() -> VoicePicker {
+    Box::new(default_pick_voice)
+}
+
+fn default_pick_voice(tile: Tile, song: Option<&Song>, track: &Track) -> &'static str {
+    if matches!(track.format, Format::Wav | Format::Mp3) {
+        return "—";
+    }
+    match tile {
+        Tile::Classical => return "piano-modal",
+        Tile::Game => return "square",
+        Tile::Folk => return "guitar-stk",
+        _ => {}
+    }
+    if let Some(s) = song {
+        let ins = s.instrument.to_ascii_lowercase();
+        if ins.contains("guitar") {
+            return "guitar-stk";
+        }
+        if ins.contains("piano") {
+            return "piano-modal";
+        }
+        if let Some(era) = s.era.as_deref() {
+            if matches!(era, "Baroque" | "Classical" | "Romantic" | "Modern") {
+                return "piano-modal";
+            }
+            if era == "Traditional" {
+                return "guitar-stk";
+            }
+        }
+    }
+    let stem = track.label.to_ascii_lowercase();
+    if stem.starts_with("cc0_")
+        || stem.starts_with("parodius")
+        || stem.starts_with("bgm_v")
+        || stem.starts_with('v')
+    {
+        return "square";
+    }
+    "guitar-stk"
+}
+
+/// Bundle of all jukebox-shared state. Owned single-source-of-truth
+/// for the UI variant — every mutation flows through here.
+pub struct JukeboxCore {
+    pub library: JukeboxLibrary,
+    pub audio: JukeboxAudio,
+    pub selection: JukeboxSelection,
+    pub history: JukeboxHistory,
+    pub control: JukeboxControl,
+    pub voice_picker: VoicePicker,
+}
+
+impl JukeboxCore {
+    /// Build the core. Audio/mixer failures bubble up as `Err(String)`;
+    /// library_db / play_log / CP-server failures only log (the GUI is
+    /// expected to keep working with degraded metadata rather than
+    /// silently fail to paint).
+    pub fn new(
+        dirs: Vec<PathBuf>,
+        app_name: &'static str,
+        egui_ctx: egui::Context,
+    ) -> Result<Self, String> {
+        Self::with_voice_picker(dirs, app_name, egui_ctx, default_voice_picker())
+    }
+
+    pub fn with_voice_picker(
+        dirs: Vec<PathBuf>,
+        app_name: &'static str,
+        egui_ctx: egui::Context,
+        voice_picker: VoicePicker,
+    ) -> Result<Self, String> {
+        let library = JukeboxLibrary::load(dirs);
+        let history = JukeboxHistory::load();
+        let audio = JukeboxAudio::build()?;
+        let initial_label = history
+            .recent_entries
+            .first()
+            .map(|e| e.song_id.clone())
+            .or_else(|| history.favorites.iter().next().cloned())
+            .or_else(|| library.tracks.first().map(|t| t.label.clone()));
+        let selection = JukeboxSelection::new(initial_label);
+        let control = JukeboxControl::spawn(app_name, egui_ctx);
+        eprintln!(
+            "jukebox_core: catalog ready — {} songs / {} voices ({} on-disk)",
+            library.song_index.len(),
+            library.db_voice_count,
+            library.tracks.len(),
+        );
+        Ok(Self {
+            library,
+            audio,
+            selection,
+            history,
+            control,
+            voice_picker,
+        })
+    }
+
+    pub fn visible_tracks(&self) -> Vec<Track> {
+        self.selection.visible(&self.library, &self.history)
+    }
+
+    pub fn rescan(&mut self) {
+        self.library.rescan();
+        self.history.refresh();
+    }
+
+    pub fn select_tile(&mut self, tile: Tile) {
+        self.selection.tile = tile;
+    }
+
+    pub fn stop(&mut self) {
+        self.audio.stop();
+    }
+
+    /// Resolve a label → MIDI render or direct WAV/MP3 path → cpal.
+    /// MIDI cache misses spawn a background `render_midi` subprocess
+    /// and return early; `tick` will pick up the result.
+    pub fn play_label(&mut self, label: &str) {
+        let track = match self.library.find_track(label) {
+            Some(t) => t,
+            None => {
+                eprintln!("jukebox_core: play_label unknown label={label}");
+                return;
+            }
+        };
+        let song = self.library.song(label).cloned();
+        let voice = (self.voice_picker)(self.selection.tile, song.as_ref(), &track).to_string();
+        self.selection.selected_label = Some(track.label.clone());
+
+        let playable: PathBuf = match track.format {
+            Format::Mid => match lookup_in_cache(&track.path, &voice) {
+                Ok(Some(p)) => p,
+                Ok(None) => {
+                    self.spawn_render(&track, &voice);
+                    return;
+                }
+                Err(e) => {
+                    eprintln!("jukebox_core: cache lookup {}: {e}", track.path.display());
+                    return;
+                }
+            },
+            Format::Wav | Format::Mp3 => track.path.clone(),
+        };
+        self.load_resolved(track.label.clone(), playable, &voice);
+    }
+
+    fn spawn_render(&mut self, track: &Track, voice: &str) {
+        let path = track.path.clone();
+        let voice_for_thread = voice.to_string();
+        let label = track.label.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = match std::thread::Builder::new()
+            .name("jukebox-core-render".into())
+            .spawn(move || {
+                let result = render_midi_blocking(&path, &voice_for_thread);
+                let _ = tx.send(result);
+            }) {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!("jukebox_core: spawn render thread: {e}");
+                return;
+            }
+        };
+        eprintln!(
+            "jukebox_core: render queued ({}) — voice={}",
+            track.path.display(),
+            voice
+        );
+        self.audio.pending_render = Some(PendingRender {
+            track_label: label,
+            voice_id: voice.to_string(),
+            started: Instant::now(),
+            rx,
+            _handle: handle,
+        });
+    }
+
+    fn poll_pending_render(&mut self) {
+        let pending = match self.audio.pending_render.as_ref() {
+            Some(p) => p,
+            None => return,
+        };
+        let result = match pending.rx.try_recv() {
+            Ok(r) => r,
+            Err(std::sync::mpsc::TryRecvError::Empty) => return,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                self.audio.pending_render = None;
+                return;
+            }
+        };
+        let pending = self.audio.pending_render.take().expect("guarded by Some()");
+        let elapsed = pending.started.elapsed().as_millis();
+        match result {
+            Ok(wav) => {
+                eprintln!(
+                    "jukebox_core: render done ({}) in {} ms",
+                    wav.display(),
+                    elapsed
+                );
+                self.load_resolved(pending.track_label, wav, &pending.voice_id);
+            }
+            Err(e) => {
+                eprintln!("jukebox_core: render failed: {e}");
+            }
+        }
+    }
+
+    fn load_resolved(&mut self, label: String, playable: PathBuf, voice: &str) {
+        let dec = match open_decoded(&playable) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("jukebox_core: open {}: {e}", playable.display());
+                return;
+            }
+        };
+        self.audio.load(label.clone(), dec);
+        self.selection.selected_label = Some(label.clone());
+        let v = if voice == "—" { None } else { Some(voice) };
+        self.history.record_play(&label, v);
+        self.history.refresh();
+    }
+
+    fn drain_cp_commands(&mut self) {
+        for cmd in self.control.state.drain_commands() {
+            match cmd {
+                CpCommand::LoadTrack { label } => self.play_label(&label),
+                CpCommand::Play => self.audio.resume(),
+                CpCommand::Stop => self.audio.stop(),
+                CpCommand::SelectTile { tile } => {
+                    if let Some(t) = Tile::from_str(&tile) {
+                        self.selection.tile = t;
+                    }
+                }
+                CpCommand::Rescan => self.rescan(),
+            }
+        }
+    }
+
+    fn publish_snapshot(&mut self, visible: &[Track]) {
+        self.control.frame_id = self.control.frame_id.saturating_add(1);
+        let audio = self.audio.snapshot();
+        let snap = CpSnapshot {
+            frame_id: self.control.frame_id,
+            track_count: self.library.tracks.len(),
+            db_song_count: self.library.song_index.len(),
+            db_voice_count: self.library.db_voice_count,
+            selected_label: self.selection.selected_label.clone(),
+            selected_tile: self.selection.tile.label().to_string(),
+            any_playing: audio.is_playing,
+            loaded_label: audio.label,
+            cursor_frames: audio.cursor_frames,
+            total_frames: audio.total_frames,
+            sample_rate: self.audio.sample_rate_for_progress,
+            visible_labels: visible.iter().map(|t| t.label.clone()).collect(),
+            all_labels: self.library.tracks.iter().map(|t| t.label.clone()).collect(),
+        };
+        self.control.state.publish(snap);
+    }
+
+    /// Per-frame housekeeping. UI variants don't normally call this
+    /// directly; `JukeboxRunner::update` calls it before the variant's
+    /// `render`. Returns the visible-track list so the UI can iterate
+    /// it without recomputing.
+    pub fn tick(&mut self, _ctx: &egui::Context) -> Vec<Track> {
+        self.drain_cp_commands();
+        self.poll_pending_render();
+        let visible = self.visible_tracks();
+        self.publish_snapshot(&visible);
+        visible
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JukeboxApp + JukeboxRunner
+// ---------------------------------------------------------------------------
+
+/// UI hook implemented by each `jukebox_lite*` variant. Receives the
+/// pre-computed visible-track list so the variant can skip the filter
+/// pass on its own.
+pub trait JukeboxApp {
+    fn render(&mut self, ctx: &egui::Context, core: &mut JukeboxCore, visible: &[Track]);
+}
+
+/// Default `eframe::App` impl. Owns one `JukeboxCore` and one
+/// `JukeboxApp`. Applies the two invariants in [module-level docs](self):
+///
+/// * `core.tick(ctx)` runs CP drain + render-queue poll + visible-track
+///   recomputation before each paint;
+/// * `ctx.request_repaint_after(500ms)` runs unconditionally at the
+///   end so first-paint always completes and idle state still
+///   refreshes 2× per second (pending-render arrival, CP commands
+///   from a verifier, etc.).
+pub struct JukeboxRunner<A: JukeboxApp> {
+    pub core: JukeboxCore,
+    pub app: A,
+}
+
+impl<A: JukeboxApp> JukeboxRunner<A> {
+    pub fn new(core: JukeboxCore, app: A) -> Self {
+        Self { core, app }
+    }
+}
+
+impl<A: JukeboxApp> eframe::App for JukeboxRunner<A> {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        let visible = self.core.tick(ctx);
+        self.app.render(ctx, &mut self.core, &visible);
+        // Backstop: unconditional repaint request so the first paint
+        // completes (so eframe flips WS_VISIBLE), and idle frames still
+        // re-tick at 2 Hz to pick up CP commands or finished renders.
+        ctx.request_repaint_after(Duration::from_millis(500));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_from_extension() {
+        assert_eq!(Format::from_ext("mid"), Some(Format::Mid));
+        assert_eq!(Format::from_ext("MIDI"), Some(Format::Mid));
+        assert_eq!(Format::from_ext("wav"), Some(Format::Wav));
+        assert_eq!(Format::from_ext("mp3"), Some(Format::Mp3));
+        assert_eq!(Format::from_ext("flac"), None);
+    }
+
+    #[test]
+    fn tile_label_round_trip() {
+        for &t in Tile::all() {
+            assert_eq!(Tile::from_str(t.label()), Some(t));
+        }
+    }
+
+    #[test]
+    fn default_voice_uses_active_tile_first() {
+        let track = Track {
+            path: PathBuf::from("dummy.mid"),
+            label: "dummy".into(),
+            format: Format::Mid,
+        };
+        assert_eq!(default_pick_voice(Tile::Classical, None, &track), "piano-modal");
+        assert_eq!(default_pick_voice(Tile::Game, None, &track), "square");
+        assert_eq!(default_pick_voice(Tile::Folk, None, &track), "guitar-stk");
+    }
+
+    #[test]
+    fn default_voice_falls_back_to_song_metadata() {
+        let track = Track {
+            path: PathBuf::from("x.mid"),
+            label: "x".into(),
+            format: Format::Mid,
+        };
+        let song = Song {
+            id: "x".into(),
+            title: "T".into(),
+            composer: "C".into(),
+            composer_key: "c".into(),
+            era: Some("Baroque".into()),
+            instrument: "guitar".into(),
+            license: "PD".into(),
+            source: None,
+            source_url: None,
+            suggested_voice: None,
+            midi_path: PathBuf::from("x.mid"),
+            context: None,
+            tags: vec![],
+        };
+        assert_eq!(default_pick_voice(Tile::All, Some(&song), &track), "guitar-stk");
+    }
+
+    #[test]
+    fn rendered_audio_uses_no_voice_sentinel() {
+        let track = Track {
+            path: PathBuf::from("foo.wav"),
+            label: "foo".into(),
+            format: Format::Wav,
+        };
+        assert_eq!(default_pick_voice(Tile::All, None, &track), "—");
+    }
+
+    #[test]
+    fn classical_tile_includes_baroque_classical_romantic_modern() {
+        let mk = |era: Option<&str>, ins: &str| Song {
+            id: "x".into(),
+            title: "T".into(),
+            composer: "C".into(),
+            composer_key: "c".into(),
+            era: era.map(String::from),
+            instrument: ins.into(),
+            license: "PD".into(),
+            source: None,
+            source_url: None,
+            suggested_voice: None,
+            midi_path: PathBuf::from("x.mid"),
+            context: None,
+            tags: vec![],
+        };
+        let t = Track {
+            path: PathBuf::from("x.mid"),
+            label: "x".into(),
+            format: Format::Mid,
+        };
+        let favs = HashSet::new();
+        let recent = HashSet::new();
+        for era in ["Baroque", "Classical", "Romantic", "Modern"] {
+            let s = mk(Some(era), "piano");
+            assert!(track_matches_tile(
+                Tile::Classical,
+                &t,
+                Some(&s),
+                &favs,
+                &recent
+            ));
+        }
+        let s = mk(Some("Traditional"), "guitar");
+        assert!(!track_matches_tile(
+            Tile::Classical,
+            &t,
+            Some(&s),
+            &favs,
+            &recent
+        ));
+        assert!(track_matches_tile(Tile::Folk, &t, Some(&s), &favs, &recent));
+    }
+
+    #[test]
+    fn game_tile_catches_metadata_less_tracks() {
+        let t = Track {
+            path: PathBuf::from("v01_chip.mid"),
+            label: "v01_chip".into(),
+            format: Format::Mid,
+        };
+        let favs = HashSet::new();
+        let recent = HashSet::new();
+        assert!(track_matches_tile(Tile::Game, &t, None, &favs, &recent));
+    }
+
+    #[test]
+    fn scan_dirs_dedups_mp3_over_same_stem_wav() {
+        let dir = std::env::temp_dir().join("keysynth_jukebox_core_dedup_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("a.wav"), b"RIFF").unwrap();
+        std::fs::write(dir.join("a.mp3"), b"ID3").unwrap();
+        std::fs::write(dir.join("b.wav"), b"RIFF").unwrap();
+        let tracks = scan_dirs(&[dir.as_path()]);
+        assert_eq!(tracks.len(), 2);
+        let a = tracks.iter().find(|t| t.label == "a").unwrap();
+        assert_eq!(a.format, Format::Mp3);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod drums;
 #[cfg(feature = "native")]
 pub mod gui_cp;
 #[cfg(feature = "native")]
+pub mod jukebox_core;
+#[cfg(feature = "native")]
 pub mod dsp;
 #[cfg(feature = "native")]
 pub mod extract;


### PR DESCRIPTION
## Summary
3 つの `jukebox_lite*` 変種 (Claude/Codex/Gemini) を共通コア層 `src/jukebox_core.rs` 上に書き直し。各変種は壊れやすい巨大 bin (1263–2635 行) からスタイル特徴のみ残した薄い UI 層 (419–563 行) に縮小。

## 動機
Gemini 版 `jukebox_lite_g` で window が WS_VISIBLE 立たないまま `frame_id=1` で停止する致命バグを発見。原因は CP callback が `request_repaint()` を呼ばない・条件付き repaint backstop で first paint 失敗時に静止する設計欠陥。3変種が独立に書かれた結果、egui の暗黙前提 (first frame で paint 完了する・状態変化で repaint を要求する) を踏み外す同種の罠を各々独自コードで踏んでいた。

## 実装
**Phase 1: CORE 抽出** (`feat(jukebox_core): extract shared core layer`)
- `JukeboxCore`: library/audio/selection/history/control の単一所有
- `JukeboxApp` trait: UI 層実装フック (`fn render(&mut self, ctx, core, visible)`)
- `JukeboxRunner<A>`: `eframe::App` デフォルト impl
- **不変条件で旧バグを構造で殺す**:
  - `JukeboxControl` の CP callback 5箇所すべて `egui_ctx.request_repaint()` 発火
  - `JukeboxRunner::update` 末尾に**無条件** `request_repaint_after(500ms)` backstop
  - `JukeboxCore::new` が全失敗を `Result<_, String>` に畳み panic 経路を排除

**Phase 2: 3 UI 並列書き直し** (3 cherry-picked commits)
| 変種 | スタイル | 行数 (before → after) |
|---|---|---|
| `jukebox_lite` (Claude) | YouTube card grid | 2044 → **563** (-72%) |
| `jukebox_lite_c` (Codex) | foobar2000 dense list | 2635 → **419** (-84%) |
| `jukebox_lite_g` (Gemini) | Spotify sidebar+table | 1263 → **453** (-64%) |

## チーム実行プロセス
worktree 隔離 + 別 `CARGO_TARGET_DIR` で並列衝突を物理的に回避。各 agent に foreground 強制・自己修正3回上限・smoke test (起動5秒以内に `IsWindowVisible == true`) を完了条件として設定。詳細は `JUKEBOX_REBUILD.md`。

## Test plan
- [x] CORE 単独 build (release, 5m11s) + jukebox_core unit tests 8件 PASS
- [x] UI-A 単独 build + smoke test PASS (window visible within 5s)
- [x] UI-C 単独 build + smoke test PASS
- [x] UI-G 単独 build + smoke test PASS (旧バグ再発防止ゲート)
- [x] 統合 build (3 bin 同時 release, 3m14s)
- [x] 統合 smoke test 3 bin 全 PASS

## 旧バグの状態
`jukebox_lite_g` は Phase 2 で構造的に解決済。`JukeboxRunner` の無条件 backstop と CP callback の `request_repaint()` 発火で再発不可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)